### PR TITLE
add mod extension for editing mod.json

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,6 @@ indent_style = tab
 
 [*.gradle]
 indent_style = tab
+
+[*.java]
+indent_style = tab

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,6 @@ jar {
 	manifest {
 		attributes 'Implementation-Version': version + " Build(" + build + ")"
 	}
-	from { zipTree("/home/asie/intellij-fernflower-1.0.0.2.jar") }
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/build.gradle
+++ b/build.gradle
@@ -35,10 +35,11 @@ dependencies {
 	implementation ('com.google.code.gson:gson:2.8.5')
 	implementation ('com.google.guava:guava:27.0.1-jre')
 	implementation ('net.fabricmc:stitch:0.1.0.17')
-	implementation ('net.fabricmc:tiny-remapper:0.1.0.19') {
+	implementation ('net.fabricmc:tiny-remapper:0.1.0.20') {
 		transitive = false
 	}
-	implementation ('org.benf:cfr:0.136')
+//	implementation ('org.benf:cfr:0.136')
+	implementation ('org.jetbrains:intellij-fernflower:1.0.0.2')
 
 	implementation ('net.fabricmc:sponge-mixin:0.7.11.3') {
 		exclude module: 'launchwrapper'
@@ -50,6 +51,7 @@ jar {
 	manifest {
 		attributes 'Implementation-Version': version + " Build(" + build + ")"
 	}
+	from { zipTree("/home/asie/intellij-fernflower-1.0.0.2.jar") }
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ targetCompatibility = 1.8
 
 group = 'net.fabricmc'
 archivesBaseName = project.name
-version = '0.0.13-SNAPSHOT'
+version = '0.0.14-SNAPSHOT'
 
 def build = "local"
 def ENV = System.getenv()
@@ -33,11 +33,12 @@ dependencies {
 	implementation ('commons-io:commons-io:2.6')
 	implementation ('org.zeroturnaround:zt-zip:1.13')
 	implementation ('com.google.code.gson:gson:2.8.5')
-	implementation ('com.google.guava:guava:27.0-jre')
-	implementation ('net.fabricmc:stitch:0.1.0.11')
-	implementation ('net.fabricmc:tiny-remapper:0.1.0.18') {
+	implementation ('com.google.guava:guava:27.0.1-jre')
+	implementation ('net.fabricmc:stitch:0.1.0.16')
+	implementation ('net.fabricmc:tiny-remapper:0.1.0.19') {
 		transitive = false
 	}
+	implementation ('org.benf:cfr:0.136')
 
 	implementation ('net.fabricmc:sponge-mixin:0.7.11.3') {
 		exclude module: 'launchwrapper'

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 	implementation ('org.zeroturnaround:zt-zip:1.13')
 	implementation ('com.google.code.gson:gson:2.8.5')
 	implementation ('com.google.guava:guava:27.0.1-jre')
-	implementation ('net.fabricmc:stitch:0.1.0.17')
+	implementation ('net.fabricmc:stitch:0.1.0.18')
 	implementation ('net.fabricmc:tiny-remapper:0.1.0.20') {
 		transitive = false
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 	implementation ('org.zeroturnaround:zt-zip:1.13')
 	implementation ('com.google.code.gson:gson:2.8.5')
 	implementation ('com.google.guava:guava:27.0.1-jre')
-	implementation ('net.fabricmc:stitch:0.1.0.16')
+	implementation ('net.fabricmc:stitch:0.1.0.17')
 	implementation ('net.fabricmc:tiny-remapper:0.1.0.19') {
 		transitive = false
 	}

--- a/src/main/java/net/fabricmc/loom/AbstractPlugin.java
+++ b/src/main/java/net/fabricmc/loom/AbstractPlugin.java
@@ -68,6 +68,7 @@ public class AbstractPlugin implements Plugin<Project> {
 		project.apply(ImmutableMap.of("plugin", "idea"));
 
 		project.getExtensions().create("minecraft", LoomGradleExtension.class, project);
+		project.getExtensions().create("mod", ModExtension.class, project);
 
 		LoomGradleExtension extension = project.getExtensions().getByType(LoomGradleExtension.class);
 		// Force add Mojang repository

--- a/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
@@ -37,6 +37,7 @@ public class LoomGradlePlugin extends AbstractPlugin {
 		makeTask("genSources", GenSourcesTask.class);
 
 		makeTask("genIdeaWorkspace", GenIdeaProjectTask.class).dependsOn("idea").setGroup("ide");
+		makeTask("vscode", GenVsCodeProjectTask.class).setGroup("ide");
 
 		makeTask("runClient", RunClientTask.class).dependsOn("buildNeeded").setGroup("minecraftMapped");
 		makeTask("runServer", RunServerTask.class).dependsOn("buildNeeded").setGroup("minecraftMapped");

--- a/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
@@ -24,10 +24,7 @@
 
 package net.fabricmc.loom;
 
-import net.fabricmc.loom.task.GenIdeaProjectTask;
-import net.fabricmc.loom.task.RemapJar;
-import net.fabricmc.loom.task.RunClientTask;
-import net.fabricmc.loom.task.RunServerTask;
+import net.fabricmc.loom.task.*;
 import org.gradle.api.Project;
 
 public class LoomGradlePlugin extends AbstractPlugin {
@@ -36,6 +33,8 @@ public class LoomGradlePlugin extends AbstractPlugin {
 		super.apply(target);
 
 		makeTask("remapJar", RemapJar.class);
+
+		makeTask("genSources", GenSourcesTask.class);
 
 		makeTask("genIdeaWorkspace", GenIdeaProjectTask.class).dependsOn("idea").setGroup("ide");
 

--- a/src/main/java/net/fabricmc/loom/ModExtension.java
+++ b/src/main/java/net/fabricmc/loom/ModExtension.java
@@ -30,6 +30,6 @@ public class ModExtension {
     }
 
     public boolean getEnabled() {
-    	return id != null && version != null;
+    	return id != null || version != null;
 	}
 }

--- a/src/main/java/net/fabricmc/loom/ModExtension.java
+++ b/src/main/java/net/fabricmc/loom/ModExtension.java
@@ -1,0 +1,31 @@
+package net.fabricmc.loom;
+
+import org.gradle.api.Project;
+
+public class ModExtension {
+    private final Project project;
+    private String id = null;
+    private String version = null;
+    // TODO: add more properties
+    // TODO: add dependencies
+
+    public ModExtension(Project project) {
+        this.project = project;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+}

--- a/src/main/java/net/fabricmc/loom/ModExtension.java
+++ b/src/main/java/net/fabricmc/loom/ModExtension.java
@@ -28,4 +28,8 @@ public class ModExtension {
     public void setVersion(String version) {
         this.version = version;
     }
+
+    public boolean getEnabled() {
+    	return id != null && version != null;
+	}
 }

--- a/src/main/java/net/fabricmc/loom/ModExtension.java
+++ b/src/main/java/net/fabricmc/loom/ModExtension.java
@@ -3,33 +3,33 @@ package net.fabricmc.loom;
 import org.gradle.api.Project;
 
 public class ModExtension {
-    private final Project project;
-    private String id = null;
-    private String version = null;
-    // TODO: add more properties
-    // TODO: add dependencies
+	private final Project project;
+	private String id = null;
+	private String version = null;
+	// TODO: add more properties
+	// TODO: add dependencies
 
-    public ModExtension(Project project) {
-        this.project = project;
-    }
+	public ModExtension(Project project) {
+		this.project = project;
+	}
 
-    public String getId() {
-        return id;
-    }
+	public String getId() {
+		return id;
+	}
 
-    public String getVersion() {
-        return version;
-    }
+	public String getVersion() {
+		return version;
+	}
 
-    public void setId(String id) {
-        this.id = id;
-    }
+	public void setId(String id) {
+		this.id = id;
+	}
 
-    public void setVersion(String version) {
-        this.version = version;
-    }
+	public void setVersion(String version) {
+		this.version = version;
+	}
 
-    public boolean getEnabled() {
-    	return id != null || version != null;
+	public boolean getEnabled() {
+		return id != null || version != null;
 	}
 }

--- a/src/main/java/net/fabricmc/loom/ModExtension.java
+++ b/src/main/java/net/fabricmc/loom/ModExtension.java
@@ -2,34 +2,30 @@ package net.fabricmc.loom;
 
 import org.gradle.api.Project;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class ModExtension {
 	private final Project project;
-	private String id = null;
-	private String version = null;
-	// TODO: add more properties
-	// TODO: add dependencies
+	private HashMap<String, String> replacements = new HashMap<>();
 
 	public ModExtension(Project project) {
 		this.project = project;
 	}
 
-	public String getId() {
-		return id;
+	public void replace(String key, String value) {
+		replacements.put(key, value);
 	}
 
-	public String getVersion() {
-		return version;
+	public void replace(Map<String, String> replacements) {
+		this.replacements.putAll(replacements);
 	}
 
-	public void setId(String id) {
-		this.id = id;
-	}
-
-	public void setVersion(String version) {
-		this.version = version;
+	public Map<String, String> getReplacements() {
+		return replacements;
 	}
 
 	public boolean getEnabled() {
-		return id != null || version != null;
+		return !replacements.isEmpty();
 	}
 }

--- a/src/main/java/net/fabricmc/loom/providers/MinecraftJarProvider.java
+++ b/src/main/java/net/fabricmc/loom/providers/MinecraftJarProvider.java
@@ -71,7 +71,7 @@ public class MinecraftJarProvider {
 	private void initFiles(Project project, MinecraftProvider minecraftProvider) {
 		LoomGradleExtension extension = project.getExtensions().getByType(LoomGradleExtension.class);
 		PomfProvider pomfProvider = extension.getPomfProvider();
-		MINECRAFT_MERGED_JAR = new File(extension.getUserCache(), minecraftProvider.minecraftVersion + "-merged.jar");
+		MINECRAFT_MERGED_JAR = new File(extension.getUserCache(), "minecraft-" + minecraftProvider.minecraftVersion + "-merged.jar");
 	}
 
 	public File getInputJar() {

--- a/src/main/java/net/fabricmc/loom/providers/MinecraftLibraryProvider.java
+++ b/src/main/java/net/fabricmc/loom/providers/MinecraftLibraryProvider.java
@@ -123,7 +123,7 @@ public class MinecraftLibraryProvider {
 
 	private void initFiles(Project project, MinecraftProvider minecraftProvider) {
 		LoomGradleExtension extension = project.getExtensions().getByType(LoomGradleExtension.class);
-		MINECRAFT_LIBS = new File(extension.getUserCache(), minecraftProvider.minecraftVersion + "-libs");
+		MINECRAFT_LIBS = new File(extension.getUserCache(), "libraries");
 	}
 
 }

--- a/src/main/java/net/fabricmc/loom/providers/MinecraftLibraryProvider.java
+++ b/src/main/java/net/fabricmc/loom/providers/MinecraftLibraryProvider.java
@@ -58,17 +58,15 @@ public class MinecraftLibraryProvider {
 
 		for (MinecraftVersionInfo.Library library : versionInfo.libraries) {
 			if (library.allowed() && library.getFile(MINECRAFT_LIBS) != null) {
+				// TODO: Add custom library locations
+
 				// By default, they are all available on all sides
-				boolean isClientOnly = false;
+				/* boolean isClientOnly = false;
 				if (library.name.contains("java3d") || library.name.contains("paulscode") || library.name.contains("lwjgl") || library.name.contains("twitch") || library.name.contains("jinput") || library.name.contains("text2speech") || library.name.contains("objc")) {
 					isClientOnly = true;
-				}
-				if(!library.getFile(MINECRAFT_LIBS).exists()){
-					project.getLogger().lifecycle(":downloading " + library.getURL());
-					FileUtils.copyURLToFile(new URL(library.getURL()), library.getFile(MINECRAFT_LIBS));
-				}
-				libs.add(library.getFile(MINECRAFT_LIBS));
-				minecraftProvider.addDependency(library.getFile(MINECRAFT_LIBS), project);
+				} */
+
+				project.getDependencies().add("compile", project.getDependencies().module(library.getArtifactName()));
 			}
 		}
 

--- a/src/main/java/net/fabricmc/loom/providers/MinecraftMappedProvider.java
+++ b/src/main/java/net/fabricmc/loom/providers/MinecraftMappedProvider.java
@@ -25,10 +25,13 @@
 package net.fabricmc.loom.providers;
 
 import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.task.GenSourcesTask;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.DependencyProvider;
 import net.fabricmc.loom.util.MapJarsTiny;
+import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 
 import java.io.File;
 import java.util.Collection;
@@ -54,14 +57,16 @@ public class MinecraftMappedProvider extends DependencyProvider {
         if (!MINECRAFT_MAPPED_JAR.exists()) {
             throw new RuntimeException("mapped jar not found");
         }
-        minecraftProvider.addDependency(MINECRAFT_MAPPED_JAR, project);
+
+        String version = minecraftProvider.minecraftVersion + "-mapped-" + extension.getPomfProvider().pomfVersion;
+        project.getDependencies().add("compile", project.getDependencies().module("net.minecraft:minecraft:" + version));
     }
 
     public void initFiles(Project project, MinecraftProvider minecraftProvider, PomfProvider pomfProvider) {
         LoomGradleExtension extension = project.getExtensions().getByType(LoomGradleExtension.class);
         this.minecraftProvider = minecraftProvider;
-        MINECRAFT_INTERMEDIARY_JAR = new File(extension.getUserCache(), minecraftProvider.minecraftVersion + "-intermediary.jar");
-        MINECRAFT_MAPPED_JAR = new File(extension.getUserCache(), minecraftProvider.minecraftVersion + "-mapped-" + pomfProvider.pomfVersion + ".jar");
+        MINECRAFT_INTERMEDIARY_JAR = new File(extension.getUserCache(), "minecraft-" + minecraftProvider.minecraftVersion + "-intermediary.jar");
+        MINECRAFT_MAPPED_JAR = new File(extension.getUserCache(), "minecraft-" + minecraftProvider.minecraftVersion + "-mapped-" + pomfProvider.pomfVersion + ".jar");
     }
 
     public Collection<File> getMapperPaths() {

--- a/src/main/java/net/fabricmc/loom/providers/MinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/providers/MinecraftProvider.java
@@ -75,10 +75,10 @@ public class MinecraftProvider extends DependencyProvider {
 
 	private void initFiles(Project project) {
 		LoomGradleExtension extension = project.getExtensions().getByType(LoomGradleExtension.class);
-		MINECRAFT_JSON = new File(extension.getUserCache(), minecraftVersion + "-info.json");
-		MINECRAFT_CLIENT_JAR = new File(extension.getUserCache(), minecraftVersion + "-client.jar");
-		MINECRAFT_SERVER_JAR = new File(extension.getUserCache(), minecraftVersion + "-server.jar");
-		MINECRAFT_MERGED_JAR = new File(extension.getUserCache(), minecraftVersion + "-merged.jar");
+		MINECRAFT_JSON = new File(extension.getUserCache(), "minecraft-" + minecraftVersion + "-info.json");
+		MINECRAFT_CLIENT_JAR = new File(extension.getUserCache(), "minecraft-" + minecraftVersion + "-client.jar");
+		MINECRAFT_SERVER_JAR = new File(extension.getUserCache(), "minecraft-" + minecraftVersion + "-server.jar");
+		MINECRAFT_MERGED_JAR = new File(extension.getUserCache(), "minecraft-" + minecraftVersion + "-merged.jar");
 
 	}
 

--- a/src/main/java/net/fabricmc/loom/providers/MinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/providers/MinecraftProvider.java
@@ -64,7 +64,7 @@ public class MinecraftProvider extends DependencyProvider {
 		versionInfo = gson.fromJson(new FileReader(MINECRAFT_JSON), MinecraftVersionInfo.class);
 
 		// Add Loom as an annotation processor
-        addDependency(project.files(this.getClass().getProtectionDomain().getCodeSource().getLocation()), project, "compileOnly");
+		addDependency(project.files(this.getClass().getProtectionDomain().getCodeSource().getLocation()), project, "compileOnly");
 
 		downloadJars();
 

--- a/src/main/java/net/fabricmc/loom/task/GenSourcesCfrTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenSourcesCfrTask.java
@@ -1,0 +1,118 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task;
+
+import org.gradle.api.DefaultTask;
+
+public class GenSourcesCfrTask extends DefaultTask {
+	/*
+	@TaskAction
+	public void genSources() throws IOException {
+		Project project = this.getProject();
+		LoomGradleExtension extension = project.getExtensions().getByType(LoomGradleExtension.class);
+		PomfProvider pomfProvider = extension.getPomfProvider();
+		File mappedJar = pomfProvider.mappedProvider.getMappedJar();
+		File sourcesJar = getSourcesJar(project);
+
+		Manifest manifest = new Manifest();
+		manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+		Set<String> addedDirectories = new HashSet<>();
+
+		try (FileOutputStream fos = new FileOutputStream(sourcesJar);
+			JarOutputStream jos = new JarOutputStream(fos, manifest)) {
+
+			project.getLogger().lifecycle(":generating sources JAR");
+			CfrDriver driver = new CfrDriver.Builder()
+					.withOptions(ImmutableMap.of("renameillegalidents","true"))
+					.withOutputSink(new OutputSinkFactory() {
+						@Override
+						public List<SinkClass> getSupportedSinks(SinkType sinkType, Collection<SinkClass> collection) {
+							switch (sinkType) {
+								case PROGRESS:
+									return Collections.singletonList(SinkClass.STRING);
+								case JAVA:
+									return Collections.singletonList(SinkClass.DECOMPILED);
+								default:
+									return Collections.emptyList();
+							}
+						}
+
+						@Override
+						public <T> Sink<T> getSink(SinkType sinkType, SinkClass sinkClass) {
+							switch (sinkType) {
+								case PROGRESS:
+									return (t) -> getLogger().debug((String) t);
+								case JAVA:
+									//noinspection unchecked
+									return (Sink<T>) new Sink<SinkReturns.Decompiled>() {
+										@Override
+										public void write(SinkReturns.Decompiled decompiled) {
+											String filename = decompiled.getPackageName().replace('.', '/');
+											if (!filename.isEmpty()) filename += "/";
+											filename += decompiled.getClassName() + ".java";
+
+											String[] path = filename.split("/");
+											String pathPart = "";
+											for (int i = 0; i < path.length - 1; i++) {
+												pathPart += path[i] + "/";
+												if (addedDirectories.add(pathPart)) {
+													JarEntry entry = new JarEntry(pathPart);
+													entry.setTime(new Date().getTime());
+
+													try {
+														jos.putNextEntry(entry);
+														jos.closeEntry();
+													} catch (IOException e) {
+														throw new RuntimeException(e);
+													}
+												}
+											}
+
+											byte[] data = decompiled.getJava().getBytes(Charsets.UTF_8);
+											JarEntry entry = new JarEntry(filename);
+											entry.setTime(new Date().getTime());
+											entry.setSize(data.length);
+
+											try {
+												jos.putNextEntry(entry);
+												jos.write(data);
+												jos.closeEntry();
+											} catch (IOException e) {
+												throw new RuntimeException(e);
+											}
+										}
+									};
+								default:
+									return (t) -> {};
+							}
+						}
+					})
+					.build();
+
+			driver.analyse(Collections.singletonList(mappedJar.getAbsolutePath()));
+		}
+	}
+	*/
+}

--- a/src/main/java/net/fabricmc/loom/task/GenSourcesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenSourcesTask.java
@@ -1,0 +1,154 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableMap;
+import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.providers.MinecraftProvider;
+import net.fabricmc.loom.providers.PomfProvider;
+import net.fabricmc.loom.util.MinecraftVersionInfo;
+import org.benf.cfr.reader.api.CfrDriver;
+import org.benf.cfr.reader.api.ClassFileSource;
+import org.benf.cfr.reader.api.OutputSinkFactory;
+import org.benf.cfr.reader.api.SinkReturns;
+import org.benf.cfr.reader.entities.Method;
+import org.benf.cfr.reader.util.output.StreamDumper;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskAction;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.*;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+
+public class GenSourcesTask extends DefaultTask {
+	public static File getSourcesJar(Project project) {
+		LoomGradleExtension extension = project.getExtensions().getByType(LoomGradleExtension.class);
+		PomfProvider pomfProvider = extension.getPomfProvider();
+		File mappedJar = pomfProvider.mappedProvider.getMappedJar();
+		String path = mappedJar.getAbsolutePath();
+		if (!path.toLowerCase(Locale.ROOT).endsWith(".jar")) {
+			throw new RuntimeException("Invalid mapped JAR path: " + path);
+		}
+
+		return new File(path.substring(0, path.length() - 4) + "-sources.jar");
+	}
+
+	@TaskAction
+	public void genSources() throws IOException {
+		Project project = this.getProject();
+		LoomGradleExtension extension = project.getExtensions().getByType(LoomGradleExtension.class);
+		PomfProvider pomfProvider = extension.getPomfProvider();
+		File mappedJar = pomfProvider.mappedProvider.getMappedJar();
+		File sourcesJar = getSourcesJar(project);
+
+		Manifest manifest = new Manifest();
+		manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+		Set<String> addedDirectories = new HashSet<>();
+
+		try (FileOutputStream fos = new FileOutputStream(sourcesJar);
+			JarOutputStream jos = new JarOutputStream(fos, manifest)) {
+
+			project.getLogger().lifecycle(":generating sources JAR");
+			CfrDriver driver = new CfrDriver.Builder()
+					.withOptions(ImmutableMap.of("renameillegalidents","true"))
+					.withOutputSink(new OutputSinkFactory() {
+						@Override
+						public List<SinkClass> getSupportedSinks(SinkType sinkType, Collection<SinkClass> collection) {
+							switch (sinkType) {
+								case PROGRESS:
+									return Collections.singletonList(SinkClass.STRING);
+								case JAVA:
+									return Collections.singletonList(SinkClass.DECOMPILED);
+								default:
+									return Collections.emptyList();
+							}
+						}
+
+						@Override
+						public <T> Sink<T> getSink(SinkType sinkType, SinkClass sinkClass) {
+							switch (sinkType) {
+								case PROGRESS:
+									return (t) -> getLogger().debug((String) t);
+								case JAVA:
+									//noinspection unchecked
+									return (Sink<T>) new Sink<SinkReturns.Decompiled>() {
+										@Override
+										public void write(SinkReturns.Decompiled decompiled) {
+											String filename = decompiled.getPackageName().replace('.', '/');
+											if (!filename.isEmpty()) filename += "/";
+											filename += decompiled.getClassName() + ".java";
+
+											String[] path = filename.split("/");
+											String pathPart = "";
+											for (int i = 0; i < path.length - 1; i++) {
+												pathPart += path[i] + "/";
+												if (addedDirectories.add(pathPart)) {
+													JarEntry entry = new JarEntry(pathPart);
+													entry.setTime(new Date().getTime());
+
+													try {
+														jos.putNextEntry(entry);
+														jos.closeEntry();
+													} catch (IOException e) {
+														throw new RuntimeException(e);
+													}
+												}
+											}
+
+											byte[] data = decompiled.getJava().getBytes(Charsets.UTF_8);
+											JarEntry entry = new JarEntry(filename);
+											entry.setTime(new Date().getTime());
+											entry.setSize(data.length);
+
+											try {
+												jos.putNextEntry(entry);
+												jos.write(data);
+												jos.closeEntry();
+											} catch (IOException e) {
+												throw new RuntimeException(e);
+											}
+										}
+									};
+								default:
+									return (t) -> {};
+							}
+						}
+					})
+					.build();
+
+			driver.analyse(Collections.singletonList(mappedJar.getAbsolutePath()));
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/GenVsCodeProjectTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenVsCodeProjectTask.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.util.Constants;
+import net.fabricmc.loom.util.IdeaRunConfig;
+import org.apache.commons.io.FileUtils;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+//Recommended vscode plugins:
+// https://marketplace.visualstudio.com/items?itemName=redhat.java
+// https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug
+// https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack
+public class GenVsCodeProjectTask extends DefaultTask {
+
+    @TaskAction
+    public void genRuns() {
+        LoomGradleExtension extension = getProject().getExtensions().getByType(LoomGradleExtension.class);
+        File projectDir = new File(".vscode");
+        if (!projectDir.exists()) {
+            projectDir.mkdir();
+        }
+        File launchJson = new File(projectDir, "launch.json");
+        if (launchJson.exists()) {
+            launchJson.delete();
+        }
+
+        VsCodeLaunch launch = new VsCodeLaunch();
+        launch.add(IdeaRunConfig.clientRunConfig(getProject()));
+        launch.add(IdeaRunConfig.serverRunConfig(getProject()));
+
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        String json = gson.toJson(launch);
+
+        try {
+            FileUtils.writeStringToFile(launchJson, json, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to write launch.json", e);
+        }
+
+        File runDir = new File(Constants.WORKING_DIRECTORY, extension.runDir);
+        if (!runDir.exists()) {
+            runDir.mkdirs();
+        }
+    }
+
+    private static class VsCodeLaunch {
+        public String version = "0.2.0";
+        public List<VsCodeConfiguration> configurations = new ArrayList<>();
+
+        public void add(IdeaRunConfig runConfig) {
+            configurations.add(new VsCodeConfiguration(runConfig));
+        }
+    }
+
+    private static class VsCodeConfiguration {
+        public String type = "java";
+        public String name;
+        public String request = "launch";
+        public String cwd = "${workspaceFolder}\\run";
+        public String conolse = "internalConsole";
+        public boolean stopOnEntry = false;
+        public String mainClass;
+        public String vmArgs;
+        public String args;
+
+        public VsCodeConfiguration(IdeaRunConfig runConfig) {
+            this.name = runConfig.configName;
+            this.mainClass = runConfig.mainClass;
+            this.vmArgs = runConfig.vmArgs;
+            this.args = runConfig.programArgs;
+        }
+    }
+}

--- a/src/main/java/net/fabricmc/loom/task/LineNumberAdjustmentVisitor.java
+++ b/src/main/java/net/fabricmc/loom/task/LineNumberAdjustmentVisitor.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LineNumberAdjustmentVisitor extends ClassVisitor {
+	public class Method extends MethodVisitor {
+		public Method(int api, MethodVisitor methodVisitor) {
+			super(api, methodVisitor);
+		}
+
+		@Override
+		public void visitLineNumber(final int line, final Label start) {
+			int tLine = line;
+			/* while (tLine >= 1 && !lineNumberMap.containsKey(tLine)) {
+				tLine--;
+			} */
+			while (tLine <= maxLine && !lineNumberMap.containsKey(tLine)) {
+				tLine++;
+			}
+			if (tLine <= 0) {
+				tLine = 1;
+			} else if (tLine >= maxLine) {
+				tLine = maxLineDst;
+			} else {
+				tLine = lineNumberMap.get(tLine);
+			}
+			super.visitLineNumber(tLine, start);
+		}
+	}
+
+	private final Map<Integer, Integer> lineNumberMap;
+	private int maxLine, maxLineDst;
+
+	public LineNumberAdjustmentVisitor(int api, ClassVisitor classVisitor, int[] mapping) {
+		super(api, classVisitor);
+
+		lineNumberMap = new HashMap<>();
+		maxLine = 0;
+
+		for (int i = 0; i < mapping.length; i += 2) {
+			lineNumberMap.put(mapping[i], mapping[i+1]);
+			if (mapping[i] > maxLine) {
+				maxLine = mapping[i];
+			}
+			if (mapping[i+1] > maxLineDst) {
+				maxLineDst = mapping[i+1];
+			}
+		}
+	}
+
+	@Override
+	public MethodVisitor visitMethod(
+			final int access,
+			final String name,
+			final String descriptor,
+			final String signature,
+			final String[] exceptions) {
+		return new Method(api, super.visitMethod(access, name, descriptor, signature, exceptions));
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/LoomFernflowerDecompiler.java
+++ b/src/main/java/net/fabricmc/loom/task/LoomFernflowerDecompiler.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task;
+
+import org.jetbrains.java.decompiler.main.decompiler.BaseDecompiler;
+import org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler;
+import org.jetbrains.java.decompiler.main.extern.IBytecodeProvider;
+import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;
+import org.jetbrains.java.decompiler.main.extern.IResultSaver;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+
+public class LoomFernflowerDecompiler extends ConsoleDecompiler {
+	private final Map<String, int[]> differingMappings = new HashMap<>();
+	private final String jarName;
+
+	public LoomFernflowerDecompiler(File destination, String jarName, Map<String, Object> options, IFernflowerLogger logger) {
+		super(destination, options, logger);
+		this.jarName = jarName;
+	}
+
+	public Map<String, int[]> getDifferingMappings() {
+		return differingMappings;
+	}
+
+	@Override
+	public void saveFolder(String s) {
+		super.saveFolder(s);
+	}
+
+	@Override
+	public void copyFile(String s, String s1, String s2) {
+		throw new RuntimeException("TODO copyFile " + s + " " + s1 + " " + s2);
+	}
+
+	@Override
+	public void saveClassFile(String s, String s1, String s2, String s3, int[] ints) {
+		throw new RuntimeException("TODO saveClassFile " + s + " " + s1 + " " + s2 + " " + s3);
+	}
+
+	@Override
+	public void createArchive(String s, String s1, Manifest manifest) {
+		super.createArchive(s, jarName, manifest);
+	}
+
+	@Override
+	public void saveDirEntry(String s, String s1, String s2) {
+		super.saveDirEntry(s, jarName, s2);
+	}
+
+	@Override
+	public void copyEntry(String s, String s1, String s2, String s3) {
+		super.copyEntry(s, s1, jarName, s3);
+	}
+
+	@Override
+	public void saveClassEntry(String s, String s1, String s2, String s3, String s4, int[] mapping) {
+		if (mapping != null) {
+			differingMappings.put(s2, mapping);
+		}
+
+		super.saveClassEntry(s, jarName, s2, s3, s4, mapping);
+	}
+
+	@Override
+	public void closeArchive(String s, String s1) {
+		super.closeArchive(s, jarName);
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/LoomFernflowerLogger.java
+++ b/src/main/java/net/fabricmc/loom/task/LoomFernflowerLogger.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task;
+
+import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;
+
+public class LoomFernflowerLogger extends IFernflowerLogger {
+	@Override
+	public void writeMessage(String s, Severity severity) {
+		if (severity == Severity.WARN || severity == Severity.ERROR) {
+			System.err.println(s);
+		}
+	}
+
+	@Override
+	public void writeMessage(String s, Severity severity, Throwable throwable) {
+		if (severity == Severity.WARN || severity == Severity.ERROR) {
+			System.err.println(s);
+			throwable.printStackTrace(System.err);
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/MapJarsTiny.java
+++ b/src/main/java/net/fabricmc/loom/util/MapJarsTiny.java
@@ -63,6 +63,7 @@ public class MapJarsTiny {
 
 			TinyRemapper remapper = TinyRemapper.newRemapper()
 					.withMappings(TinyUtils.createTinyMappingProvider(mappings, fromM, toM))
+					.rebuildSourceFilenames(true)
 					.build();
 
 			try (OutputConsumerPath outputConsumer = new OutputConsumerPath(output)) {

--- a/src/main/java/net/fabricmc/loom/util/MixinRefmapHelper.java
+++ b/src/main/java/net/fabricmc/loom/util/MixinRefmapHelper.java
@@ -45,162 +45,162 @@ import java.util.Set;
 import java.util.zip.ZipEntry;
 
 public final class MixinRefmapHelper {
-    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 
-    private MixinRefmapHelper() {
+	private MixinRefmapHelper() {
 
-    }
-    public static boolean addRefmapName(String filename, File output) {
-        Set<String> mixinFilenames = findMixins(output, true);
+	}
+	public static boolean addRefmapName(String filename, File output) {
+		Set<String> mixinFilenames = findMixins(output, true);
 
-        if (mixinFilenames.size() > 0) {
-            ZipUtil.transformEntries(
-                    output,
-                    mixinFilenames.stream()
-                            .map((f) -> new ZipEntryTransformerEntry(f, new StringZipEntryTransformer("UTF-8") {
-                                @Override
-                                protected String transform(ZipEntry zipEntry, String input) throws IOException {
-                                    JsonObject json = GSON.fromJson(input, JsonObject.class);
-                                    json.addProperty("refmap", filename);
-                                    return GSON.toJson(json);
-                                }
-                            })).toArray(ZipEntryTransformerEntry[]::new)
-            );
+		if (mixinFilenames.size() > 0) {
+			ZipUtil.transformEntries(
+					output,
+					mixinFilenames.stream()
+							.map((f) -> new ZipEntryTransformerEntry(f, new StringZipEntryTransformer("UTF-8") {
+								@Override
+								protected String transform(ZipEntry zipEntry, String input) throws IOException {
+									JsonObject json = GSON.fromJson(input, JsonObject.class);
+									json.addProperty("refmap", filename);
+									return GSON.toJson(json);
+								}
+							})).toArray(ZipEntryTransformerEntry[]::new)
+			);
 
-            return true;
-        } else {
-            return false;
-        }
-    }
+			return true;
+		} else {
+			return false;
+		}
+	}
 
-    private static Set<String> findMixins(File output, boolean onlyWithoutRefmap) {
-        // first, identify all of the mixin files
-        Set<String> mixinFilename = new HashSet<>();
-        // TODO: this is a lovely hack
-        ZipUtil.iterate(output, (stream, entry) -> {
-            if (!entry.isDirectory() && entry.getName().endsWith(".json") && !entry.getName().contains("/") && !entry.getName().contains("\\")) {
-                // JSON file in root directory
-                InputStreamReader inputStreamReader = new InputStreamReader(stream);
-                try {
-                    JsonObject json = GSON.fromJson(inputStreamReader, JsonObject.class);
-                    if (json != null && json.has("mixins") && json.get("mixins").isJsonArray()) {
-                        if (!onlyWithoutRefmap || !json.has("refmap")) {
-                            mixinFilename.add(entry.getName());
-                        }
-                    }
-                } catch (Exception e) {
-                    // ...
-                } finally {
-                    inputStreamReader.close();
-                    stream.close();
-                }
-            }
-        });
-        return mixinFilename;
-    }
+	private static Set<String> findMixins(File output, boolean onlyWithoutRefmap) {
+		// first, identify all of the mixin files
+		Set<String> mixinFilename = new HashSet<>();
+		// TODO: this is a lovely hack
+		ZipUtil.iterate(output, (stream, entry) -> {
+			if (!entry.isDirectory() && entry.getName().endsWith(".json") && !entry.getName().contains("/") && !entry.getName().contains("\\")) {
+				// JSON file in root directory
+				InputStreamReader inputStreamReader = new InputStreamReader(stream);
+				try {
+					JsonObject json = GSON.fromJson(inputStreamReader, JsonObject.class);
+					if (json != null && json.has("mixins") && json.get("mixins").isJsonArray()) {
+						if (!onlyWithoutRefmap || !json.has("refmap")) {
+							mixinFilename.add(entry.getName());
+						}
+					}
+				} catch (Exception e) {
+					// ...
+				} finally {
+					inputStreamReader.close();
+					stream.close();
+				}
+			}
+		});
+		return mixinFilename;
+	}
 
-    private static Set<String> findRefmaps(File output) {
-        // first, identify all of the mixin refmaps
-        Set<String> mixinRefmapFilenames = new HashSet<>();
-        // TODO: this is also a lovely hack
-        ZipUtil.iterate(output, (stream, entry) -> {
-            if (!entry.isDirectory() && entry.getName().endsWith(".json") && !entry.getName().contains("/") && !entry.getName().contains("\\")) {
-                // JSON file in root directory
-                InputStreamReader inputStreamReader = new InputStreamReader(stream);
-                try {
-                    JsonObject json = GSON.fromJson(inputStreamReader, JsonObject.class);
-                    if (json != null && json.has("refmap")) {
-                        mixinRefmapFilenames.add(json.get("refmap").getAsString());
-                    }
-                } catch (Exception e) {
-                    // ...
-                } finally {
-                    inputStreamReader.close();
-                    stream.close();
-                }
-            }
-        });
-        return mixinRefmapFilenames;
-    }
+	private static Set<String> findRefmaps(File output) {
+		// first, identify all of the mixin refmaps
+		Set<String> mixinRefmapFilenames = new HashSet<>();
+		// TODO: this is also a lovely hack
+		ZipUtil.iterate(output, (stream, entry) -> {
+			if (!entry.isDirectory() && entry.getName().endsWith(".json") && !entry.getName().contains("/") && !entry.getName().contains("\\")) {
+				// JSON file in root directory
+				InputStreamReader inputStreamReader = new InputStreamReader(stream);
+				try {
+					JsonObject json = GSON.fromJson(inputStreamReader, JsonObject.class);
+					if (json != null && json.has("refmap")) {
+						mixinRefmapFilenames.add(json.get("refmap").getAsString());
+					}
+				} catch (Exception e) {
+					// ...
+				} finally {
+					inputStreamReader.close();
+					stream.close();
+				}
+			}
+		});
+		return mixinRefmapFilenames;
+	}
 
-    public static boolean transformRefmaps(TinyRemapper remapper, File output) {
-        Set<String> mixinRefmapFilenames = findRefmaps(output);
+	public static boolean transformRefmaps(TinyRemapper remapper, File output) {
+		Set<String> mixinRefmapFilenames = findRefmaps(output);
 
-        if (mixinRefmapFilenames.size() > 0) {
-            Remapper asmRemapper;
-            // TODO: Expose in tiny-remapper
-            try {
-                Field f = TinyRemapper.class.getDeclaredField("remapper");;
-                f.setAccessible(true);
-                asmRemapper = (Remapper) f.get(remapper);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
+		if (mixinRefmapFilenames.size() > 0) {
+			Remapper asmRemapper;
+			// TODO: Expose in tiny-remapper
+			try {
+				Field f = TinyRemapper.class.getDeclaredField("remapper");;
+				f.setAccessible(true);
+				asmRemapper = (Remapper) f.get(remapper);
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
 
-            ZipUtil.transformEntries(
-                    output,
-                    mixinRefmapFilenames.stream()
-                            .map((f) -> new ZipEntryTransformerEntry(f, new StringZipEntryTransformer("UTF-8") {
-                                @Override
-                                protected String transform(ZipEntry zipEntry, String input) throws IOException {
-                                    return transformRefmap(asmRemapper, GSON, input);
-                                }
-                            })).toArray(ZipEntryTransformerEntry[]::new)
-            );
+			ZipUtil.transformEntries(
+					output,
+					mixinRefmapFilenames.stream()
+							.map((f) -> new ZipEntryTransformerEntry(f, new StringZipEntryTransformer("UTF-8") {
+								@Override
+								protected String transform(ZipEntry zipEntry, String input) throws IOException {
+									return transformRefmap(asmRemapper, GSON, input);
+								}
+							})).toArray(ZipEntryTransformerEntry[]::new)
+			);
 
-            return true;
-        } else {
-            return false;
-        }
-    }
+			return true;
+		} else {
+			return false;
+		}
+	}
 
-    public static String transformRefmap(Remapper remapper, Gson gson, String input) throws IOException {
-        try {
-            JsonObject refMap = gson.fromJson(input, JsonObject.class);
-            JsonObject mappings = refMap.getAsJsonObject("mappings");
+	public static String transformRefmap(Remapper remapper, Gson gson, String input) throws IOException {
+		try {
+			JsonObject refMap = gson.fromJson(input, JsonObject.class);
+			JsonObject mappings = refMap.getAsJsonObject("mappings");
 
-            for (Map.Entry<String, JsonElement> elementEntry : mappings.entrySet()) {
-                JsonObject value = elementEntry.getValue().getAsJsonObject();
-                for (String k : new HashSet<>(value.keySet())) {
-                    try {
-                        String v = value.get(k).getAsString();
-                        String v2;
+			for (Map.Entry<String, JsonElement> elementEntry : mappings.entrySet()) {
+				JsonObject value = elementEntry.getValue().getAsJsonObject();
+				for (String k : new HashSet<>(value.keySet())) {
+					try {
+						String v = value.get(k).getAsString();
+						String v2;
 
-                        if (v.charAt(0) == 'L') {
-                            // field or member
-                            MemberInfo info = MemberInfo.parse(v);
-                            String owner = remapper.map(info.owner);
-                            if (info.isField()) {
-                                v2 = new MemberInfo(
-                                        remapper.mapFieldName(info.owner, info.name, info.desc),
-                                        owner,
-                                        remapper.mapDesc(info.desc)
-                                ).toString();
-                            } else {
-                                v2 = new MemberInfo(
-                                        remapper.mapMethodName(info.owner, info.name, info.desc),
-                                        owner,
-                                        remapper.mapMethodDesc(info.desc)
-                                ).toString();
-                            }
-                        } else {
-                            // class
-                            v2 = remapper.map(v);
-                        }
+						if (v.charAt(0) == 'L') {
+							// field or member
+							MemberInfo info = MemberInfo.parse(v);
+							String owner = remapper.map(info.owner);
+							if (info.isField()) {
+								v2 = new MemberInfo(
+										remapper.mapFieldName(info.owner, info.name, info.desc),
+										owner,
+										remapper.mapDesc(info.desc)
+								).toString();
+							} else {
+								v2 = new MemberInfo(
+										remapper.mapMethodName(info.owner, info.name, info.desc),
+										owner,
+										remapper.mapMethodDesc(info.desc)
+								).toString();
+							}
+						} else {
+							// class
+							v2 = remapper.map(v);
+						}
 
-                        if (v2 != null) {
-                            value.addProperty(k, v2);
-                        }
-                    } catch (Exception ee) {
-                        ee.printStackTrace();
-                    }
-                }
-            }
+						if (v2 != null) {
+							value.addProperty(k, v2);
+						}
+					} catch (Exception ee) {
+						ee.printStackTrace();
+					}
+				}
+			}
 
-            return gson.toJson(refMap);
-        } catch (Exception e) {
-            e.printStackTrace();
-            return input;
-        }
-    }
+			return gson.toJson(refMap);
+		} catch (Exception e) {
+			e.printStackTrace();
+			return input;
+		}
+	}
 }

--- a/src/main/java/net/fabricmc/loom/util/ModJsonUpdater.java
+++ b/src/main/java/net/fabricmc/loom/util/ModJsonUpdater.java
@@ -2,16 +2,14 @@ package net.fabricmc.loom.util;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
 import net.fabricmc.loom.ModExtension;
 import org.zeroturnaround.zip.ZipUtil;
 import org.zeroturnaround.zip.transform.StringZipEntryTransformer;
 import org.zeroturnaround.zip.transform.ZipEntryTransformerEntry;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 
@@ -26,15 +24,11 @@ public class ModJsonUpdater {
 				modJsonFileNames.stream()
 						.map((f) -> new ZipEntryTransformerEntry(f, new StringZipEntryTransformer("UTF-8") {
 							@Override
-							protected String transform(ZipEntry zipEntry, String input) throws IOException {
-								JsonObject json = GSON.fromJson(input, JsonObject.class);
-								if(modExtension.getId() != null) {
-									json.add("id", new JsonPrimitive(modExtension.getId()));
+							protected String transform(ZipEntry zipEntry, String json) {
+								for (Map.Entry<String, String> entry : modExtension.getReplacements().entrySet()) {
+									json = json.replace(entry.getKey(), entry.getValue());
 								}
-								if(modExtension.getVersion() != null) {
-									json.add("version", new JsonPrimitive(modExtension.getVersion()));
-								}
-								return GSON.toJson(json);
+								return json;
 							}
 						})).toArray(ZipEntryTransformerEntry[]::new)
 		);

--- a/src/main/java/net/fabricmc/loom/util/ModJsonUpdater.java
+++ b/src/main/java/net/fabricmc/loom/util/ModJsonUpdater.java
@@ -19,7 +19,7 @@ public class ModJsonUpdater {
 	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 
 	public static void updateModJson(ModExtension modExtension, File jarFile) {
-		Set<String> modJsonFileNames = new HashSet<String>();
+		Set<String> modJsonFileNames = new HashSet<>();
 		modJsonFileNames.add("mod.json");
 		ZipUtil.transformEntries(
 				jarFile,

--- a/src/main/java/net/fabricmc/loom/util/ModJsonUpdater.java
+++ b/src/main/java/net/fabricmc/loom/util/ModJsonUpdater.java
@@ -1,0 +1,42 @@
+package net.fabricmc.loom.util;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import net.fabricmc.loom.ModExtension;
+import org.zeroturnaround.zip.ZipUtil;
+import org.zeroturnaround.zip.transform.StringZipEntryTransformer;
+import org.zeroturnaround.zip.transform.ZipEntryTransformerEntry;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+
+public class ModJsonUpdater {
+	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+	public static void updateModJson(ModExtension modExtension, File jarFile) {
+		Set<String> modJsonFileNames = new HashSet<String>();
+		modJsonFileNames.add("mod.json");
+		ZipUtil.transformEntries(
+				jarFile,
+				modJsonFileNames.stream()
+						.map((f) -> new ZipEntryTransformerEntry(f, new StringZipEntryTransformer("UTF-8") {
+							@Override
+							protected String transform(ZipEntry zipEntry, String input) throws IOException {
+								JsonObject json = GSON.fromJson(input, JsonObject.class);
+								if(modExtension.getId() != null) {
+									json.add("id", new JsonPrimitive(modExtension.getId()));
+								}
+								if(modExtension.getVersion() != null) {
+									json.add("version", new JsonPrimitive(modExtension.getVersion()));
+								}
+								return GSON.toJson(json);
+							}
+						})).toArray(ZipEntryTransformerEntry[]::new)
+		);
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/ModRemapper.java
+++ b/src/main/java/net/fabricmc/loom/util/ModRemapper.java
@@ -25,6 +25,7 @@
 package net.fabricmc.loom.util;
 
 import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.ModExtension;
 import net.fabricmc.loom.providers.PomfProvider;
 import net.fabricmc.loom.task.RemapJar;
 import net.fabricmc.tinyremapper.OutputConsumerPath;
@@ -42,6 +43,7 @@ public class ModRemapper {
 	public static void remap(RemapJar task) {
 		Project project = task.getProject();
 		LoomGradleExtension extension = project.getExtensions().getByType(LoomGradleExtension.class);
+		ModExtension modExtension = project.getExtensions().getByType(ModExtension.class);
 
 		File modJar = task.jar;
 
@@ -96,6 +98,11 @@ public class ModRemapper {
 
 		if (extension.refmapName != null && extension.refmapName.length() > 0) {
 			MixinRefmapHelper.addRefmapName(extension.refmapName, modJarOutput);
+		}
+
+		if (modExtension.getId() != null && modExtension.getVersion() != null) {
+			// update mod.json in jar
+			ModJsonUpdater.updateModJson(modExtension, modJarOutput);
 		}
 
 		if (modJar.exists()) {

--- a/src/main/java/net/fabricmc/loom/util/ModRemapper.java
+++ b/src/main/java/net/fabricmc/loom/util/ModRemapper.java
@@ -100,8 +100,7 @@ public class ModRemapper {
 			MixinRefmapHelper.addRefmapName(extension.refmapName, modJarOutput);
 		}
 
-		if (modExtension.getId() != null && modExtension.getVersion() != null) {
-			// update mod.json in jar
+		if (modExtension.getEnabled()) {
 			ModJsonUpdater.updateModJson(modExtension, modJarOutput);
 		}
 


### PR DESCRIPTION
<s>this currently only works on a existing `mod.json`

properties that can be set: `id`, `version`

planned: everything else

properties currently just override what happened to be in the mod.json, this could be changed to allow appending or prepending values
I think this would be overengineered
such things can also just stay in the `build.gradle`
</s>

new approach: dumb token replacement

available methods on the mod extension:
- `replace(String key, String value)`
- `replace(Map<String, String> replacements)`

sample usage

```kotlin
mod {
   replace("VERSION", version + "-" + buildNumber)
}
```

`mod.json`
```json
{
  "id": "fabric-language-kotlin",
  "version": "VERSION"
}
```