### PR TITLE
Prevent remapJar task parameters from being overwritten

### DIFF
--- a/src/main/java/net/fabricmc/loom/AbstractPlugin.java
+++ b/src/main/java/net/fabricmc/loom/AbstractPlugin.java
@@ -259,7 +259,7 @@ public class AbstractPlugin implements Plugin<Project> {
 				AbstractArchiveTask jarTask = (AbstractArchiveTask) project1.getTasks().getByName("jar");
 
 				RemapJar remapJarTask = (RemapJar) project1.getTasks().findByName("remapJar");
-				remapJarTask.jar = jarTask.getArchivePath();
+				if (remapJarTask.jar==null) remapJarTask.jar = jarTask.getArchivePath();
 				remapJarTask.doLast(task -> project1.getArtifacts().add("archives", remapJarTask.jar));
 				remapJarTask.dependsOn(project1.getTasks().getByName("jar"));
 				project1.getTasks().getByName("build").dependsOn(remapJarTask);


### PR DESCRIPTION
The best (well, most stable, safest from race conditions) way to get shadowJar and remapJar to play nicely is to set `jar` to the output from the shadow task and set dependsOn's accordingly. Something like,
```java
remapJar {
	jar = tasks.shadowJar.outputs.getFiles()[0]
}
```
...we can get into solutions for `.getFiles()[0]` later, but for now the issue is, the above closure doesn't work. `Task::apply` is run *after* the project configurations are run, meaning we always have the default jar parameter from `configureCompile`. Working around requires a kludge like,
```java
tasks.jar.doLast {
	tasks.remapJar.jar = tasks.shadowJar.outputs.getFiles()[0]
}
```
in order to run configuration code after `Task::apply`

This felt like the minimal diff that solves this problem. If access to the default setting of the jar param is desired, we could talk about hoisting the parameter to before `apply`, but that'd be more research, some side effects (it might not default to the output of a reconfigured jar task), and a bigger diff.