### PR TITLE
CleanLoomBinaries now removes mappings too

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/CleanLoomBinaries.java
+++ b/src/main/java/net/fabricmc/loom/task/CleanLoomBinaries.java
@@ -34,6 +34,8 @@ public class CleanLoomBinaries extends DefaultTask {
     public void run() {
         Project project = this.getProject();
         LoomGradleExtension extension = project.getExtensions().getByType(LoomGradleExtension.class);
+        extension.getMappingsProvider().MAPPINGS_TINY.delete();
+        extension.getMappingsProvider().MAPPINGS_TINY_BASE.delete();
         extension.getMinecraftProvider().jarProvider.getMergedJar().delete();
         extension.getMinecraftMappedProvider().getIntermediaryJar().delete();
         extension.getMinecraftMappedProvider().getMappedJar().delete();


### PR DESCRIPTION
With this, I can now run `gradle cleanLoomBinaries` after rebuilding yarn into my local Maven repo, to cause the next `gradle build` to rebuild the mapped jar using the updated mappings.

Kind of a solution to #35