### PR TITLE
Speed up genSources by 3000%*

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ targetCompatibility = 1.8
 
 group = 'net.fabricmc'
 archivesBaseName = project.name
-version = '0.2.9-SNAPSHOT'
+version = '0.2.7-SNAPSHOT'
 
 def build = "local"
 def ENV = System.getenv()

--- a/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
@@ -30,25 +30,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
 
+import net.fabricmc.loom.task.*;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.tasks.TaskContainer;
 
 import net.fabricmc.loom.providers.MappingsProvider;
 import net.fabricmc.loom.providers.MinecraftLibraryProvider;
-import net.fabricmc.loom.task.AbstractDecompileTask;
-import net.fabricmc.loom.task.CleanLoomBinaries;
-import net.fabricmc.loom.task.CleanLoomMappings;
-import net.fabricmc.loom.task.DownloadAssetsTask;
-import net.fabricmc.loom.task.GenEclipseRunsTask;
-import net.fabricmc.loom.task.GenIdeaProjectTask;
-import net.fabricmc.loom.task.GenVsCodeProjectTask;
-import net.fabricmc.loom.task.MigrateMappingsTask;
-import net.fabricmc.loom.task.RemapJarTask;
-import net.fabricmc.loom.task.RemapLineNumbersTask;
-import net.fabricmc.loom.task.RemapSourcesJarTask;
-import net.fabricmc.loom.task.RunClientTask;
-import net.fabricmc.loom.task.RunServerTask;
 import net.fabricmc.loom.task.fernflower.FernFlowerTask;
 
 public class LoomGradlePlugin extends AbstractPlugin {
@@ -93,7 +81,7 @@ public class LoomGradlePlugin extends AbstractPlugin {
 			t.getOutputs().upToDateWhen((o) -> false);
 		});
 
-		tasks.register("genSources", t -> {
+		tasks.register("genSources", ApplyLinemappedJarTask.class, t -> {
 			t.getOutputs().upToDateWhen((o) -> false);
 			t.setGroup("fabric");
 		});
@@ -124,19 +112,6 @@ public class LoomGradlePlugin extends AbstractPlugin {
 			remapLineNumbersTask.setLineMapFile(linemapFile);
 			remapLineNumbersTask.setOutput(linemappedJar);
 
-			Path mappedJarPath = mappedJar.toPath();
-			Path linemappedJarPath = linemappedJar.toPath();
-
-			genSourcesTask.doLast((tt) -> {
-				if (Files.exists(linemappedJarPath)) {
-					try {
-						Files.deleteIfExists(mappedJarPath);
-						Files.copy(linemappedJarPath, mappedJarPath);
-					} catch (IOException e) {
-						throw new RuntimeException(e);
-					}
-				}
-			});
 		});
 
 		tasks.register("downloadAssets", DownloadAssetsTask.class);

--- a/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
@@ -37,6 +37,7 @@ import net.fabricmc.loom.task.AbstractDecompileTask;
 import net.fabricmc.loom.task.ApplyLinemappedJarTask;
 import net.fabricmc.loom.task.CleanLoomBinaries;
 import net.fabricmc.loom.task.CleanLoomMappings;
+import net.fabricmc.loom.task.CleanSourcesTask;
 import net.fabricmc.loom.task.DownloadAssetsTask;
 import net.fabricmc.loom.task.GenEclipseRunsTask;
 import net.fabricmc.loom.task.GenIdeaProjectTask;
@@ -95,6 +96,8 @@ public class LoomGradlePlugin extends AbstractPlugin {
 			t.getOutputs().upToDateWhen((o) -> false);
 			t.setGroup("fabric");
 		});
