### PR TITLE
Make generated Eclipse run configs more reliably pick the right working directory

### DIFF
--- a/src/main/resources/eclipse_run_config_template.xml
+++ b/src/main/resources/eclipse_run_config_template.xml
@@ -12,5 +12,5 @@
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="%PROGRAM_ARGS%"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="%MODULE%"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="%VM_ARGS%"/>
-    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${project_loc}/run"/>
+    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${project_loc:%MODULE%}/run"/>
 </launchConfiguration>


### PR DESCRIPTION
The working directory for the generated Eclipse run configs is currently `${project_loc}/run`.
This causes problems because if no argument is passed, `${project_loc}` refers to the project containing the resource selected when the config is run. This means that the generated configs will not always launch the expected project, and will error on run if nothing is selected. This PR adds the project name as an argument, so that the config always launches the correct project and does not error if nothing is selected.