### PR TITLE
add correct Maven dependencies to maven-publish mod POMs

### DIFF
--- a/src/main/java/net/fabricmc/loom/AbstractPlugin.java
+++ b/src/main/java/net/fabricmc/loom/AbstractPlugin.java
@@ -25,6 +25,9 @@
 package net.fabricmc.loom;
 
 import com.google.common.collect.ImmutableMap;
+import groovy.util.Node;
+import groovy.util.NodeList;
+import groovy.xml.QName;
 import net.fabricmc.loom.providers.MappingsProvider;
 import net.fabricmc.loom.providers.MinecraftProvider;
 import net.fabricmc.loom.providers.ModRemapperProvider;
@@ -36,10 +39,21 @@ import net.fabricmc.loom.util.NestedJars;
 import net.fabricmc.loom.util.SetupIntelijRunConfigs;
 import org.gradle.api.*;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.artifacts.maven.Conf2ScopeMappingContainer;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.MavenPlugin;
+import org.gradle.api.plugins.MavenPluginConvention;
+import org.gradle.api.publish.Publication;
+import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.publish.maven.MavenPublication;
+import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven;
+import org.gradle.api.publish.maven.tasks.GenerateMavenPom;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.api.tasks.compile.JavaCompile;
@@ -49,6 +63,9 @@ import org.gradle.plugins.ide.idea.model.IdeaModel;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -77,7 +94,7 @@ public class AbstractPlugin implements Plugin<Project> {
 		addMavenRepo(target, "Mojang", "https://libraries.minecraft.net/");
 
 		Configuration compileModsConfig = project.getConfigurations().maybeCreate(Constants.COMPILE_MODS);
-		compileModsConfig.setTransitive(false); // Dont get transitive deps of mods
+		compileModsConfig.setTransitive(false);
 		Configuration compileModsMappedConfig = project.getConfigurations().maybeCreate(Constants.COMPILE_MODS_MAPPED);
 		compileModsMappedConfig.setTransitive(false); // Dont get transitive deps of mods
 		Configuration minecraftNamedConfig = project.getConfigurations().maybeCreate(Constants.MINECRAFT_NAMED);
@@ -127,9 +144,42 @@ public class AbstractPlugin implements Plugin<Project> {
 					});
 				}
 			}
-
 		}
 
+		project.afterEvaluate((p) -> {
+			// add modsCompile to maven
+			MavenPluginConvention maven = p.getConvention().findPlugin(MavenPluginConvention.class);
+			if (maven != null) {
+				// TODO: non-functional
+				maven.getConf2ScopeMappings().addMapping(MavenPlugin.COMPILE_PRIORITY, compileModsConfig, Conf2ScopeMappingContainer.COMPILE);
+			}
+
+			// add modsCompile to maven-publish
+			PublishingExtension mavenPublish = p.getExtensions().findByType(PublishingExtension.class);
+			if (mavenPublish != null) {
+				System.out.println("YASSS");
+				mavenPublish.publications((publications) -> {
+					for (Publication publication : publications) {
+						System.out.println("yass " + publication.getName());
+						if (publication instanceof MavenPublication) {
+							((MavenPublication) publication).pom((pom) -> {
+								pom.withXml((xml) -> {
+									Node dependencies = xml.asNode().appendNode("dependencies");
+
+									for (Dependency dependency : compileModsConfig.getAllDependencies()) {
+										Node depNode = dependencies.appendNode("dependency");
+										depNode.appendNode("groupId", dependency.getGroup());
+										depNode.appendNode("artifactId", dependency.getName());
+										depNode.appendNode("version", dependency.getVersion());
+										depNode.appendNode("scope", "compile");
+									}
+								});
+							});
+						}
+					}
+				});
+			}
+		});
 	}
 
 	/**
@@ -240,7 +290,6 @@ public class AbstractPlugin implements Plugin<Project> {
 			dependencyManager.addProvider(new MinecraftProvider());
 			dependencyManager.addProvider(new MappingsProvider());
 			dependencyManager.addProvider(new ModRemapperProvider());
-
 			dependencyManager.handleDependencies(project1);
 
 			project1.getTasks().getByName("idea").finalizedBy(project1.getTasks().getByName("genIdeaWorkspace"));

--- a/src/main/java/net/fabricmc/loom/util/LoomDependencyManager.java
+++ b/src/main/java/net/fabricmc/loom/util/LoomDependencyManager.java
@@ -122,7 +122,7 @@ public class LoomDependencyManager {
 		libraries.get("common").getAsJsonArray().forEach(jsonElement -> {
 			String name = jsonElement.getAsJsonObject().get("name").getAsString();
 
-			Configuration configuration = project.getConfigurations().getByName("compile");
+			Configuration configuration = project.getConfigurations().getByName(Constants.MINECRAFT_DEPENDENCIES);
 			ExternalModuleDependency modDep = (ExternalModuleDependency) project.getDependencies().create(name);
 			modDep.setTransitive(false);
 			configuration.getDependencies().add(modDep);


### PR DESCRIPTION
For supporting transitive mod dependencies, work should instead focus on Loom 0.3.x. This just means that mods built from now until then have correct dependencies in the POMs - and yes, it's a hack; and yes, I haven't figured out how to support "maven" (non-publish) yet.