### PR TITLE
Quote the entire System property if it contains spaces

### DIFF
--- a/src/main/java/net/fabricmc/loom/util/RunConfig.java
+++ b/src/main/java/net/fabricmc/loom/util/RunConfig.java
@@ -106,7 +106,7 @@ public class RunConfig {
 		default:
 			runConfig.mainClass = "net.fabricmc.devlaunchinjector.Main";
 			runConfig.programArgs = "";
-			runConfig.vmArgs = "-Dfabric.dli.config=" + quoteIfNeeded(extension.getDevLauncherConfig().getAbsolutePath()) + " -Dfabric.dli.env=" + mode.toLowerCase();
+			runConfig.vmArgs = quoteIfNeeded("-Dfabric.dli.config=" + extension.getDevLauncherConfig().getAbsolutePath()) + " -Dfabric.dli.env=" + mode.toLowerCase();
 			break;
 		}
 


### PR DESCRIPTION
This should be more compatible than just quoting the value.