### PR TITLE
Put tasks in 'fabric' group

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/CleanLoomBinaries.java
+++ b/src/main/java/net/fabricmc/loom/task/CleanLoomBinaries.java
@@ -25,11 +25,10 @@
 package net.fabricmc.loom.task;
 
 import net.fabricmc.loom.LoomGradleExtension;
-import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.TaskAction;
 
-public class CleanLoomBinaries extends DefaultTask {
+public class CleanLoomBinaries extends DefaultLoomTask {
     @TaskAction
     public void run() {
         Project project = this.getProject();

--- a/src/main/java/net/fabricmc/loom/task/CleanLoomMappings.java
+++ b/src/main/java/net/fabricmc/loom/task/CleanLoomMappings.java
@@ -26,14 +26,13 @@ package net.fabricmc.loom.task;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.util.DeletingFileVisitor;
-import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.IOException;
 import java.nio.file.Files;
 
-public class CleanLoomMappings extends DefaultTask {
+public class CleanLoomMappings extends DefaultLoomTask {
     @TaskAction
     public void run() {
         Project project = this.getProject();

--- a/src/main/java/net/fabricmc/loom/task/DefaultLoomTask.java
+++ b/src/main/java/net/fabricmc/loom/task/DefaultLoomTask.java
@@ -1,0 +1,11 @@
+package net.fabricmc.loom.task;
+
+import org.gradle.api.DefaultTask;
+
+public abstract class DefaultLoomTask extends DefaultTask {
+
+	public DefaultLoomTask() {
+		setGroup("fabric");
+	}
+
+}

--- a/src/main/java/net/fabricmc/loom/task/GenEclipseRunsTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenEclipseRunsTask.java
@@ -26,14 +26,13 @@ package net.fabricmc.loom.task;
 
 import net.fabricmc.loom.util.RunConfig;
 import org.apache.commons.io.FileUtils;
-import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-public class GenEclipseRunsTask extends DefaultTask {
+public class GenEclipseRunsTask extends DefaultLoomTask {
 
     @TaskAction
     public void genRuns() throws IOException {

--- a/src/main/java/net/fabricmc/loom/task/GenIdeaProjectTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenIdeaProjectTask.java
@@ -26,7 +26,6 @@ package net.fabricmc.loom.task;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.util.RunConfig;
-import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.TaskAction;
 import org.w3c.dom.Document;
@@ -46,7 +45,7 @@ import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.io.IOException;
 
-public class GenIdeaProjectTask extends DefaultTask {
+public class GenIdeaProjectTask extends DefaultLoomTask {
 
 	@TaskAction
 	public void genIdeaRuns() throws IOException, ParserConfigurationException, SAXException, TransformerException {

--- a/src/main/java/net/fabricmc/loom/task/GenSourcesCfrTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenSourcesCfrTask.java
@@ -24,9 +24,7 @@
 
 package net.fabricmc.loom.task;
 
-import org.gradle.api.DefaultTask;
-
-public class GenSourcesCfrTask extends DefaultTask {
+public class GenSourcesCfrTask extends DefaultLoomTask {
 	/*
 	@TaskAction
 	public void genSources() throws IOException {

--- a/src/main/java/net/fabricmc/loom/task/GenSourcesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenSourcesTask.java
@@ -28,7 +28,6 @@ import com.google.common.io.ByteStreams;
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.providers.MappingsProvider;
 import net.fabricmc.loom.providers.MinecraftLibraryProvider;
-import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.TaskAction;
 import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
@@ -40,10 +39,12 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 import java.util.jar.*;
 
-public class GenSourcesTask extends DefaultTask {
+public class GenSourcesTask extends DefaultLoomTask {
 	public static File getSourcesJar(Project project) {
 		LoomGradleExtension extension = project.getExtensions().getByType(LoomGradleExtension.class);
 		MappingsProvider mappingsProvider = extension.getMappingsProvider();

--- a/src/main/java/net/fabricmc/loom/task/GenVsCodeProjectTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenVsCodeProjectTask.java
@@ -29,7 +29,6 @@ import com.google.gson.GsonBuilder;
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.util.RunConfig;
 import org.apache.commons.io.FileUtils;
-import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
@@ -42,7 +41,7 @@ import java.util.List;
 // https://marketplace.visualstudio.com/items?itemName=redhat.java
 // https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug
 // https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack
-public class GenVsCodeProjectTask extends DefaultTask {
+public class GenVsCodeProjectTask extends DefaultLoomTask {
 
     @TaskAction
     public void genRuns() {

--- a/src/main/java/net/fabricmc/loom/task/RemapJar.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapJar.java
@@ -25,15 +25,12 @@
 package net.fabricmc.loom.task;
 
 import net.fabricmc.loom.util.ModRemapper;
-import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.jvm.tasks.Jar;
 
 import java.io.File;
 
-public class RemapJar extends DefaultTask {
+public class RemapJar extends DefaultLoomTask {
 	public File jar;
 
 	@Input

--- a/src/main/java/net/fabricmc/loom/task/RemapSourcesJar.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapSourcesJar.java
@@ -25,13 +25,12 @@
 package net.fabricmc.loom.task;
 
 import net.fabricmc.loom.util.SourceRemapper;
-import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
 
-public class RemapSourcesJar extends DefaultTask {
+public class RemapSourcesJar extends DefaultLoomTask {
 	public File jar;
 	public String direction = "intermediary";
 

--- a/src/main/java/net/fabricmc/loom/task/RunClientTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RunClientTask.java
@@ -36,6 +36,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class RunClientTask extends JavaExec {
+	public RunClientTask() {
+		setGroup("fabric");
+	}
 
 	@Override
 	public void exec() {

--- a/src/main/java/net/fabricmc/loom/task/RunServerTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RunServerTask.java
@@ -33,6 +33,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class RunServerTask extends JavaExec {
+	public RunServerTask() {
+		setGroup("fabric");
+	}
 
 	@Override
 	public void exec() {


### PR DESCRIPTION
This is to put the fabric specific tasks into their own category in the IDE, so that they're not mixed with everything in the 'other' group.