### PR TITLE
Fix V2 regressions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 	implementation ('com.google.guava:guava:28.0-jre')
 
 	// game handling utils
-	implementation ('net.fabricmc:stitch:0.3.0.66') {
+	implementation ('net.fabricmc:stitch:0.4.0.67') {
 		exclude module: 'enigma'
 	}
 
@@ -47,9 +47,7 @@ dependencies {
 	implementation ('net.fabricmc:tiny-remapper:0.2.0.53') {
 		transitive = false
 	}
-	implementation ('net.fabricmc:fabric-mixin-compile-extensions:0.2.0.3'){
-		exclude group :"net.fabricmc"
-	}
+	implementation ('net.fabricmc:fabric-mixin-compile-extensions:0.2.0.3')
 
 	// decompilers
 	implementation ('net.fabricmc:procyon-fabric-compilertools:0.5.35.+')

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
 	}
 
 	// tinyfile management
-	implementation ('net.fabricmc:tiny-remapper:0.2.0.53') {
+	implementation ('net.fabricmc:tiny-remapper:0.2.0.56') {
 		transitive = false
 	}
 	implementation ('net.fabricmc:fabric-mixin-compile-extensions:0.2.0.3')

--- a/src/main/java/net/fabricmc/loom/util/ModProcessor.java
+++ b/src/main/java/net/fabricmc/loom/util/ModProcessor.java
@@ -169,6 +169,7 @@ public class ModProcessor {
 
 		TinyRemapper remapper = TinyRemapper.newRemapper()
 						.withMappings(TinyRemapperMappingsHelper.create(mappingsProvider.getMappings(), fromM, toM, false))
+						.renameInvalidLocals(true)
 						.build();
 
 		try (OutputConsumerPath outputConsumer = new OutputConsumerPath.Builder(Paths.get(output.getAbsolutePath())).build()) {


### PR DESCRIPTION
Upgrading stitch fixes part 1 of #143 , not excluding dependencies from mixin compile extensions should fix part 2 of #143 . 
Upgrading tiny remapper and setting `renameInvalidLocals` to true should fix FabricMC/tiny-remapper#21.
Fixes #143.