### PR TITLE
copy non-java files into remapped sources jar (fixes #126 and #118)

### DIFF
--- a/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
+++ b/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
@@ -40,6 +40,7 @@ import org.gradle.api.Project;
 import org.gradle.internal.impldep.aQute.bnd.build.Run;
 import org.objectweb.asm.commons.Remapper;
 import org.zeroturnaround.zip.ZipUtil;
+import org.zeroturnaround.zip.commons.FileUtils;
 
 import java.io.*;
 import java.net.URI;
@@ -144,6 +145,7 @@ public class SourceRemapper {
 		if (isSrcTmp) {
 			Files.walkFileTree(srcPath, new DeletingFileVisitor());
 		}
+
 	}
 
 	private static void copyNonJavaFiles(File from, Path to) throws IOException {
@@ -158,15 +160,9 @@ public class SourceRemapper {
         }
     }
 
-    private static Boolean isJavaFile(File file) {
-    	String name = file.getName();
-        String extension = "";
-
-        int i = name.lastIndexOf('.');
-        if (i > 0) {
-            extension = name.substring(i + 1);
-        }
-        return extension.equals("java");
+    private static boolean isJavaFile(File file) {
+		String name = file.getName();
+		return name.endsWith(".java") && name.lastIndexOf('.') > 0;
     }
 
 	public static class TinyReader extends MappingsReader {

--- a/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
+++ b/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
@@ -135,7 +135,7 @@ public class SourceRemapper {
 			project.getLogger().warn("Could not remap " + source.getName() + " fully!", e);
 		}
 
-		copyNonJavaFiles(srcPath.toFile(), dstPath);
+		copyNonJavaFiles(srcPath, dstPath, project, source);
 
 		if (dstFs != null) {
 			dstFs.close();
@@ -147,21 +147,23 @@ public class SourceRemapper {
 
 	}
 
-	private static void copyNonJavaFiles(File from, Path to) throws IOException {
-        for (File file : from.listFiles()) {
-            Path path = to.resolve(file.getName());
-            if (file.isDirectory()) {
-                Files.createDirectories(path);
-                copyNonJavaFiles(file, path);
-            } else if (!isJavaFile(file)) {
-                Files.copy(file.toPath(), path, StandardCopyOption.REPLACE_EXISTING);
+    private static void copyNonJavaFiles(Path from, Path to, Project project, File source) throws IOException {
+        Files.walk(from).forEach(path -> {
+            Path targetPath = to.resolve(from.relativize(path).toString());
+            if (!isJavaFile(path) && !Files.exists(targetPath)) {
+                try {
+                    Files.copy(path, targetPath);
+                } catch (IOException e) {
+                    project.getLogger().warn("Could not copy non-java sources '" + source.getName() + "' fully!", e);
+                }
             }
-        }
+        });
     }
 
-    private static boolean isJavaFile(File file) {
-		String name = file.getName();
-		return name.endsWith(".java") && name.lastIndexOf('.') > 0;
+    private static boolean isJavaFile(Path path) {
+        String name = path.getFileName().toString();
+        // ".java" is not a valid java file
+        return name.endsWith(".java") && name.length() != 5;
     }
 
 	public static class TinyReader extends MappingsReader {

--- a/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
+++ b/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
@@ -135,6 +135,8 @@ public class SourceRemapper {
 			project.getLogger().warn("Could not remap " + source.getName() + " fully!", e);
 		}
 
+		copyNonJavaFiles(srcPath.toFile(), dstPath);
+
 		if (dstFs != null) {
 			dstFs.close();
 		}
@@ -143,6 +145,29 @@ public class SourceRemapper {
 			Files.walkFileTree(srcPath, new DeletingFileVisitor());
 		}
 	}
+
+	private static void copyNonJavaFiles(File from, Path to) throws IOException {
+        for (File file : from.listFiles()) {
+            Path path = to.resolve(file.getName());
+            if (file.isDirectory()) {
+                Files.createDirectories(path);
+                copyNonJavaFiles(file, path);
+            } else if (!isJavaFile(file)) {
+                Files.copy(file.toPath(), path, StandardCopyOption.REPLACE_EXISTING);
+            }
+        }
+    }
+
+    private static Boolean isJavaFile(File file) {
+    	String name = file.getName();
+        String extension = "";
+
+        int i = name.lastIndexOf('.');
+        if (i > 0) {
+            extension = name.substring(i + 1);
+        }
+        return extension.equals("java");
+    }
 
 	public static class TinyReader extends MappingsReader {
 		private final Mappings m;

--- a/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
+++ b/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
@@ -40,7 +40,6 @@ import org.gradle.api.Project;
 import org.gradle.internal.impldep.aQute.bnd.build.Run;
 import org.objectweb.asm.commons.Remapper;
 import org.zeroturnaround.zip.ZipUtil;
-import org.zeroturnaround.zip.commons.FileUtils;
 
 import java.io.*;
 import java.net.URI;


### PR DESCRIPTION
No-java sources files are copied into the remapped source jar as-is, both when building the source jar and when consuming it. This might result in seeing source code with different mappings, but that's minor (have you seen decompiled Kotlin code before?). 