### PR TITLE
Remap less

### DIFF
--- a/src/main/java/net/fabricmc/loom/providers/ModRemapperProvider.java
+++ b/src/main/java/net/fabricmc/loom/providers/ModRemapperProvider.java
@@ -61,6 +61,8 @@ public class ModRemapperProvider extends DependencyProvider {
 			}
 
 			output.setLastModified(input.lastModified());
+		} else {
+			project.getLogger().info(output.getName() + " is up to date with " + input.getName());
 		}
 
 		project.getDependencies().add(Constants.COMPILE_MODS_MAPPED, project.getDependencies().module(
@@ -85,7 +87,11 @@ public class ModRemapperProvider extends DependencyProvider {
 					} catch (Exception e) {
 						e.printStackTrace();
 					}
+				} else {
+					project.getLogger().info(remappedSources.getName() + " is up to date with " + sources.getName());
 				}
+			} else {
+				project.getLogger().info(":skipping " + rds + " sources, not found");
 			}
 		});
 	}

--- a/src/main/java/net/fabricmc/loom/util/ModProcessor.java
+++ b/src/main/java/net/fabricmc/loom/util/ModProcessor.java
@@ -190,7 +190,7 @@ public class ModProcessor {
 		}
 	}
 
-	private static void readInstallerJson(File file, Project project){
+	static void readInstallerJson(File file, Project project){
 		try {
 			JarFile jarFile = new JarFile(file);
 


### PR DESCRIPTION
Now checks if an output exists and has a last modified date older than the input that otherwise will be remapped. Makes Loom a whole load faster as a result. Forces going digging for the installer JSON as a result of not always remapping Fabric-Loader, but fairly certain I've handled that as it works now.