### PR TITLE
Change mixin refmap default name to use archivesBaseName instead of the project name

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -48,6 +48,7 @@ import net.fabricmc.loom.providers.MappingsProvider;
 import net.fabricmc.loom.providers.MinecraftMappedProvider;
 import net.fabricmc.loom.providers.MinecraftProvider;
 import net.fabricmc.loom.util.LoomDependencyManager;
+import org.gradle.api.plugins.BasePluginConvention;
 
 public class LoomGradleExtension {
 	public String runDir = "run";
@@ -284,8 +285,9 @@ public class LoomGradleExtension {
 
 	public String getRefmapName() {
 		if (refmapName == null || refmapName.isEmpty()) {
-			project.getLogger().warn("Could not find refmap definition, will be using default name: " + project.getName() + "-refmap.json");
-			refmapName = project.getName() + "-refmap.json";
+			String defaultRefmapName = project.getConvention().getPlugin(BasePluginConvention.class).getArchivesBaseName() + "-refmap.json";
+			project.getLogger().warn("Could not find refmap definition, will be using default name: " + defaultRefmapName);
+			refmapName = defaultRefmapName;
 		}
 
 		return refmapName;

--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -43,12 +43,12 @@ import org.cadixdev.mercury.Mercury;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.plugins.BasePluginConvention;
 
 import net.fabricmc.loom.providers.MappingsProvider;
 import net.fabricmc.loom.providers.MinecraftMappedProvider;
 import net.fabricmc.loom.providers.MinecraftProvider;
 import net.fabricmc.loom.util.LoomDependencyManager;
-import org.gradle.api.plugins.BasePluginConvention;
 
 public class LoomGradleExtension {
 	public String runDir = "run";


### PR DESCRIPTION
Using the project name for the default refmap name can cause problems when libraries are pulled in with Jitpack. When building, Jitpack clones projects in a directory called `build`, which sets the project name to `build` if not manually defined. The resulting refmap, `build-refmap.json`, can conflict with other mods' refmaps, leading to mixin crashes.

Unlike the project name or the refmap name, the `archivesBaseName` of a project is usually set manually [like in the example mod](https://github.com/FabricMC/fabric-example-mod/blob/705d4da55b9a514e5e7279a2ea5becaf039cf2d0/gradle.properties#L13), so conflicts should be more rare.