### PR TITLE
Add JavaDocs from .tiny files when decompiling sources with FF

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 
 	// decompilers
 	implementation ('net.fabricmc:procyon-fabric-compilertools:0.5.35.+')
-	implementation ('org.jetbrains:intellij-fernflower:1.0.0.9')
+	implementation ('org.jetbrains:intellij-fernflower:1.1.0')
 
 	// source code remapping
 	implementation ('org.cadixdev:mercury:0.1.0.fabric-SNAPSHOT')

--- a/src/main/java/net/fabricmc/loom/task/fernflower/FernFlowerTask.java
+++ b/src/main/java/net/fabricmc/loom/task/fernflower/FernFlowerTask.java
@@ -64,6 +64,7 @@ public class FernFlowerTask extends AbstractDecompileTask implements ForkingJava
 		Map<String, Object> options = new HashMap<>();
 		options.put(IFernflowerPreferences.DECOMPILE_GENERIC_SIGNATURES, "1");
 		options.put(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, "1");
+		options.put(IFernflowerPreferences.REMOVE_SYNTHETIC, "1");
 		options.put(IFernflowerPreferences.LOG_LEVEL, "trace");
 		getLogging().captureStandardOutput(LogLevel.LIFECYCLE);
 
@@ -78,6 +79,7 @@ public class FernFlowerTask extends AbstractDecompileTask implements ForkingJava
 		}
 
 		args.add("-t=" + getNumThreads());
+		args.add("-m=" + getExtension().getMappingsProvider().tinyMappings.getAbsolutePath());
 
 		//TODO, Decompiler breaks on jemalloc, J9 module-info.class?
 		getLibraries().forEach(f -> args.add("-e=" + f.getAbsolutePath()));

--- a/src/main/java/net/fabricmc/loom/task/fernflower/ForkedFFExecutor.java
+++ b/src/main/java/net/fabricmc/loom/task/fernflower/ForkedFFExecutor.java
@@ -36,6 +36,8 @@ import org.jetbrains.java.decompiler.main.Fernflower;
 import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;
 import org.jetbrains.java.decompiler.main.extern.IResultSaver;
 
+import net.fabricmc.fernflower.api.IFabricJavadocProvider;
+
 /**
  * Entry point for Forked FernFlower task.
  * Takes one parameter, a single file, each line is treated as command line input.
@@ -49,6 +51,7 @@ public class ForkedFFExecutor {
 		File input = null;
 		File output = null;
 		File lineMap = null;
+		File mappings = null;
 		List<File> libraries = new ArrayList<>();
 		int numThreads = 0;
 
@@ -82,6 +85,12 @@ public class ForkedFFExecutor {
 					}
 
 					lineMap = new File(arg.substring(3));
+				} else if (arg.startsWith("-m=")) {
+					if (mappings != null) {
+						throw new RuntimeException("Unable to use more than one mappings file.");
+					}
+
+					mappings = new File(arg.substring(3));
 				} else if (arg.startsWith("-t=")) {
 					numThreads = Integer.parseInt(arg.substring(3));
 				} else {
@@ -92,6 +101,10 @@ public class ForkedFFExecutor {
 					input = new File(arg);
 				}
 			}
+		}
+
+		if (mappings != null) {
+			options.put(IFabricJavadocProvider.PROPERTY_NAME, new TinyJavadocProvider(mappings));
 		}
 
 		Objects.requireNonNull(input, "Input not set.");

--- a/src/main/java/net/fabricmc/loom/task/fernflower/TinyJavadocProvider.java
+++ b/src/main/java/net/fabricmc/loom/task/fernflower/TinyJavadocProvider.java
@@ -1,0 +1,113 @@
+package net.fabricmc.loom.task.fernflower;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.common.base.Splitter;
+import org.jetbrains.java.decompiler.struct.StructClass;
+import org.jetbrains.java.decompiler.struct.StructField;
+import org.jetbrains.java.decompiler.struct.StructMethod;
+
+import net.fabricmc.fernflower.api.IFabricJavadocProvider;
+import net.fabricmc.mapping.tree.ClassDef;
+import net.fabricmc.mapping.tree.FieldDef;
+import net.fabricmc.mapping.tree.MethodDef;
+import net.fabricmc.mapping.tree.ParameterDef;
+import net.fabricmc.mapping.tree.TinyMappingFactory;
+import net.fabricmc.mapping.tree.TinyTree;
+import net.fabricmc.mappings.EntryTriple;
+
+public class TinyJavadocProvider implements IFabricJavadocProvider {
+	private static TinyTree readTiny(File input) {
+		try (BufferedReader reader = Files.newBufferedReader(input.toPath())) {
+			return TinyMappingFactory.loadWithDetection(reader);
+		} catch (IOException e) {
+			throw new RuntimeException("Failed to read mappings", e);
+		}
+	}
+
+	private final String namespace;
+
+	private final Map<String, ClassDef> classes = new HashMap<>();
+	private final Map<EntryTriple, FieldDef> fields = new HashMap<>();
+	private final Map<EntryTriple, MethodDef> methods = new HashMap<>();
+
+	public TinyJavadocProvider(File input) {
+		this.namespace = "named";
+
+		TinyTree mapping = readTiny(input);
+
+		for (ClassDef classDef : mapping.getClasses()) {
+			String className = classDef.getName(namespace);
+			classes.put(className, classDef);
+
+			for (FieldDef fieldDef : classDef.getFields()) {
+				fields.put(new EntryTriple(className, fieldDef.getName(namespace), fieldDef.getDescriptor(namespace)), fieldDef);
+			}
+
+			for (MethodDef methodDef : classDef.getMethods()) {
+				methods.put(new EntryTriple(className, methodDef.getName(namespace), methodDef.getDescriptor(namespace)), methodDef);
+			}
+		}
+	}
+
+	private static Iterable<String> asLines(String doc) {
+		if (doc == null) {
+			return null;
+		}
+
+		return Splitter.on('\n').split(doc);
+	}
+
+	@Override
+	public Iterable<String> getClassDoc(StructClass structClass) {
+		ClassDef classDef = classes.get(structClass.qualifiedName);
+
+		if (classDef == null) {
+			return null;
+		}
+
+		return asLines(classDef.getComment());
+	}
+
+	@Override
+	public Iterable<String> getFieldDoc(StructClass structClass, StructField structField) {
+		FieldDef fieldDef = fields.get(new EntryTriple(structClass.qualifiedName, structField.getName(), structField.getDescriptor()));
+
+		if (fieldDef == null) {
+			return null;
+		}
+
+		return asLines(fieldDef.getComment());
+	}
+
+	@Override
+	public Iterable<String> getMethodDoc(StructClass structClass, StructMethod structMethod) {
+		MethodDef methodDef = methods.get(new EntryTriple(structClass.qualifiedName, structMethod.getName(), structMethod.getDescriptor()));
+
+		if (methodDef == null || methodDef.getComment() == null) {
+			return null;
+		}
+
+		ArrayList<String> doc = new ArrayList<>();
+
+		for (String line : asLines(methodDef.getComment())) {
+			doc.add(line);
+		}
+
+		for (ParameterDef param : methodDef.getParameters()) {
+			String comment = param.getComment();
+
+			if (comment != null) {
+				doc.add(String.format("@param %s %s", param.getName(namespace), comment));
+			}
+		}
+
+		return doc;
+	}
+}


### PR DESCRIPTION
Based mostly on the work of @modmuss50 - with some minor modifications to ensure a smaller patch to FF.

Requires https://github.com/FabricMC/intellij-fernflower/pull/5
