### PR TITLE
Depend on assemble rather than buildNeeded

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
@@ -139,12 +139,12 @@ public class LoomGradlePlugin extends AbstractPlugin {
 		tasks.register("remapSourcesJar", RemapSourcesJarTask.class);
 
 		tasks.register("runClient", RunClientTask.class, t -> {
-			t.dependsOn("buildNeeded", "downloadAssets");
+			t.dependsOn("assemble", "downloadAssets");
 			t.setGroup("minecraftMapped");
 		});
 
 		tasks.register("runServer", RunServerTask.class, t -> {
-			t.dependsOn("buildNeeded");
+			t.dependsOn("assemble");
 			t.setGroup("minecraftMapped");
 		});
 	}


### PR DESCRIPTION
`buildNeeded` runs the test suite for your project (and any sub-projects). This is not required in order to run Minecraft, and is probably a rather undesirable property.

We switch this out to use `assemble`, which should be sufficient to create a jar, while not doing too much extra work.