### PR TITLE
[0.2.7] Make remap source jar an archive task

### DIFF
--- a/src/main/java/net/fabricmc/loom/AbstractPlugin.java
+++ b/src/main/java/net/fabricmc/loom/AbstractPlugin.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import groovy.util.Node;
 import org.gradle.api.Plugin;
@@ -330,9 +331,10 @@ public class AbstractPlugin implements Plugin<Project> {
 					remapSourcesJarTask.setInput(sourcesTask.getArchivePath());
 					remapSourcesJarTask.setDestinationDir(sourcesTask.getDestinationDir());
 					String oldClassifier = sourcesTask.getClassifier();
-					remapSourcesJarTask.setClassifier(oldClassifier == null ? "dev" : "dev-" + oldClassifier);
+					remapSourcesJarTask.setClassifier(oldClassifier);
+					sourcesTask.setClassifier(Strings.isNullOrEmpty(oldClassifier) ? "dev" : "dev-" + oldClassifier);
 					remapSourcesJarTask.doLast(task -> project1.getArtifacts().add("archives", remapSourcesJarTask));
-					remapSourcesJarTask.dependsOn(project1.getTasks().getByName("sourcesJar"));
+					remapSourcesJarTask.dependsOn(sourcesTask);
 					project1.getTasks().getByName("build").dependsOn(remapSourcesJarTask);
 				} catch (UnknownTaskException e) {
 					// pass

--- a/src/main/java/net/fabricmc/loom/AbstractPlugin.java
+++ b/src/main/java/net/fabricmc/loom/AbstractPlugin.java
@@ -326,10 +326,12 @@ public class AbstractPlugin implements Plugin<Project> {
 				try {
 					AbstractArchiveTask sourcesTask = (AbstractArchiveTask) project1.getTasks().getByName("sourcesJar");
 
-					RemapSourcesJarTask remapSourcesJarTask = (RemapSourcesJarTask) project1.getTasks().findByName("remapSourcesJar");
+					RemapSourcesJarTask remapSourcesJarTask = (RemapSourcesJarTask) project1.getTasks().getByName("remapSourcesJar");
 					remapSourcesJarTask.setInput(sourcesTask.getArchivePath());
-					remapSourcesJarTask.setOutput(sourcesTask.getArchivePath());
-					remapSourcesJarTask.doLast(task -> project1.getArtifacts().add("archives", remapSourcesJarTask.getOutput()));
+					remapSourcesJarTask.setDestinationDir(sourcesTask.getDestinationDir());
+					String oldClassifier = sourcesTask.getClassifier();
+					remapSourcesJarTask.setClassifier(oldClassifier == null ? "dev" : "dev-" + oldClassifier);
+					remapSourcesJarTask.doLast(task -> project1.getArtifacts().add("archives", remapSourcesJarTask));
 					remapSourcesJarTask.dependsOn(project1.getTasks().getByName("sourcesJar"));
 					project1.getTasks().getByName("build").dependsOn(remapSourcesJarTask);
 				} catch (UnknownTaskException e) {

--- a/src/main/java/net/fabricmc/loom/AbstractPlugin.java
+++ b/src/main/java/net/fabricmc/loom/AbstractPlugin.java
@@ -326,13 +326,13 @@ public class AbstractPlugin implements Plugin<Project> {
 
 				try {
 					AbstractArchiveTask sourcesTask = (AbstractArchiveTask) project1.getTasks().getByName("sourcesJar");
+					String oldClassifier = sourcesTask.getClassifier();
+					sourcesTask.setClassifier(Strings.isNullOrEmpty(oldClassifier) ? "dev" : oldClassifier + "-dev");
 
 					RemapSourcesJarTask remapSourcesJarTask = (RemapSourcesJarTask) project1.getTasks().getByName("remapSourcesJar");
 					remapSourcesJarTask.setInput(sourcesTask.getArchivePath());
 					remapSourcesJarTask.setDestinationDir(sourcesTask.getDestinationDir());
-					String oldClassifier = sourcesTask.getClassifier();
 					remapSourcesJarTask.setClassifier(oldClassifier);
-					sourcesTask.setClassifier(Strings.isNullOrEmpty(oldClassifier) ? "dev" : "dev-" + oldClassifier);
 					remapSourcesJarTask.doLast(task -> project1.getArtifacts().add("archives", remapSourcesJarTask));
 					remapSourcesJarTask.dependsOn(sourcesTask);
 					project1.getTasks().getByName("build").dependsOn(remapSourcesJarTask);

--- a/src/main/java/net/fabricmc/loom/task/RemapSourcesJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapSourcesJarTask.java
@@ -28,19 +28,18 @@ import java.io.File;
 
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
-import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.jvm.tasks.Jar;
 
 import net.fabricmc.loom.util.SourceRemapper;
 
-public class RemapSourcesJarTask extends AbstractLoomTask {
+public class RemapSourcesJarTask extends Jar {
 	private Object input;
-	private Object output;
 	private String direction = "intermediary";
 
 	@TaskAction
 	public void remap() throws Exception {
-		SourceRemapper.remapSources(getProject(), getInput(), getOutput(), direction.equals("named"));
+		SourceRemapper.remapSources(getProject(), getInput(), getArchivePath(), direction.equals("named"));
 	}
 
 	@InputFile
@@ -48,9 +47,9 @@ public class RemapSourcesJarTask extends AbstractLoomTask {
 		return getProject().file(input);
 	}
 
-	@OutputFile
+	@Deprecated // Use getArchivePath
 	public File getOutput() {
-		return getProject().file(output == null ? input : output);
+		return getArchivePath();
 	}
 
 	@Input
@@ -62,8 +61,11 @@ public class RemapSourcesJarTask extends AbstractLoomTask {
 		this.input = input;
 	}
 
+	@Deprecated // Use setArchiveName setDestination
 	public void setOutput(Object output) {
-		this.output = output;
+		File file = getProject().file(output);
+		setDestinationDir(file.getParentFile());
+		setArchiveName(file.getName());
 	}
 
 	public void setTargetNamespace(String value) {


### PR DESCRIPTION
Much like #110 so that the task itself can be used in some gradle places.

Should be backward compatible as old methods are preserved and deprecated.

Signed-off-by: liach <liach@users.noreply.github.com>