### PR TITLE
Fix the handling of file paths

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -94,7 +94,7 @@ public class LoomGradleExtension {
 	}
 
 	public File getProjectCache(){
-		File projectCache = new File(project.getRootDir(), ".gradle/minecraft/");
+		File projectCache = new File(project.getRootDir(), ".gradle" + File.separator + "minecraft");
 		if(!projectCache.exists()){
 			projectCache.mkdirs();
 		}
@@ -102,7 +102,7 @@ public class LoomGradleExtension {
 	}
 
 	public File getRemappedModCache() {
-		File remappedModCache = new File(getProjectCache(), "remapped_mods/");
+		File remappedModCache = new File(getProjectCache(), "remapped_mods");
 		if (!remappedModCache.exists()) {
 			remappedModCache.mkdir();
 		}
@@ -110,7 +110,7 @@ public class LoomGradleExtension {
 	}
 
 	public File getNestedModCache() {
-		File nestedModCache = new File(getProjectCache(), "nested_mods/");
+		File nestedModCache = new File(getProjectCache(), "nested_mods");
 		if (!nestedModCache.exists()) {
 			nestedModCache.mkdir();
 		}

--- a/src/main/java/net/fabricmc/loom/task/GenIdeaProjectTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenIdeaProjectTask.java
@@ -58,7 +58,7 @@ public class GenIdeaProjectTask extends DefaultLoomTask {
 		LoomGradleExtension extension = project.getExtensions().getByType(LoomGradleExtension.class);
 		project.getLogger().lifecycle(":Building idea workspace");
 
-		File file = new File(project.getName() + ".iws");
+		File file = project.file(project.getName() + ".iws");
 		DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
 		DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
 		Document doc = docBuilder.parse(file);

--- a/src/main/java/net/fabricmc/loom/task/GenVsCodeProjectTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenVsCodeProjectTask.java
@@ -46,7 +46,7 @@ public class GenVsCodeProjectTask extends DefaultLoomTask {
     @TaskAction
     public void genRuns() {
         LoomGradleExtension extension = getProject().getExtensions().getByType(LoomGradleExtension.class);
-        File projectDir = new File(".vscode");
+        File projectDir = getProject().file(".vscode");
         if (!projectDir.exists()) {
             projectDir.mkdir();
         }

--- a/src/main/java/net/fabricmc/loom/util/SetupIntelijRunConfigs.java
+++ b/src/main/java/net/fabricmc/loom/util/SetupIntelijRunConfigs.java
@@ -37,7 +37,7 @@ public class SetupIntelijRunConfigs {
 	public static void setup(Project project) {
 		LoomGradleExtension extension = project.getExtensions().getByType(LoomGradleExtension.class);
 
-		File projectDir = new File(".idea");
+		File projectDir = project.file(".idea");
 		if(!projectDir.exists()){
 			return;
 		}
@@ -54,7 +54,7 @@ public class SetupIntelijRunConfigs {
 	}
 
 	private static void generate(Project project) throws IOException {
-		File projectDir = new File(".idea");
+		File projectDir = project.file(".idea");
 		File runConfigsDir = new File(projectDir, "runConfigurations");
 		File clientRunConfigs = new File(runConfigsDir, "Minecraft_Client.xml");
 		File serverRunConfigs = new File(runConfigsDir, "Minecraft_Server.xml");


### PR DESCRIPTION
Some tasks used the `File(String)` constructor to attempt to open files in the project directory. Gradle does not have to (and it doesn't) use the project directory as the working directory. As a result, these tasks were broken. Switch to the correct way of creating `File`s under Gradle,
`Project#file`.