### PR TITLE
Add -XstartOnFirstThread, required when running on macOS

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/RunClientTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RunClientTask.java
@@ -79,6 +79,7 @@ public class RunClientTask extends JavaExec {
 		LoomGradleExtension extension = this.getProject().getExtensions().getByType(LoomGradleExtension.class);
 		List<String> args = new ArrayList<>();
 		args.add("-Dfabric.development=true");
+		args.add("-XstartOnFirstThread");
 		return args;
 	}
 

--- a/src/main/java/net/fabricmc/loom/task/RunServerTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RunServerTask.java
@@ -75,6 +75,7 @@ public class RunServerTask extends JavaExec {
 		LoomGradleExtension extension = this.getProject().getExtensions().getByType(LoomGradleExtension.class);
 		List<String> args = new ArrayList<>();
 		args.add("-Dfabric.development=true");
+		args.add("-XstartOnFirstThread");
 		return args;
 	}
 

--- a/src/main/java/net/fabricmc/loom/util/IdeaRunConfig.java
+++ b/src/main/java/net/fabricmc/loom/util/IdeaRunConfig.java
@@ -92,7 +92,7 @@ public class IdeaRunConfig {
 		ideaClient.projectName = project.getName();
 		ideaClient.configName = "Minecraft Client";
 		ideaClient.runDir = "file://$PROJECT_DIR$/" + extension.runDir;
-		ideaClient.vmArgs = "-Dfabric.development=true";
+		ideaClient.vmArgs = "-Dfabric.development=true -XstartOnFirstThread";
 		ideaClient.programArgs = "--tweakClass " + Constants.FABRIC_CLIENT_TWEAKER + " --assetIndex " + minecraftVersionInfo.assetIndex.getFabricId(extension.getMinecraftProvider().minecraftVersion) + " --assetsDir \"" + new File(extension.getUserCache(), "assets").getAbsolutePath() + "\"";
 
 		return ideaClient;


### PR DESCRIPTION
Required when running on macOS, otherwise GLFW crashes trying to create a window:

```
java.lang.ExceptionInInitializerError
	at org.lwjgl.glfw.GLFW.glfwCreateWindow(GLFW.java:1823)
	at net.minecraft.client.util.Window.<init>(Window.java:88)
	at net.minecraft.class_3682.method_16038(class_3682.java:25)
	at net.minecraft.client.MinecraftClient.init(MinecraftClient.java:416)
	at net.minecraft.client.MinecraftClient.start(MinecraftClient.java:357)
	at net.minecraft.client.main.Main.main(Main.java:126)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
Caused by: java.lang.IllegalStateException: GLFW windows may only be created on the main thread and that thread must be the first thread in the process. Please run the JVM with -XstartOnFirstThread. For offscreen rendering, make sure another window toolkit (e.g. AWT or JavaFX) is initialized before GLFW.
	at org.lwjgl.glfw.EventLoop$OffScreen.<clinit>(EventLoop.java:39)
	... 12 more
```

Right now, this isn't macOS specific, as there should be no harm in doing so on other platforms as well, and there's no need to unnecessarily complicate the code.