+
+		tasks.register("cleanMinecraftSources", CleanSourcesTask.class);
 
 		project.afterEvaluate((p) -> {
 			AbstractDecompileTask decompileTask = (AbstractDecompileTask) p.getTasks().getByName("genSourcesDecompile");

--- a/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
@@ -112,6 +112,10 @@ public class LoomGradlePlugin extends AbstractPlugin {
 			remapLineNumbersTask.setLineMapFile(linemapFile);
 			remapLineNumbersTask.setOutput(linemappedJar);
 
+			ApplyLinemappedJarTask applyLinemappedJarTask = (ApplyLinemappedJarTask) p.getTasks().getByName("genSources");
+			applyLinemappedJarTask.setLinemappedJar(linemappedJar);
+			applyLinemappedJarTask.setMappedJar(mappedJar);
+
 		});
 
 		tasks.register("downloadAssets", DownloadAssetsTask.class);

--- a/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
@@ -25,18 +25,28 @@
 package net.fabricmc.loom;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Locale;
 
-import net.fabricmc.loom.task.*;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.tasks.TaskContainer;
 
 import net.fabricmc.loom.providers.MappingsProvider;
 import net.fabricmc.loom.providers.MinecraftLibraryProvider;
+import net.fabricmc.loom.task.AbstractDecompileTask;
+import net.fabricmc.loom.task.ApplyLinemappedJarTask;
+import net.fabricmc.loom.task.CleanLoomBinaries;
+import net.fabricmc.loom.task.CleanLoomMappings;
+import net.fabricmc.loom.task.DownloadAssetsTask;
+import net.fabricmc.loom.task.GenEclipseRunsTask;
+import net.fabricmc.loom.task.GenIdeaProjectTask;
+import net.fabricmc.loom.task.GenVsCodeProjectTask;
+import net.fabricmc.loom.task.MigrateMappingsTask;
+import net.fabricmc.loom.task.RemapJarTask;
+import net.fabricmc.loom.task.RemapLineNumbersTask;
+import net.fabricmc.loom.task.RemapSourcesJarTask;
+import net.fabricmc.loom.task.RunClientTask;
+import net.fabricmc.loom.task.RunServerTask;
 import net.fabricmc.loom.task.fernflower.FernFlowerTask;
 
 public class LoomGradlePlugin extends AbstractPlugin {
@@ -115,7 +125,6 @@ public class LoomGradlePlugin extends AbstractPlugin {
 			ApplyLinemappedJarTask applyLinemappedJarTask = (ApplyLinemappedJarTask) p.getTasks().getByName("genSources");
 			applyLinemappedJarTask.setLinemappedJar(linemappedJar);
 			applyLinemappedJarTask.setMappedJar(mappedJar);
-
 		});
 
 		tasks.register("downloadAssets", DownloadAssetsTask.class);

--- a/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
@@ -32,6 +32,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Optional;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
@@ -42,7 +43,7 @@ import net.fabricmc.loom.task.fernflower.IncrementalDecompilation;
 public class ApplyLinemappedJarTask extends AbstractLoomTask {
 	private Object mappedJar;
 	private Object linemappedJar;
-	private IncrementalDecompilation incrementalDecompilation;
+	private @Nullable IncrementalDecompilation incrementalDecompilation;
 
 	@InputFile
 	public File getMappedJar() {
@@ -62,7 +63,7 @@ public class ApplyLinemappedJarTask extends AbstractLoomTask {
 		this.linemappedJar = linemappedJar;
 	}
 
-	public void setIncrementalDecompilation(IncrementalDecompilation incrementalDecompilation) {
+	public void setIncrementalDecompilation(@Nullable IncrementalDecompilation incrementalDecompilation) {
 		this.incrementalDecompilation = incrementalDecompilation;
 	}
 
@@ -92,6 +93,7 @@ public class ApplyLinemappedJarTask extends AbstractLoomTask {
 	}
 
 	private void addUnchangedLinemappedFiles(Path linemappedJarPath) throws IOException {
+		if (incrementalDecompilation == null) return;
 		Path closestCompiledJar = incrementalDecompilation.getOldCompiledJar();
 		if (closestCompiledJar == null) return;
 

--- a/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
@@ -58,7 +58,7 @@ public class ApplyLinemappedJarTask extends AbstractLoomTask {
 				Files.createDirectories(jarsBeforeLinemapping(getExtension()));
 				Path notLinemappedJar = jarsBeforeLinemapping(getExtension()).resolve(mappedJarPath.getFileName());
 				// The original jars without the linemapping needs to be saved for incremental decompilation
-				Files.copy(mappedJarPath, notLinemappedJar);
+				if (!Files.exists(notLinemappedJar)) Files.copy(mappedJarPath, notLinemappedJar);
 				Files.copy(linemappedJarPath, mappedJarPath, StandardCopyOption.REPLACE_EXISTING);
 
 				addUnchangedLinemappedFiles(linemappedJarPath);

--- a/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
@@ -42,8 +42,10 @@ public class ApplyLinemappedJarTask extends AbstractLoomTask {
 		this.incrementalDecompilation = incrementalDecompilation;
 	}
 
-	public static Path jarsBeforeLinemapping(LoomGradleExtension extension) {
-		return Paths.get(extension.getUserCache().getPath(), "jarsBeforeLinemapping");
+	public static Path jarsBeforeLinemapping(LoomGradleExtension extension) throws IOException {
+		Path path = Paths.get(extension.getUserCache().getPath(), "jarsBeforeLinemapping");
+		Files.createDirectories(path);
+		return path;
 	}
 
 
@@ -54,14 +56,12 @@ public class ApplyLinemappedJarTask extends AbstractLoomTask {
 
 		if (Files.exists(linemappedJarPath)) {
 			try {
-
 				Files.createDirectories(jarsBeforeLinemapping(getExtension()));
 				Path notLinemappedJar = jarsBeforeLinemapping(getExtension()).resolve(mappedJarPath.getFileName());
 				// The original jars without the linemapping needs to be saved for incremental decompilation
 				if (!Files.exists(notLinemappedJar)) Files.copy(mappedJarPath, notLinemappedJar);
 				Files.copy(linemappedJarPath, mappedJarPath, StandardCopyOption.REPLACE_EXISTING);
-
-				addUnchangedLinemappedFiles(linemappedJarPath);
+				addUnchangedLinemappedFiles(mappedJarPath);
 
 			} catch (IOException e) {
 				throw new RuntimeException(e);

--- a/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 
 public class ApplyLinemappedJarTask extends AbstractLoomTask {
 	private Object mappedJar;
@@ -48,8 +49,7 @@ public class ApplyLinemappedJarTask extends AbstractLoomTask {
 			try {
 				// The original jars without the linemapping needs to be saved for incremental decompilation
 				Files.copy(mappedJarPath, jarsBeforeLinemapping(getExtension()));
-				Files.deleteIfExists(mappedJarPath);
-				Files.copy(linemappedJarPath, mappedJarPath);
+				Files.copy(linemappedJarPath, mappedJarPath, StandardCopyOption.REPLACE_EXISTING);
 			} catch (IOException e) {
 				throw new RuntimeException(e);
 			}

--- a/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
@@ -1,4 +1,60 @@
 package net.fabricmc.loom.task;
 
-public class ApplyLinemappedJarTask {
+import net.fabricmc.loom.LoomGradleExtension;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class ApplyLinemappedJarTask extends AbstractLoomTask {
+	private Object mappedJar;
+	private Object linemappedJar;
+
+	@InputFile
+	public File getMappedJar() {
+		return getProject().file(mappedJar);
+	}
+
+	@OutputFile
+	public File getLinemappedJar() {
+		return getProject().file(linemappedJar);
+	}
+
+
+	public void setMappedJar(Object mappedJar) {
+		this.mappedJar = mappedJar;
+	}
+
+	public void setLinemappedJar(Object linemappedJar) {
+		this.linemappedJar = linemappedJar;
+	}
+
+	public static Path jarsBeforeLinemapping(LoomGradleExtension extension) {
+		return Paths.get(extension.getUserCache().getPath(), "jarsBeforeLinemapping");
+	}
+
+
+	@TaskAction
+	public void run() {
+		Path mappedJarPath = getMappedJar().toPath();
+		Path linemappedJarPath = getLinemappedJar().toPath();
+
+		if (Files.exists(linemappedJarPath)) {
+			try {
+				// The original jars without the linemapping needs to be saved for incremental decompilation
+				Files.copy(mappedJarPath, jarsBeforeLinemapping(getExtension()));
+				Files.deleteIfExists(mappedJarPath);
+				Files.copy(linemappedJarPath, mappedJarPath);
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+
+
 }

--- a/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
@@ -1,6 +1,7 @@
 package net.fabricmc.loom.task;
 
 import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.task.fernflower.IncrementalDecompilation;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
@@ -11,10 +12,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.Optional;
 
 public class ApplyLinemappedJarTask extends AbstractLoomTask {
 	private Object mappedJar;
 	private Object linemappedJar;
+	private IncrementalDecompilation incrementalDecompilation;
 
 	@InputFile
 	public File getMappedJar() {
@@ -35,6 +38,10 @@ public class ApplyLinemappedJarTask extends AbstractLoomTask {
 		this.linemappedJar = linemappedJar;
 	}
 
+	public void setIncrementalDecompilation(IncrementalDecompilation incrementalDecompilation) {
+		this.incrementalDecompilation = incrementalDecompilation;
+	}
+
 	public static Path jarsBeforeLinemapping(LoomGradleExtension extension) {
 		return Paths.get(extension.getUserCache().getPath(), "jarsBeforeLinemapping");
 	}
@@ -47,15 +54,41 @@ public class ApplyLinemappedJarTask extends AbstractLoomTask {
 
 		if (Files.exists(linemappedJarPath)) {
 			try {
+
 				Files.createDirectories(jarsBeforeLinemapping(getExtension()));
+				Path notLinemappedJar = jarsBeforeLinemapping(getExtension()).resolve(mappedJarPath.getFileName());
 				// The original jars without the linemapping needs to be saved for incremental decompilation
-				Files.copy(mappedJarPath, jarsBeforeLinemapping(getExtension()).resolve(mappedJarPath.getFileName()));
+				Files.copy(mappedJarPath, notLinemappedJar);
 				Files.copy(linemappedJarPath, mappedJarPath, StandardCopyOption.REPLACE_EXISTING);
+
+				addUnchangedLinemappedFiles(linemappedJarPath);
 
 			} catch (IOException e) {
 				throw new RuntimeException(e);
 			}
 		}
+	}
+
+	private void addUnchangedLinemappedFiles(Path linemappedJarPath) throws IOException {
+		Path closestCompiledJar = incrementalDecompilation.getOldCompiledJar();
+		if (closestCompiledJar == null) return;
+
+		Optional<Path> oldLinemappedJar = getLinemappedJarOf(closestCompiledJar);
+		if (!oldLinemappedJar.isPresent()) {
+			getLogger().error("Could not find linemapped jar of previously decompiled jar: " + oldLinemappedJar);
+			return;
+		}
+
+		incrementalDecompilation.useUnchangedLinemappedClassFiles(oldLinemappedJar.get(), linemappedJarPath);
+	}
+
+	private Optional<Path> getLinemappedJarOf(Path compiledJar) throws IOException {
+		// Note we don't use the normal mapped jar in the top-level user cache and not the so called 'linemapped' jar because
+		// during the last phase of genSources the normal mapped jar gets overwritten with the linemapped one, and this way linemap changes
+		// applied with incremental decompilation are also taken into account.
+		return Files.list(getExtension().getUserCache().toPath())
+				.filter(path -> path.getFileName().toString().equals(compiledJar.getFileName().toString()))
+				.findAny();
 	}
 
 

--- a/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
@@ -1,0 +1,4 @@
+package net.fabricmc.loom.task;
+
+public class ApplyLinemappedJarTask {
+}

--- a/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
@@ -46,8 +46,9 @@ public class ApplyLinemappedJarTask extends AbstractLoomTask {
 
 		if (Files.exists(linemappedJarPath)) {
 			try {
+				Files.createDirectories(jarsBeforeLinemapping(getExtension()));
 				// The original jars without the linemapping needs to be saved for incremental decompilation
-				Files.copy(mappedJarPath, jarsBeforeLinemapping(getExtension()));
+				Files.copy(mappedJarPath, jarsBeforeLinemapping(getExtension()).resolve(mappedJarPath.getFileName()));
 				Files.deleteIfExists(mappedJarPath);
 				Files.copy(linemappedJarPath, mappedJarPath);
 			} catch (IOException e) {

--- a/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
@@ -1,10 +1,28 @@
-package net.fabricmc.loom.task;
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 
-import net.fabricmc.loom.LoomGradleExtension;
-import net.fabricmc.loom.task.fernflower.IncrementalDecompilation;
-import org.gradle.api.tasks.InputFile;
-import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.TaskAction;
+package net.fabricmc.loom.task;
 
 import java.io.File;
 import java.io.IOException;
@@ -13,6 +31,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Optional;
+
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.task.fernflower.IncrementalDecompilation;
 
 public class ApplyLinemappedJarTask extends AbstractLoomTask {
 	private Object mappedJar;
@@ -28,7 +53,6 @@ public class ApplyLinemappedJarTask extends AbstractLoomTask {
 	public File getLinemappedJar() {
 		return getProject().file(linemappedJar);
 	}
-
 
 	public void setMappedJar(Object mappedJar) {
 		this.mappedJar = mappedJar;
@@ -48,7 +72,6 @@ public class ApplyLinemappedJarTask extends AbstractLoomTask {
 		return path;
 	}
 
-
 	@TaskAction
 	public void run() {
 		Path mappedJarPath = getMappedJar().toPath();
@@ -62,7 +85,6 @@ public class ApplyLinemappedJarTask extends AbstractLoomTask {
 				if (!Files.exists(notLinemappedJar)) Files.copy(mappedJarPath, notLinemappedJar);
 				Files.copy(linemappedJarPath, mappedJarPath, StandardCopyOption.REPLACE_EXISTING);
 				addUnchangedLinemappedFiles(mappedJarPath);
-
 			} catch (IOException e) {
 				throw new RuntimeException(e);
 			}
@@ -74,6 +96,7 @@ public class ApplyLinemappedJarTask extends AbstractLoomTask {
 		if (closestCompiledJar == null) return;
 
 		Optional<Path> oldLinemappedJar = getLinemappedJarOf(closestCompiledJar);
+
 		if (!oldLinemappedJar.isPresent()) {
 			getLogger().error("Could not find linemapped jar of previously decompiled jar: " + oldLinemappedJar);
 			return;
@@ -87,9 +110,7 @@ public class ApplyLinemappedJarTask extends AbstractLoomTask {
 		// during the last phase of genSources the normal mapped jar gets overwritten with the linemapped one, and this way linemap changes
 		// applied with incremental decompilation are also taken into account.
 		return Files.list(getExtension().getUserCache().toPath())
-				.filter(path -> path.getFileName().toString().equals(compiledJar.getFileName().toString()))
-				.findAny();
+						.filter(path -> path.getFileName().toString().equals(compiledJar.getFileName().toString()))
+						.findAny();
 	}
-
-
 }

--- a/src/main/java/net/fabricmc/loom/task/CleanSourcesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/CleanSourcesTask.java
@@ -1,4 +1,39 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package net.fabricmc.loom.task;
 
-public class CleanSourceTask {
+import java.io.File;
+import java.io.IOException;
+
+import org.gradle.api.tasks.TaskAction;
+
+public class CleanSourcesTask extends AbstractLoomTask {
+	@TaskAction
+	public void clean() throws IOException {
+		for (File sourceFile : getExtension().getUserCache().listFiles(f -> f.getName().endsWith("-sources.jar"))) {
+			if (!sourceFile.delete()) getLogger().warn("Could not delete source file " + sourceFile);
+		}
+	}
 }

--- a/src/main/java/net/fabricmc/loom/task/CleanSourcesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/CleanSourcesTask.java
@@ -1,0 +1,4 @@
+package net.fabricmc.loom.task;
+
+public class CleanSourceTask {
+}

--- a/src/main/java/net/fabricmc/loom/task/fernflower/ForkedFFExecutor.java
+++ b/src/main/java/net/fabricmc/loom/task/fernflower/ForkedFFExecutor.java
@@ -48,8 +48,8 @@ import net.fabricmc.fernflower.api.IFabricJavadocProvider;
 public class ForkedFFExecutor {
 	public static void main(String[] args) throws IOException {
 		Map<String, Object> options = new HashMap<>();
-		File input = null;
 		File output = null;
+		File input = null;
 		File lineMap = null;
 		File mappings = null;
 		List<File> libraries = new ArrayList<>();

--- a/src/main/java/net/fabricmc/loom/task/fernflower/ForkedFFExecutor.java
+++ b/src/main/java/net/fabricmc/loom/task/fernflower/ForkedFFExecutor.java
@@ -24,14 +24,19 @@
 
 package net.fabricmc.loom.task.fernflower;
 
-import net.fabricmc.fernflower.api.IFabricJavadocProvider;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
 import org.jetbrains.java.decompiler.main.Fernflower;
 import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;
 import org.jetbrains.java.decompiler.main.extern.IResultSaver;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.*;
+import net.fabricmc.fernflower.api.IFabricJavadocProvider;
 
 /**
  * Entry point for Forked FernFlower task.

--- a/src/main/java/net/fabricmc/loom/task/fernflower/ForkedFFExecutor.java
+++ b/src/main/java/net/fabricmc/loom/task/fernflower/ForkedFFExecutor.java
@@ -24,19 +24,14 @@
 
 package net.fabricmc.loom.task.fernflower;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-
+import net.fabricmc.fernflower.api.IFabricJavadocProvider;
 import org.jetbrains.java.decompiler.main.Fernflower;
 import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;
 import org.jetbrains.java.decompiler.main.extern.IResultSaver;
 
-import net.fabricmc.fernflower.api.IFabricJavadocProvider;
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
 
 /**
  * Entry point for Forked FernFlower task.
@@ -112,7 +107,7 @@ public class ForkedFFExecutor {
 	}
 
 	public static void runFF(Map<String, Object> options, List<File> libraries, File input, File output, File lineMap) {
-		IResultSaver saver = new ThreadSafeResultSaver(() -> output, () -> lineMap);
+		IResultSaver saver = new ThreadSafeResultSaver(() -> output, () -> lineMap, input.isDirectory());
 		IFernflowerLogger logger = new ThreadIDFFLogger();
 		Fernflower ff = new Fernflower(FernFlowerUtils::getBytecode, saver, options, logger);
 
@@ -122,5 +117,7 @@ public class ForkedFFExecutor {
 
 		ff.addSource(input);
 		ff.decompileContext();
+
+		saver.closeArchive("", output.getName());
 	}
 }

--- a/src/main/java/net/fabricmc/loom/task/fernflower/IncrementalDecompilation.java
+++ b/src/main/java/net/fabricmc/loom/task/fernflower/IncrementalDecompilation.java
@@ -123,7 +123,7 @@ public class IncrementalDecompilation {
 					oldCompiledJar.getFileName(), unchangedClasses.size(), changedClasses.size()
 			));
 		} else {
-			logger.lifecycle("There are no older named minecraft jars that have been decompiled in store; The sources jar will be decompiled from scratch");
+			logger.lifecycle("Minecraft jar was not decompiled before; The sources jar will be decompiled from scratch");
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loom/task/fernflower/IncrementalDecompilation.java
+++ b/src/main/java/net/fabricmc/loom/task/fernflower/IncrementalDecompilation.java
@@ -1,13 +1,36 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package net.fabricmc.loom.task.fernflower;
 
-import net.fabricmc.loom.task.ApplyLinemappedJarTask;
-import org.apache.tools.ant.util.StringUtils;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.gradle.api.logging.Logger;
-
 import java.io.IOException;
-import java.nio.file.*;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -15,9 +38,13 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
-public class IncrementalDecompilation {
+import org.apache.tools.ant.util.StringUtils;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.gradle.api.logging.Logger;
 
-	public static Optional<Path> getClosestCompiledJar(Path closestTo,Path compiledJarsDir) throws IOException {
+public class IncrementalDecompilation {
+	public static Optional<Path> getClosestCompiledJar(Path closestTo, Path compiledJarsDir) throws IOException {
 		Stream<Path> candidateJars = Files.list(compiledJarsDir);
 
 		// Return the newest of available jars
@@ -29,7 +56,6 @@ public class IncrementalDecompilation {
 				throw new RuntimeException("Could not get last modified time of compiled jar", e);
 			}
 		});
-
 	}
 
 	private final Path newCompiledJar;
@@ -70,16 +96,16 @@ public class IncrementalDecompilation {
 				Files.copy(compiledJarFs.getPath(path), tempClassfileForFF);
 			}
 		}
+
 		return changedClassfilesDir;
 	}
 
 	/**
 	 * Since we don't decompile the entire jar then the line mapping is not complete,
-	 * however we can reuse the old linemapped jar and copy the unchanged parts over to the new partially linemapped jar
+	 * however we can reuse the old linemapped jar and copy the unchanged parts over to the new partially linemapped jar.
 	 */
 	public void useUnchangedLinemappedClassFiles(Path oldLinemappedJar, Path newLinemappedJar) throws IOException {
-		try (FileSystem oldLinemappedFs = FileSystems.newFileSystem(oldLinemappedJar, null);
-			 FileSystem newCompiledFs = FileSystems.newFileSystem(newLinemappedJar, null)
+		try (FileSystem oldLinemappedFs = FileSystems.newFileSystem(oldLinemappedJar, null); FileSystem newCompiledFs = FileSystems.newFileSystem(newLinemappedJar, null)
 		) {
 			for (String unchangedClass : unchangedClasses) {
 				String path = unchangedClass + ".class";
@@ -104,9 +130,9 @@ public class IncrementalDecompilation {
 		}
 	}
 
-
 	private void diffCompiledJars(List<String> unchangedClasses, List<String> changedClasses) {
 		if (oldCompiledJar == null) return;
+
 		try (FileSystem newFs = FileSystems.newFileSystem(newCompiledJar, null)) {
 			try (FileSystem oldFs = FileSystems.newFileSystem(oldCompiledJar, null)) {
 				addClassfiles(newFs, oldFs, unchangedClasses, changedClasses);
@@ -116,17 +142,15 @@ public class IncrementalDecompilation {
 		}
 	}
 
-
 	private void logStatus() {
 		if (oldCompiledJar != null) {
 			logger.lifecycle(String.format("%s was already decompiled; Reusing %d old classes and redecompiling %d changed classes",
-					oldCompiledJar.getFileName(), unchangedClasses.size(), changedClasses.size()
+							oldCompiledJar.getFileName(), unchangedClasses.size(), changedClasses.size()
 			));
 		} else {
 			logger.lifecycle("Minecraft jar was not decompiled before; The sources jar will be decompiled from scratch");
 		}
 	}
-
 
 	/**
 	 * @return A directory that contains the changed classfiles
@@ -135,6 +159,7 @@ public class IncrementalDecompilation {
 		for (Path rootDir : jarFs.getRootDirectories()) {
 			Files.walk(rootDir).forEach(newJarPath -> {
 				if (Files.isDirectory(newJarPath) || !newJarPath.toString().endsWith(".class")) return;
+
 				try {
 					String pathString = StringUtils.removeSuffix(newJarPath.toString(), ".class");
 
@@ -145,16 +170,12 @@ public class IncrementalDecompilation {
 						//TODO: filter out inner classes
 						unchanged.add(pathString);
 					}
-
 				} catch (IOException e) {
 					throw new RuntimeException("Could not visit compiled jar file", e);
 				}
-
 			});
 		}
 	}
-
-
 
 	private static boolean changed(@Nullable FileSystem oldJarFs, Path classFile) throws IOException {
 		Path classFileInOldJar = oldJarFs != null ? oldJarFs.getPath(classFile.toString()) : null;
@@ -178,6 +199,7 @@ public class IncrementalDecompilation {
 			try {
 				if (changed.get()) return;
 				if (Files.isDirectory(pathInDir)) return;
+
 				if (getOuterClassName(pathInDir).equals(outerClassName) && changed(oldJarFs, pathInDir)) {
 					changed.set(true);
 				}
@@ -192,8 +214,8 @@ public class IncrementalDecompilation {
 		String className = path.getFileName().toString();
 		int index = className.indexOf("$");
 		String withExtension = index == -1 ? className : className.substring(0, index);
-		return withExtension.endsWith(".class") ? withExtension.
-				substring(0, withExtension.length() - ".class".length()) : withExtension;
+		return withExtension.endsWith(".class") ? withExtension
+						.substring(0, withExtension.length() - ".class".length()) : withExtension;
 	}
 
 	private static boolean isInnerClass(String path) {

--- a/src/main/java/net/fabricmc/loom/task/fernflower/IncrementalDecompilation.java
+++ b/src/main/java/net/fabricmc/loom/task/fernflower/IncrementalDecompilation.java
@@ -1,0 +1,4 @@
+package net.fabricmc.loom.task.fernflower;
+
+public class IncrementalDecompilation {
+}

--- a/src/main/java/net/fabricmc/loom/task/fernflower/IncrementalDecompilation.java
+++ b/src/main/java/net/fabricmc/loom/task/fernflower/IncrementalDecompilation.java
@@ -1,4 +1,169 @@
 package net.fabricmc.loom.task.fernflower;
 
+import org.apache.tools.ant.util.StringUtils;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.gradle.api.logging.Logger;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 public class IncrementalDecompilation {
+
+	private final Path newCompiledJar;
+	private final @Nullable Path oldCompiledJar;
+	private final List<String> unchangedClasses = new ArrayList<>();
+	private final List<String> changedClasses = new ArrayList<>();
+	private final Logger logger;
+
+	public @Nullable Path getOldCompiledJar() {
+		return oldCompiledJar;
+	}
+
+	public IncrementalDecompilation(Path newCompiledJar, @Nullable Path oldCompiledJar, Logger logger) {
+		this.newCompiledJar = newCompiledJar;
+		this.oldCompiledJar = oldCompiledJar;
+		this.logger = logger;
+	}
+
+	/**
+	 * Since we don't decompile the entire jar then the line mapping is not complete,
+	 * however we can reuse the old linemapped jar and copy the unchanged parts over to the new partially linemapped jar
+	 */
+	public void useUnchangedLinemappedClassFiles(Path oldLinemappedJar) throws IOException {
+		try (FileSystem oldLinemappedFs = FileSystems.newFileSystem(oldLinemappedJar, null);
+			 FileSystem newCompiledFs = FileSystems.newFileSystem(newCompiledJar, null)
+		) {
+			for (String unchangedClass : unchangedClasses) {
+				String path = unchangedClass + ".class";
+				Files.copy(oldLinemappedFs.getPath(path), newCompiledFs.getPath(path), StandardCopyOption.REPLACE_EXISTING);
+			}
+		}
+	}
+
+	public void addUnchangedSourceFiles(Path newSourceFile, @NonNull Path oldSourceFile) throws IOException {
+		// Copy over unchanged sources
+		try (FileSystem oldSourcesFs = FileSystems.newFileSystem(oldSourceFile, null)) {
+			try (FileSystem newSourcesFs = FileSystems.newFileSystem(newSourceFile, null)) {
+				for (String unchangedClass : unchangedClasses) {
+					// Inner classes are included as part of the outer classes in source files
+					if (isInnerClass(unchangedClass)) continue;
+					String path = unchangedClass + ".java";
+					Path targetPath = newSourcesFs.getPath(path);
+					Files.createDirectories(targetPath.getParent());
+					Files.copy(oldSourcesFs.getPath(path), targetPath);
+				}
+			}
+		}
+	}
+
+	/**
+	 * @return A directory that contains the changed classfiles, or just the compiled jar if there's nothing to compare against
+	 */
+	public Path diffCompiledJars() throws IOException {
+		if (oldCompiledJar == null) return newCompiledJar;
+		Path changedDir;
+		try (FileSystem newFs = FileSystems.newFileSystem(newCompiledJar, null)) {
+			try (FileSystem oldFs = FileSystems.newFileSystem(oldCompiledJar, null)) {
+				changedDir = addClassfiles(newFs, oldFs);
+			}
+		}
+		logStatus();
+		return changedDir;
+	}
+
+
+	private void logStatus() {
+		if (oldCompiledJar != null) {
+			logger.lifecycle(String.format("%s was already decompiled; Reusing %d old classes and redecompiling %d changed classes",
+					oldCompiledJar.getFileName(), unchangedClasses.size(), changedClasses.size()
+			));
+		} else {
+			logger.lifecycle("There are no older named minecraft jars that have been decompiled in store; The sources jar will be decompiled from scratch");
+		}
+	}
+
+
+	/**
+	 * @return A directory that contains the changed classfiles
+	 */
+	private Path addClassfiles(FileSystem jarFs, @Nullable FileSystem closestJarFs) throws IOException {
+		// copy over the classfiles we want to be decompiled to a normal directory
+		Path changedClassfilesDir = Files.createTempDirectory("compiled");
+
+		for (Path rootDir : jarFs.getRootDirectories()) {
+			Files.walk(rootDir).forEach(newJarPath -> {
+				if (Files.isDirectory(newJarPath) || !newJarPath.toString().endsWith(".class")) return;
+				try {
+					String pathString = StringUtils.removeSuffix(newJarPath.toString(), ".class");
+
+					if (outerOrInnerClassesChanged(closestJarFs, newJarPath)) {
+						// Nothing to reuse from an old jar, decompile it
+
+						Path tempClassfileForFF = Paths.get(changedClassfilesDir.toString(), newJarPath.toString());
+						Files.createDirectories(tempClassfileForFF.getParent());
+						Files.copy(newJarPath, tempClassfileForFF);
+
+						changedClasses.add(pathString);
+					} else {
+						//TODO: filter out inner classes
+						unchangedClasses.add(pathString);
+					}
+
+				} catch (IOException e) {
+					throw new RuntimeException("Could not visit compiled jar file", e);
+				}
+
+			});
+		}
+		return changedClassfilesDir;
+	}
+
+	private static boolean changed(@Nullable FileSystem oldJarFs, Path classFile) throws IOException {
+		Path classFileInOldJar = oldJarFs != null ? oldJarFs.getPath(classFile.toString()) : null;
+
+		if (classFileInOldJar == null || !Files.exists(classFileInOldJar)) return true;
+		byte[] newClassFile = Files.readAllBytes(classFile);
+		byte[] oldClassFile = Files.readAllBytes(classFileInOldJar);
+		return !Arrays.equals(newClassFile, oldClassFile);
+	}
+
+	/**
+	 * In compiled jars, inner classes are separated into separate files, while in source jars, they are merged into one file.
+	 * This means that when the inner class has changed we need to make sure the outer class gets decompiled too, and when
+	 * and outer class gets changed we need to make sure the inner class gets decompiled too.
+	 */
+	private static boolean outerOrInnerClassesChanged(@Nullable FileSystem oldJarFs, Path classFile) throws IOException {
+		String outerClassName = getOuterClassName(classFile);
+
+		AtomicBoolean changed = new AtomicBoolean(false);
+		Files.list(classFile.getParent()).forEach(pathInDir -> {
+			try {
+				if (changed.get()) return;
+				if (Files.isDirectory(pathInDir)) return;
+				if (getOuterClassName(pathInDir).equals(outerClassName) && changed(oldJarFs, pathInDir)) {
+					changed.set(true);
+				}
+			} catch (IOException e) {
+				throw new RuntimeException("Cannot check if classfile was changed", e);
+			}
+		});
+		return changed.get();
+	}
+
+	private static String getOuterClassName(Path path) {
+		String className = path.getFileName().toString();
+		int index = className.indexOf("$");
+		String withExtension = index == -1 ? className : className.substring(0, index);
+		return withExtension.endsWith(".class") ? withExtension.
+				substring(0, withExtension.length() - ".class".length()) : withExtension;
+	}
+
+	private static boolean isInnerClass(String path) {
+		return path.contains("$");
+	}
 }

--- a/src/main/java/net/fabricmc/loom/task/fernflower/IncrementalDecompilation.java
+++ b/src/main/java/net/fabricmc/loom/task/fernflower/IncrementalDecompilation.java
@@ -152,9 +152,6 @@ public class IncrementalDecompilation {
 		}
 	}
 
-	/**
-	 * @return A directory that contains the changed classfiles
-	 */
 	private static void addClassfiles(FileSystem jarFs, @Nullable FileSystem closestJarFs, List<String> unchanged, List<String> changed) throws IOException {
 		for (Path rootDir : jarFs.getRootDirectories()) {
 			Files.walk(rootDir).forEach(newJarPath -> {
@@ -167,7 +164,6 @@ public class IncrementalDecompilation {
 						// Nothing to reuse from an old jar, decompile it
 						changed.add(pathString);
 					} else {
-						//TODO: filter out inner classes
 						unchanged.add(pathString);
 					}
 				} catch (IOException e) {

--- a/src/main/java/net/fabricmc/loom/task/fernflower/ThreadSafeResultSaver.java
+++ b/src/main/java/net/fabricmc/loom/task/fernflower/ThreadSafeResultSaver.java
@@ -24,11 +24,11 @@
 
 package net.fabricmc.loom.task.fernflower;
 
-import net.fabricmc.fernflower.api.IFabricResultSaver;
-import org.jetbrains.java.decompiler.main.DecompilerContext;
-import org.jetbrains.java.decompiler.main.extern.IResultSaver;
-
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
@@ -41,6 +41,11 @@ import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+
+import org.jetbrains.java.decompiler.main.DecompilerContext;
+import org.jetbrains.java.decompiler.main.extern.IResultSaver;
+
+import net.fabricmc.fernflower.api.IFabricResultSaver;
 
 /**
  * Created by covers1624 on 18/02/19.
@@ -128,7 +133,6 @@ public class ThreadSafeResultSaver implements IResultSaver, IFabricResultSaver {
 
 	@Override
 	public void closeArchive(String path, String archiveName) {
-
 		if (closed) return;
 
 		String key = path + "/" + archiveName;

--- a/src/test/java/net/minecraft/fabricmc/loom/IncrementalDecompilationTest.java
+++ b/src/test/java/net/minecraft/fabricmc/loom/IncrementalDecompilationTest.java
@@ -1,0 +1,4 @@
+package net.minecraft.fabricmc.loom;
+
+public class IncrementalDecompilationTest {
+}

--- a/src/test/java/net/minecraft/fabricmc/loom/IncrementalDecompilationTest.java
+++ b/src/test/java/net/minecraft/fabricmc/loom/IncrementalDecompilationTest.java
@@ -1,4 +1,66 @@
 package net.minecraft.fabricmc.loom;
 
+import net.fabricmc.loom.task.fernflower.ForkedFFExecutor;
+import net.fabricmc.loom.task.fernflower.IncrementalDecompilation;
+import net.fabricmc.loom.util.LineNumberRemapper;
+import net.fabricmc.stitch.util.StitchUtil;
+import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+
 public class IncrementalDecompilationTest {
+	private static final Path NEW_COMPILED_JAR = Paths.get("minecraft-1.15.1-build.23-not-linemapped.jar");
+	private static final Path OLD_COMPILED_JAR = Paths.get("minecraft-1.15.1-build.17-not-linemapped.jar");
+	private static final Path OLD_SOURCES_JAR = Paths.get("minecraft-1.15.1-build.17-sources.jar");
+	private static final Path OLD_LINEMAPPED_JAR = Paths.get("minecraft-1.15.1-build.17-linemapped.jar");
+
+	private static final Path OUT_LINEMAP = Paths.get("linemap.txt");
+	private static final Path OUT_SOURCES = Paths.get("minecraft-1.15.1-build.23-sources.jar");
+	private static final Path OUT_LINEMAPPED_JAR = Paths.get("minecraft-1.15.1-build.23-linemapped.jar");
+	private IncrementalDecompilation ic = new IncrementalDecompilation(NEW_COMPILED_JAR, OLD_COMPILED_JAR, new TestLogger());
+
+	@Ignore
+	@Test
+	public void test() throws IOException {
+		Path toDecompile = ic.diffCompiledJars();
+
+		decompile(toDecompile);
+
+		remapLineNumbers();
+
+		ic.addUnchangedSourceFiles(OUT_SOURCES, OLD_SOURCES_JAR);
+		ic.useUnchangedLinemappedClassFiles(OLD_LINEMAPPED_JAR);
+	}
+
+	private void remapLineNumbers() throws IOException {
+		LineNumberRemapper remapper = new LineNumberRemapper();
+		remapper.readMappings(OUT_LINEMAP.toFile());
+
+		try (StitchUtil.FileSystemDelegate inFs = StitchUtil.getJarFileSystem(OLD_COMPILED_JAR.toFile(), true);
+			 StitchUtil.FileSystemDelegate outFs = StitchUtil.getJarFileSystem(OUT_LINEMAPPED_JAR.toFile(), true)) {
+			remapper.process(null, inFs.get().getPath("/"), outFs.get().getPath("/"));
+		}
+	}
+
+	private void decompile(Path toDecompile) {
+		ForkedFFExecutor.runFF(
+				new HashMap<String, Object>() {{
+					put(IFernflowerPreferences.DECOMPILE_GENERIC_SIGNATURES, "1");
+					put(IFernflowerPreferences.REMOVE_SYNTHETIC, "1");
+					put(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, "1");
+
+				}},
+				new ArrayList<>(),
+				toDecompile.toFile(),
+				OUT_SOURCES.toFile(),
+				OUT_LINEMAP.toFile()
+		);
+	}
+
 }

--- a/src/test/java/net/minecraft/fabricmc/loom/IncrementalDecompilationTest.java
+++ b/src/test/java/net/minecraft/fabricmc/loom/IncrementalDecompilationTest.java
@@ -9,13 +9,16 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashMap;
 
 public class IncrementalDecompilationTest {
 	private static final Path NEW_COMPILED_JAR = Paths.get("minecraft-1.15.1-build.23-not-linemapped.jar");
+	private static final Path NEW_COMPILED_JAR_UNMODIFIED = Paths.get("save/minecraft-1.15.1-build.23-not-linemapped.jar");
 	private static final Path OLD_COMPILED_JAR = Paths.get("minecraft-1.15.1-build.17-not-linemapped.jar");
 	private static final Path OLD_SOURCES_JAR = Paths.get("minecraft-1.15.1-build.17-sources.jar");
 	private static final Path OLD_LINEMAPPED_JAR = Paths.get("minecraft-1.15.1-build.17-linemapped.jar");
@@ -28,14 +31,15 @@ public class IncrementalDecompilationTest {
 	@Ignore
 	@Test
 	public void test() throws IOException {
-		Path toDecompile = ic.diffCompiledJars();
+		Files.copy(NEW_COMPILED_JAR_UNMODIFIED, NEW_COMPILED_JAR, StandardCopyOption.REPLACE_EXISTING);
+		Path toDecompile = ic.getChangedClassfilesFile();
 
 		decompile(toDecompile);
 
 		remapLineNumbers();
 
 		ic.addUnchangedSourceFiles(OUT_SOURCES, OLD_SOURCES_JAR);
-		ic.useUnchangedLinemappedClassFiles(OLD_LINEMAPPED_JAR);
+		ic.useUnchangedLinemappedClassFiles(OLD_LINEMAPPED_JAR, OUT_LINEMAPPED_JAR);
 	}
 
 	private void remapLineNumbers() throws IOException {

--- a/src/test/java/net/minecraft/fabricmc/loom/IncrementalDecompilationTest.java
+++ b/src/test/java/net/minecraft/fabricmc/loom/IncrementalDecompilationTest.java
@@ -1,12 +1,28 @@
-package net.minecraft.fabricmc.loom;
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 
-import net.fabricmc.loom.task.fernflower.ForkedFFExecutor;
-import net.fabricmc.loom.task.fernflower.IncrementalDecompilation;
-import net.fabricmc.loom.util.LineNumberRemapper;
-import net.fabricmc.stitch.util.StitchUtil;
-import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
-import org.junit.Ignore;
-import org.junit.Test;
+package net.minecraft.fabricmc.loom;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -15,6 +31,15 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashMap;
+
+import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import net.fabricmc.loom.task.fernflower.ForkedFFExecutor;
+import net.fabricmc.loom.task.fernflower.IncrementalDecompilation;
+import net.fabricmc.loom.util.LineNumberRemapper;
+import net.fabricmc.stitch.util.StitchUtil;
 
 public class IncrementalDecompilationTest {
 	private static final Path NEW_COMPILED_JAR = Paths.get("minecraft-1.15.1-build.23-not-linemapped.jar");
@@ -47,24 +72,22 @@ public class IncrementalDecompilationTest {
 		remapper.readMappings(OUT_LINEMAP.toFile());
 
 		try (StitchUtil.FileSystemDelegate inFs = StitchUtil.getJarFileSystem(OLD_COMPILED_JAR.toFile(), true);
-			 StitchUtil.FileSystemDelegate outFs = StitchUtil.getJarFileSystem(OUT_LINEMAPPED_JAR.toFile(), true)) {
+			StitchUtil.FileSystemDelegate outFs = StitchUtil.getJarFileSystem(OUT_LINEMAPPED_JAR.toFile(), true)) {
 			remapper.process(null, inFs.get().getPath("/"), outFs.get().getPath("/"));
 		}
 	}
 
 	private void decompile(Path toDecompile) {
 		ForkedFFExecutor.runFF(
-				new HashMap<String, Object>() {{
-					put(IFernflowerPreferences.DECOMPILE_GENERIC_SIGNATURES, "1");
-					put(IFernflowerPreferences.REMOVE_SYNTHETIC, "1");
-					put(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, "1");
-
-				}},
-				new ArrayList<>(),
-				toDecompile.toFile(),
-				OUT_SOURCES.toFile(),
-				OUT_LINEMAP.toFile()
+						new HashMap<String, Object>() {{
+								put(IFernflowerPreferences.DECOMPILE_GENERIC_SIGNATURES, "1");
+								put(IFernflowerPreferences.REMOVE_SYNTHETIC, "1");
+								put(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, "1");
+								}},
+						new ArrayList<>(),
+						toDecompile.toFile(),
+						OUT_SOURCES.toFile(),
+						OUT_LINEMAP.toFile()
 		);
 	}
-
 }

--- a/src/test/java/net/minecraft/fabricmc/loom/TestLogger.java
+++ b/src/test/java/net/minecraft/fabricmc/loom/TestLogger.java
@@ -1,4 +1,372 @@
 package net.minecraft.fabricmc.loom;
 
-public class TestLogger {
+import org.gradle.api.logging.LogLevel;
+import org.gradle.api.logging.Logger;
+import org.slf4j.Marker;
+
+public class TestLogger implements Logger {
+	@Override
+	public boolean isLifecycleEnabled() {
+		return true;
+	}
+
+	@Override
+	public String getName() {
+		return "Test Logger";
+	}
+
+	@Override
+	public boolean isTraceEnabled() {
+		return false;
+	}
+
+	@Override
+	public void trace(String s) {
+
+	}
+
+	@Override
+	public void trace(String s, Object o) {
+
+	}
+
+	@Override
+	public void trace(String s, Object o, Object o1) {
+
+	}
+
+	@Override
+	public void trace(String s, Object... objects) {
+
+	}
+
+	@Override
+	public void trace(String s, Throwable throwable) {
+
+	}
+
+	@Override
+	public boolean isTraceEnabled(Marker marker) {
+		return false;
+	}
+
+	@Override
+	public void trace(Marker marker, String s) {
+
+	}
+
+	@Override
+	public void trace(Marker marker, String s, Object o) {
+
+	}
+
+	@Override
+	public void trace(Marker marker, String s, Object o, Object o1) {
+
+	}
+
+	@Override
+	public void trace(Marker marker, String s, Object... objects) {
+
+	}
+
+	@Override
+	public void trace(Marker marker, String s, Throwable throwable) {
+
+	}
+
+	@Override
+	public boolean isDebugEnabled() {
+		return false;
+	}
+
+	@Override
+	public void debug(String s) {
+
+	}
+
+	@Override
+	public void debug(String s, Object o) {
+
+	}
+
+	@Override
+	public void debug(String s, Object o, Object o1) {
+
+	}
+
+	@Override
+	public void debug(String message, Object... objects) {
+
+	}
+
+	@Override
+	public void debug(String s, Throwable throwable) {
+
+	}
+
+	@Override
+	public boolean isDebugEnabled(Marker marker) {
+		return false;
+	}
+
+	@Override
+	public void debug(Marker marker, String s) {
+
+	}
+
+	@Override
+	public void debug(Marker marker, String s, Object o) {
+
+	}
+
+	@Override
+	public void debug(Marker marker, String s, Object o, Object o1) {
+
+	}
+
+	@Override
+	public void debug(Marker marker, String s, Object... objects) {
+
+	}
+
+	@Override
+	public void debug(Marker marker, String s, Throwable throwable) {
+
+	}
+
+	@Override
+	public boolean isInfoEnabled() {
+		return false;
+	}
+
+	@Override
+	public void info(String s) {
+
+	}
+
+	@Override
+	public void info(String s, Object o) {
+
+	}
+
+	@Override
+	public void info(String s, Object o, Object o1) {
+
+	}
+
+	@Override
+	public void lifecycle(String message) {
+		System.out.println(message);
+	}
+
+	@Override
+	public void lifecycle(String message, Object... objects) {
+
+	}
+
+	@Override
+	public void lifecycle(String message, Throwable throwable) {
+
+	}
+
+	@Override
+	public boolean isQuietEnabled() {
+		return false;
+	}
+
+	@Override
+	public void quiet(String message) {
+
+	}
+
+	@Override
+	public void quiet(String message, Object... objects) {
+
+	}
+
+	@Override
+	public void info(String message, Object... objects) {
+
+	}
+
+	@Override
+	public void info(String s, Throwable throwable) {
+
+	}
+
+	@Override
+	public boolean isInfoEnabled(Marker marker) {
+		return false;
+	}
+
+	@Override
+	public void info(Marker marker, String s) {
+
+	}
+
+	@Override
+	public void info(Marker marker, String s, Object o) {
+
+	}
+
+	@Override
+	public void info(Marker marker, String s, Object o, Object o1) {
+
+	}
+
+	@Override
+	public void info(Marker marker, String s, Object... objects) {
+
+	}
+
+	@Override
+	public void info(Marker marker, String s, Throwable throwable) {
+
+	}
+
+	@Override
+	public boolean isWarnEnabled() {
+		return false;
+	}
+
+	@Override
+	public void warn(String s) {
+
+	}
+
+	@Override
+	public void warn(String s, Object o) {
+
+	}
+
+	@Override
+	public void warn(String s, Object... objects) {
+
+	}
+
+	@Override
+	public void warn(String s, Object o, Object o1) {
+
+	}
+
+	@Override
+	public void warn(String s, Throwable throwable) {
+
+	}
+
+	@Override
+	public boolean isWarnEnabled(Marker marker) {
+		return false;
+	}
+
+	@Override
+	public void warn(Marker marker, String s) {
+
+	}
+
+	@Override
+	public void warn(Marker marker, String s, Object o) {
+
+	}
+
+	@Override
+	public void warn(Marker marker, String s, Object o, Object o1) {
+
+	}
+
+	@Override
+	public void warn(Marker marker, String s, Object... objects) {
+
+	}
+
+	@Override
+	public void warn(Marker marker, String s, Throwable throwable) {
+
+	}
+
+	@Override
+	public boolean isErrorEnabled() {
+		return false;
+	}
+
+	@Override
+	public void error(String s) {
+
+	}
+
+	@Override
+	public void error(String s, Object o) {
+
+	}
+
+	@Override
+	public void error(String s, Object o, Object o1) {
+
+	}
+
+	@Override
+	public void error(String s, Object... objects) {
+
+	}
+
+	@Override
+	public void error(String s, Throwable throwable) {
+
+	}
+
+	@Override
+	public boolean isErrorEnabled(Marker marker) {
+		return false;
+	}
+
+	@Override
+	public void error(Marker marker, String s) {
+
+	}
+
+	@Override
+	public void error(Marker marker, String s, Object o) {
+
+	}
+
+	@Override
+	public void error(Marker marker, String s, Object o, Object o1) {
+
+	}
+
+	@Override
+	public void error(Marker marker, String s, Object... objects) {
+
+	}
+
+	@Override
+	public void error(Marker marker, String s, Throwable throwable) {
+
+	}
+
+	@Override
+	public void quiet(String message, Throwable throwable) {
+
+	}
+
+	@Override
+	public boolean isEnabled(LogLevel level) {
+		return false;
+	}
+
+	@Override
+	public void log(LogLevel level, String message) {
+
+	}
+
+	@Override
+	public void log(LogLevel level, String message, Object... objects) {
+
+	}
+
+	@Override
+	public void log(LogLevel level, String message, Throwable throwable) {
+
+	}
 }

--- a/src/test/java/net/minecraft/fabricmc/loom/TestLogger.java
+++ b/src/test/java/net/minecraft/fabricmc/loom/TestLogger.java
@@ -1,0 +1,4 @@
+package net.minecraft.fabricmc.loom;
+
+public class TestLogger {
+}

--- a/src/test/java/net/minecraft/fabricmc/loom/TestLogger.java
+++ b/src/test/java/net/minecraft/fabricmc/loom/TestLogger.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package net.minecraft.fabricmc.loom;
 
 import org.gradle.api.logging.LogLevel;
@@ -22,27 +46,22 @@ public class TestLogger implements Logger {
 
 	@Override
 	public void trace(String s) {
-
 	}
 
 	@Override
 	public void trace(String s, Object o) {
-
 	}
 
 	@Override
 	public void trace(String s, Object o, Object o1) {
-
 	}
 
 	@Override
 	public void trace(String s, Object... objects) {
-
 	}
 
 	@Override
 	public void trace(String s, Throwable throwable) {
-
 	}
 
 	@Override
@@ -52,27 +71,22 @@ public class TestLogger implements Logger {
 
 	@Override
 	public void trace(Marker marker, String s) {
-
 	}
 
 	@Override
 	public void trace(Marker marker, String s, Object o) {
-
 	}
 
 	@Override
 	public void trace(Marker marker, String s, Object o, Object o1) {
-
 	}
 
 	@Override
 	public void trace(Marker marker, String s, Object... objects) {
-
 	}
 
 	@Override
 	public void trace(Marker marker, String s, Throwable throwable) {
-
 	}
 
 	@Override
@@ -82,27 +96,22 @@ public class TestLogger implements Logger {
 
 	@Override
 	public void debug(String s) {
-
 	}
 
 	@Override
 	public void debug(String s, Object o) {
-
 	}
 
 	@Override
 	public void debug(String s, Object o, Object o1) {
-
 	}
 
 	@Override
 	public void debug(String message, Object... objects) {
-
 	}
 
 	@Override
 	public void debug(String s, Throwable throwable) {
-
 	}
 
 	@Override
@@ -112,27 +121,22 @@ public class TestLogger implements Logger {
 
 	@Override
 	public void debug(Marker marker, String s) {
-
 	}
 
 	@Override
 	public void debug(Marker marker, String s, Object o) {
-
 	}
 
 	@Override
 	public void debug(Marker marker, String s, Object o, Object o1) {
-
 	}
 
 	@Override
 	public void debug(Marker marker, String s, Object... objects) {
-
 	}
 
 	@Override
 	public void debug(Marker marker, String s, Throwable throwable) {
-
 	}
 
 	@Override
@@ -142,17 +146,14 @@ public class TestLogger implements Logger {
 
 	@Override
 	public void info(String s) {
-
 	}
 
 	@Override
 	public void info(String s, Object o) {
-
 	}
 
 	@Override
 	public void info(String s, Object o, Object o1) {
-
 	}
 
 	@Override
@@ -162,12 +163,10 @@ public class TestLogger implements Logger {
 
 	@Override
 	public void lifecycle(String message, Object... objects) {
-
 	}
 
 	@Override
 	public void lifecycle(String message, Throwable throwable) {
-
 	}
 
 	@Override
@@ -177,22 +176,18 @@ public class TestLogger implements Logger {
 
 	@Override
 	public void quiet(String message) {
-
 	}
 
 	@Override
 	public void quiet(String message, Object... objects) {
-
 	}
 
 	@Override
 	public void info(String message, Object... objects) {
-
 	}
 
 	@Override
 	public void info(String s, Throwable throwable) {
-
 	}
 
 	@Override
@@ -202,27 +197,22 @@ public class TestLogger implements Logger {
 
 	@Override
 	public void info(Marker marker, String s) {
-
 	}
 
 	@Override
 	public void info(Marker marker, String s, Object o) {
-
 	}
 
 	@Override
 	public void info(Marker marker, String s, Object o, Object o1) {
-
 	}
 
 	@Override
 	public void info(Marker marker, String s, Object... objects) {
-
 	}
 
 	@Override
 	public void info(Marker marker, String s, Throwable throwable) {
-
 	}
 
 	@Override
@@ -232,27 +222,22 @@ public class TestLogger implements Logger {
 
 	@Override
 	public void warn(String s) {
-
 	}
 
 	@Override
 	public void warn(String s, Object o) {
-
 	}
 
 	@Override
 	public void warn(String s, Object... objects) {
-
 	}
 
 	@Override
 	public void warn(String s, Object o, Object o1) {
-
 	}
 
 	@Override
 	public void warn(String s, Throwable throwable) {
-
 	}
 
 	@Override
@@ -262,27 +247,22 @@ public class TestLogger implements Logger {
 
 	@Override
 	public void warn(Marker marker, String s) {
-
 	}
 
 	@Override
 	public void warn(Marker marker, String s, Object o) {
-
 	}
 
 	@Override
 	public void warn(Marker marker, String s, Object o, Object o1) {
-
 	}
 
 	@Override
 	public void warn(Marker marker, String s, Object... objects) {
-
 	}
 
 	@Override
 	public void warn(Marker marker, String s, Throwable throwable) {
-
 	}
 
 	@Override
@@ -292,27 +272,22 @@ public class TestLogger implements Logger {
 
 	@Override
 	public void error(String s) {
-
 	}
 
 	@Override
 	public void error(String s, Object o) {
-
 	}
 
 	@Override
 	public void error(String s, Object o, Object o1) {
-
 	}
 
 	@Override
 	public void error(String s, Object... objects) {
-
 	}
 
 	@Override
 	public void error(String s, Throwable throwable) {
-
 	}
 
 	@Override
@@ -322,32 +297,26 @@ public class TestLogger implements Logger {
 
 	@Override
 	public void error(Marker marker, String s) {
-
 	}
 
 	@Override
 	public void error(Marker marker, String s, Object o) {
-
 	}
 
 	@Override
 	public void error(Marker marker, String s, Object o, Object o1) {
-
 	}
 
 	@Override
 	public void error(Marker marker, String s, Object... objects) {
-
 	}
 
 	@Override
 	public void error(Marker marker, String s, Throwable throwable) {
-
 	}
 
 	@Override
 	public void quiet(String message, Throwable throwable) {
-
 	}
 
 	@Override
@@ -357,16 +326,13 @@ public class TestLogger implements Logger {
 
 	@Override
 	public void log(LogLevel level, String message) {
-
 	}
 
 	@Override
 	public void log(LogLevel level, String message, Object... objects) {
-
 	}
 
 	@Override
 	public void log(LogLevel level, String message, Throwable throwable) {
-
 	}
 }


### PR DESCRIPTION
*provided `genSources` was run before on a sufficiently similar Minecraft jar.

## How it works
- On the first time `genSources` runs, on version A, decompile the entire jar normally. Save the compiled jar that has the original Mojang linemaps (the _original Yarn jar_) - #171.
- On subsequent runs, on version B, compare the _original yarn jar_ of version B to that of version A. Produce a list of class files in version B that are the same as those in version A (_unchanged classes_), and a list of class files that have either changed or do not have an equivalent in version A (_changed classes_) - [here](https://github.com/natanfudge/fabric-loom/blob/61652bcd4682d13bff7a17fcf6769753c1a29baf/src/main/java/net/fabricmc/loom/task/fernflower/IncrementalDecompilation.java#L133). 
- Decompile only _changed classes_ - [here](https://github.com/natanfudge/fabric-loom/blob/61652bcd4682d13bff7a17fcf6769753c1a29baf/src/main/java/net/fabricmc/loom/task/fernflower/IncrementalDecompilation.java#L89).
- Add all _unchanged classes_ from the source jar of version A into the result of the decompilation (of version B) - [here](https://github.com/natanfudge/fabric-loom/blob/61652bcd4682d13bff7a17fcf6769753c1a29baf/src/main/java/net/fabricmc/loom/task/fernflower/FernFlowerTask.java#L164).
- Linemap the compiled Yarn jar of version B is per usual.
- Copy over all _unchanged classes_ from the linemapped jar of version A to the linemapped jar of the result linemapped jar (of version B) - [here](https://github.com/natanfudge/fabric-loom/blob/61652bcd4682d13bff7a17fcf6769753c1a29baf/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java#L87) .

I dub this process **Incremental Decompilation**.

## Benefit
99.9% of time is spent inside FernFlower decompiling classfiles. This means that decompiling 50% less classfiles means the process will be twice as fast. 
From yarn version 1.15.1+build.14 to 1.15.1+build.23 **only ~140 out of ~5000 classes need to be redecompiled. This is a speedup of 3500%.**  From version 1.15.1+build.23 to 1.15+build.1 only ~800 out of ~5000 need to be redcompiled. A modest speedup of 650%. 

## Possible issues
It's possible that quality of decompilation will go down as a result. However, I haven't observed any significant changes in output. 