### PR TITLE
Improve Gradle 5 compatibility

### DIFF
--- a/src/main/java/net/fabricmc/loom/AbstractPlugin.java
+++ b/src/main/java/net/fabricmc/loom/AbstractPlugin.java
@@ -38,6 +38,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
@@ -235,6 +236,10 @@ public class AbstractPlugin implements Plugin<Project> {
 				SetupIntelijRunConfigs.setup(project1);
 			}
 
+			// add dependencies for mixin annotation processor
+			DependencyHandler handler = project1.getDependencies();
+			handler.add("annotationProcessor", "net.fabricmc:sponge-mixin:" + extension.getMixinVersion());
+			handler.add("annotationProcessor", "net.fabricmc:fabric-loom:0.2.0-SNAPSHOT"); // TODO: determine version automatically
 
 			//Enables the default mod remapper
 			if (extension.remapMod) {

--- a/src/main/java/net/fabricmc/loom/mixin/MixinServiceGradle.java
+++ b/src/main/java/net/fabricmc/loom/mixin/MixinServiceGradle.java
@@ -24,8 +24,8 @@
 
 package net.fabricmc.loom.mixin;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
-import com.strobel.collections.ImmutableList;
 import org.spongepowered.asm.lib.ClassReader;
 import org.spongepowered.asm.lib.tree.ClassNode;
 import org.spongepowered.asm.mixin.MixinEnvironment;

--- a/src/main/java/net/fabricmc/loom/util/RunConfig.java
+++ b/src/main/java/net/fabricmc/loom/util/RunConfig.java
@@ -25,10 +25,10 @@
 package net.fabricmc.loom.util;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.strobel.collections.ImmutableList;
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.providers.MinecraftProvider;
 import org.apache.commons.io.IOUtils;


### PR DESCRIPTION
fixes #38 

and clean up `ImmutableList`s from `com.strobel.collections`, uses guava instead 

has been lightly tested with gradle 4.10.2, the annotation processor still ran fine it seems

currently the version of loom is hardcoded, a possible solution to this would be to generate a file with version constants before javaCompile (of loom) and have those compiled in, this would be trivial to add in `buildSrc`, but i'd like to get a go before writing a PR for that

another option is to seperate the mixin specific from loom and have them in a separate dependency, then the same hack for finding the mixin version can be used on `loom-mixin`