### PR TITLE
Fix game launching in wrong folder with VS Code

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/GenVsCodeProjectTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenVsCodeProjectTask.java
@@ -87,7 +87,7 @@ public class GenVsCodeProjectTask extends DefaultLoomTask {
         public String type = "java";
         public String name;
         public String request = "launch";
-        public String cwd = "${workspaceFolder}\\run";
+        public String cwd = "${workspaceFolder}/run";
         public String console = "internalConsole";
         public boolean stopOnEntry = false;
         public String mainClass;


### PR DESCRIPTION
It appears that a backslash in the working directory (in `launch.json`) is not correctly handled by the Java launcher or so, causing the game to run in the workspace folder instead of `run`.

**Note:** I don't have a Windows machine so please make sure this still works on there.

(edit: Also let me know if this is the right branch.)