### PR TITLE
Make mod* work with non-empty classifiers again, fixes #162

### DIFF
--- a/src/main/java/net/fabricmc/loom/util/ModCompileRemapper.java
+++ b/src/main/java/net/fabricmc/loom/util/ModCompileRemapper.java
@@ -77,8 +77,8 @@ public class ModCompileRemapper {
 			File sources = findSources(dependencies, artifact);
 
 			String remappedLog = group + ":" + name + ":" + version + classifierSuffix + " (" + mappingsSuffix + ")";
-			String remappedNotation = String.format("%s@%s", notation, mappingsSuffix);
-			String remappedFilename = String.format("%s-%s@%s", name, version + classifierSuffix.replace(':', '-'), mappingsSuffix);
+			String remappedNotation = String.format("%s:%s:%s@%s%s", group, name, version, mappingsSuffix, classifierSuffix);
+			String remappedFilename = String.format("%s-%s@%s", name, version, mappingsSuffix + classifierSuffix.replace(':', '-'));
 			project.getLogger().info(":providing " + remappedLog);
 
 			File modStore = extension.getRemappedModCache();


### PR DESCRIPTION
This PR appends the classifier to the end of the remapped artifact's name, meaning the suffix always applies to the version component. This lets Gradle look up said artifact's presence in other repositories than the original.