### PR TITLE
Fix issues involving projects with modules that contain no java classes

### DIFF
--- a/src/main/java/net/fabricmc/loom/AbstractPlugin.java
+++ b/src/main/java/net/fabricmc/loom/AbstractPlugin.java
@@ -339,8 +339,8 @@ public class AbstractPlugin implements Plugin<Project> {
 				extension.addUnmappedMod(jarTask.getArchivePath().toPath());
 				remapJarTask.getAddNestedDependencies().set(true);
 
-				remapJarTask.doLast(task -> project1.getArtifacts().add("archives", remapJarTask.getArchivePath()));
-				remapJarTask.dependsOn(project1.getTasks().getByName("jar"));
+				project1.getArtifacts().add("archives", remapJarTask);
+				remapJarTask.dependsOn(jarTask);
 				project1.getTasks().getByName("build").dependsOn(remapJarTask);
 
 				Map<Project, Set<Task>> taskMap = project.getAllTasks(true);

--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -180,7 +180,10 @@ public class LoomGradleExtension {
 		return recurseProjects((p) -> {
 			List<Configuration> configs = new ArrayList<>();
 			// check compile classpath first
-			configs.add(p.getConfigurations().getByName("compileClasspath"));
+			Configuration possibleCompileClasspath = p.getConfigurations().findByName("compileClasspath");
+			if (possibleCompileClasspath != null) {
+				configs.add(possibleCompileClasspath);
+			}
 			// failing that, buildscript
 			configs.addAll(p.getBuildscript().getConfigurations());
 

--- a/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
@@ -77,7 +77,7 @@ public class RemapJarTask extends Jar {
 		Set<File> classpathFiles = new LinkedHashSet<>(
 				project.getConfigurations().getByName("compileClasspath").getFiles()
 		);
-		Path[] classpath = classpathFiles.stream().map(File::toPath).filter((p) -> !input.equals(p)).toArray(Path[]::new);
+		Path[] classpath = classpathFiles.stream().map(File::toPath).filter((p) -> !input.equals(p) && Files.exists(p)).toArray(Path[]::new);
 
 		File mixinMapFile = mappingsProvider.MAPPINGS_MIXIN_EXPORT;
 		Path mixinMapPath = mixinMapFile.toPath();


### PR DESCRIPTION
This PR is an attempt to resolve build issues that came up while putting together a Fabric version of PEX. I'm not super familiar with the internals of Loom, so I'm very open to changing anything here as long as I can get out of here with a working PEX build.

- Loom expects there to be a compileClasspath configuration in every project Gradle is processing. Because this configuration is provided by the java plugin, it is only present on JVM builds -- this lets non-jvm builds be present in the project.

- Some entries in the compile classpath are empty directories -- for example the classes/java folder in a pure-kotlin project. TinyRemapper doesn't like being given empty/nonexistent directories in its classpath -- ignoring invalid entries more closely matches the behaviour of `javac` and gradle's builtin tasks, and gives a more forgiving build process

- Additionally, adds the output of remapJar as an artifact before the task executes to resolve a conflict with the signing plugin -- the signing plugin adjusts the dependencies of its task whenever an artifact is added, and tasks cannot have their dependencies changed while other tasks are executing.