### PR TITLE
Enhance support for file modCompiles

### DIFF
--- a/src/main/java/net/fabricmc/loom/providers/ModRemapperProvider.java
+++ b/src/main/java/net/fabricmc/loom/providers/ModRemapperProvider.java
@@ -24,7 +24,6 @@
 
 package net.fabricmc.loom.providers;
 
-import com.google.common.io.Files;
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.DependencyProvider;
@@ -33,7 +32,6 @@ import net.fabricmc.loom.util.SourceRemapper;
 import org.gradle.api.Project;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -49,7 +47,8 @@ public class ModRemapperProvider extends DependencyProvider {
 		MappingsProvider mappingsProvider = getDependencyManager().getProvider(MappingsProvider.class);
 		String verSuffix = ".mapped." + mappingsProvider.mappingsName + "." + mappingsProvider.mappingsVersion;
 
-		String outputNamePrefix = input.getName().substring(0, input.getName().length() - 4) + verSuffix;//TODO use the hash of the input file or something?
+		//Output name should match whatever it's under as a dependency so Gradle finds it
+		String outputNamePrefix = rds.substring(rds.indexOf(':') + 1).replace(':', '-') + verSuffix; //group:name:version -> name-version.mapped.yarn.5
 		File modStore = extension.getRemappedModCache();
 		File output = new File(modStore, outputNamePrefix + ".jar");
 		if(output.exists()){

--- a/src/main/java/net/fabricmc/loom/util/DependencyProvider.java
+++ b/src/main/java/net/fabricmc/loom/util/DependencyProvider.java
@@ -214,7 +214,7 @@ public abstract class DependencyProvider {
 				break;
 
 			default: //File collection, try work out the classifiers
-				List<File> sortedFiles = files.stream().sorted(Comparator.comparing(File::getName, Comparator.comparing(String::length))).collect(Collectors.toList());
+				List<File> sortedFiles = files.stream().sorted(Comparator.comparing(File::getName, Comparator.comparingInt(String::length))).collect(Collectors.toList());
 
 				//First element in sortedFiles is the one with the shortest name, we presume all the others are different classifier types of this
 				File shortest = sortedFiles.remove(0);

--- a/src/main/java/net/fabricmc/loom/util/LoomDependencyManager.java
+++ b/src/main/java/net/fabricmc/loom/util/LoomDependencyManager.java
@@ -26,6 +26,8 @@ package net.fabricmc.loom.util;
 
 import com.google.gson.JsonObject;
 import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.util.DependencyProvider.DependencyInfo;
+
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ExternalModuleDependency;
@@ -74,7 +76,7 @@ public class LoomDependencyManager {
 			configuration.getDependencies().forEach(dependency -> {
 				for(DependencyProvider provider : dependencyProviderList){
 					if(provider.getTargetConfig().equals(config)){
-						DependencyProvider.DependencyInfo info = new DependencyProvider.DependencyInfo(project, dependency, configuration);
+						DependencyProvider.DependencyInfo info = DependencyInfo.create(project, dependency, configuration);
 						try {
 							provider.provide(info, project, extension, afterTasks::add);
 						} catch (Exception e) {


### PR DESCRIPTION
Should fix #71

Right now trying to use file dependencies with `modCompile` or `mappings` results in it trying to find `null:unspecified:null` which is never going to work. This resolves this by trying to reverse engineer the supplied dependencies to what they most likely are meant to be:
* If there is no file at all it crashes, don't think Gradle lets you do `file()` or `files()` and if it does it deserves to crash
* If there's one file that is taken as the classifier-less form. Trying to get the sources will fail similar to a maven that doesn't host them.
* If there's multiple files provided it tries quite hard:
* * First it will find the file with the shortest name, as logically that's the one that will have no classifier
* * Then it will check if all the others start with the shortest one's name. If they don't it will crash as at that point I have no idea how you'd be meant to pull the classifiers out
* * If they all do, they are separated out into the extra part of the name they have and that is taken as the classifier. Thus for a shortest name of `mymod-v1.jar`, `mymod-v1-sources.jar` is the `sources` version.

  This provides a degree of balance between still being able to attach sources (and have them remapped) if desired with not going mad trying to work out what they are. In allowing them to be resolved there is a minor change in the `remapped-mods` directory to ensure the name and version will always match the dependency in case the file name doesn't, this might fix some other edge case bugs from that too.

### `modCompile`
For Fabric mods the process is a little easier, as the `fabric.mod.json` forces at the very least an `id` and `version` to be supplied. This is used along side the random group `net.fabric.synthetic` which Gradle doesn't appear to ever go looking for. The produced dependency string should be stable enough to update as the mod does without being squished by something else accidentally.

### `mappings`
Mappings lack any kind of structure in the name, so their version is always forced to 1.0 and the name to whatever the file name is. They might well still not quite work right, but fixing it would be a mess of conflicts from the heavy amount of changes I've already done with mapping resolving in Sin².


Also this is probably the last I'll bother trying to hack 0.2.x "back" together, Sin² is already comprehensive enough for me until we can get 0.3 in a happier place.