### PR TITLE
Fix crash in multi-project build

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -37,6 +37,7 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.artifacts.UnknownConfigurationException;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -173,7 +174,11 @@ public class LoomGradleExtension {
 		return recurseProjects((p) -> {
 			List<Configuration> configs = new ArrayList<>();
 			// check compile first
-			configs.add(p.getConfigurations().getByName("compile"));
+			try {
+				configs.add(p.getConfigurations().getByName("compile"));
+			} catch (UnknownConfigurationException e) {
+				// do nothing
+			}
 			// failing that, buildscript
 			configs.addAll(p.getBuildscript().getConfigurations());
 


### PR DESCRIPTION
When using Loom in a multi-project build, `getByName("compile")` fails on the root project (as it does not exist), throwing an UnknownConfigurationException, which breaks the remapJar task. This should ensure that it falls back correctly to buildscript configurations without crashing - although I haven't found a situation where getMixinDependency returns an actual Dependency, I'm not sure exactly what it does.

I tried this with 0.2.4 and 0.2.5 and it still failed, so it hasn't been fixed in newer versions. I'm submitting the PR to the 0.2.3 branch because that's what the example mod (and therefore my mod) uses.