### PR TITLE
Save yarn jars with original line mappings for incremental decompilation

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
@@ -30,25 +30,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
 
+import net.fabricmc.loom.task.*;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.tasks.TaskContainer;
 
 import net.fabricmc.loom.providers.MappingsProvider;
 import net.fabricmc.loom.providers.MinecraftLibraryProvider;
-import net.fabricmc.loom.task.AbstractDecompileTask;
-import net.fabricmc.loom.task.CleanLoomBinaries;
-import net.fabricmc.loom.task.CleanLoomMappings;
-import net.fabricmc.loom.task.DownloadAssetsTask;
-import net.fabricmc.loom.task.GenEclipseRunsTask;
-import net.fabricmc.loom.task.GenIdeaProjectTask;
-import net.fabricmc.loom.task.GenVsCodeProjectTask;
-import net.fabricmc.loom.task.MigrateMappingsTask;
-import net.fabricmc.loom.task.RemapJarTask;
-import net.fabricmc.loom.task.RemapLineNumbersTask;
-import net.fabricmc.loom.task.RemapSourcesJarTask;
-import net.fabricmc.loom.task.RunClientTask;
-import net.fabricmc.loom.task.RunServerTask;
 import net.fabricmc.loom.task.fernflower.FernFlowerTask;
 
 public class LoomGradlePlugin extends AbstractPlugin {
@@ -93,7 +81,7 @@ public class LoomGradlePlugin extends AbstractPlugin {
 			t.getOutputs().upToDateWhen((o) -> false);
 		});
 
-		tasks.register("genSources", t -> {
+		tasks.register("genSources", ApplyLinemappedJarTask.class, t -> {
 			t.getOutputs().upToDateWhen((o) -> false);
 			t.setGroup("fabric");
 		});
@@ -124,19 +112,6 @@ public class LoomGradlePlugin extends AbstractPlugin {
 			remapLineNumbersTask.setLineMapFile(linemapFile);
 			remapLineNumbersTask.setOutput(linemappedJar);
 
-			Path mappedJarPath = mappedJar.toPath();
-			Path linemappedJarPath = linemappedJar.toPath();
-
-			genSourcesTask.doLast((tt) -> {
-				if (Files.exists(linemappedJarPath)) {
-					try {
-						Files.deleteIfExists(mappedJarPath);
-						Files.copy(linemappedJarPath, mappedJarPath);
-					} catch (IOException e) {
-						throw new RuntimeException(e);
-					}
-				}
-			});
 		});
 
 		tasks.register("downloadAssets", DownloadAssetsTask.class);

--- a/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
@@ -112,6 +112,10 @@ public class LoomGradlePlugin extends AbstractPlugin {
 			remapLineNumbersTask.setLineMapFile(linemapFile);
 			remapLineNumbersTask.setOutput(linemappedJar);
 
+			ApplyLinemappedJarTask applyLinemappedJarTask = (ApplyLinemappedJarTask) p.getTasks().getByName("genSources");
+			applyLinemappedJarTask.setLinemappedJar(linemappedJar);
+			applyLinemappedJarTask.setMappedJar(mappedJar);
+
 		});
 
 		tasks.register("downloadAssets", DownloadAssetsTask.class);

--- a/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
@@ -25,18 +25,28 @@
 package net.fabricmc.loom;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Locale;
 
-import net.fabricmc.loom.task.*;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.tasks.TaskContainer;
 
 import net.fabricmc.loom.providers.MappingsProvider;
 import net.fabricmc.loom.providers.MinecraftLibraryProvider;
+import net.fabricmc.loom.task.AbstractDecompileTask;
+import net.fabricmc.loom.task.ApplyLinemappedJarTask;
+import net.fabricmc.loom.task.CleanLoomBinaries;
+import net.fabricmc.loom.task.CleanLoomMappings;
+import net.fabricmc.loom.task.DownloadAssetsTask;
+import net.fabricmc.loom.task.GenEclipseRunsTask;
+import net.fabricmc.loom.task.GenIdeaProjectTask;
+import net.fabricmc.loom.task.GenVsCodeProjectTask;
+import net.fabricmc.loom.task.MigrateMappingsTask;
+import net.fabricmc.loom.task.RemapJarTask;
+import net.fabricmc.loom.task.RemapLineNumbersTask;
+import net.fabricmc.loom.task.RemapSourcesJarTask;
+import net.fabricmc.loom.task.RunClientTask;
+import net.fabricmc.loom.task.RunServerTask;
 import net.fabricmc.loom.task.fernflower.FernFlowerTask;
 
 public class LoomGradlePlugin extends AbstractPlugin {
@@ -115,7 +125,6 @@ public class LoomGradlePlugin extends AbstractPlugin {
 			ApplyLinemappedJarTask applyLinemappedJarTask = (ApplyLinemappedJarTask) p.getTasks().getByName("genSources");
 			applyLinemappedJarTask.setLinemappedJar(linemappedJar);
 			applyLinemappedJarTask.setMappedJar(mappedJar);
-
 		});
 
 		tasks.register("downloadAssets", DownloadAssetsTask.class);

--- a/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
@@ -30,7 +30,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.util.Optional;
 
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;

--- a/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
@@ -1,15 +1,42 @@
-package net.fabricmc.loom.task;
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 
-import net.fabricmc.loom.LoomGradleExtension;
-import org.gradle.api.tasks.InputFile;
-import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.TaskAction;
+package net.fabricmc.loom.task;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Optional;
+
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+import net.fabricmc.loom.LoomGradleExtension;
 
 public class ApplyLinemappedJarTask extends AbstractLoomTask {
 	private Object mappedJar;
@@ -25,7 +52,6 @@ public class ApplyLinemappedJarTask extends AbstractLoomTask {
 		return getProject().file(linemappedJar);
 	}
 
-
 	public void setMappedJar(Object mappedJar) {
 		this.mappedJar = mappedJar;
 	}
@@ -34,10 +60,11 @@ public class ApplyLinemappedJarTask extends AbstractLoomTask {
 		this.linemappedJar = linemappedJar;
 	}
 
-	public static Path jarsBeforeLinemapping(LoomGradleExtension extension) {
-		return Paths.get(extension.getUserCache().getPath(), "jarsBeforeLinemapping");
+	public static Path jarsBeforeLinemapping(LoomGradleExtension extension) throws IOException {
+		Path path = Paths.get(extension.getUserCache().getPath(), "jarsBeforeLinemapping");
+		Files.createDirectories(path);
+		return path;
 	}
-
 
 	@TaskAction
 	public void run() {
@@ -47,15 +74,13 @@ public class ApplyLinemappedJarTask extends AbstractLoomTask {
 		if (Files.exists(linemappedJarPath)) {
 			try {
 				Files.createDirectories(jarsBeforeLinemapping(getExtension()));
+				Path notLinemappedJar = jarsBeforeLinemapping(getExtension()).resolve(mappedJarPath.getFileName());
 				// The original jars without the linemapping needs to be saved for incremental decompilation
-				Files.copy(mappedJarPath, jarsBeforeLinemapping(getExtension()).resolve(mappedJarPath.getFileName()));
-				Files.deleteIfExists(mappedJarPath);
-				Files.copy(linemappedJarPath, mappedJarPath);
+				if (!Files.exists(notLinemappedJar)) Files.copy(mappedJarPath, notLinemappedJar);
+				Files.copy(linemappedJarPath, mappedJarPath, StandardCopyOption.REPLACE_EXISTING);
 			} catch (IOException e) {
 				throw new RuntimeException(e);
 			}
 		}
 	}
-
-
 }

--- a/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
@@ -1,4 +1,60 @@
 package net.fabricmc.loom.task;
 
-public class ApplyLinemappedJarTask {
+import net.fabricmc.loom.LoomGradleExtension;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class ApplyLinemappedJarTask extends AbstractLoomTask {
+	private Object mappedJar;
+	private Object linemappedJar;
+
+	@InputFile
+	public File getMappedJar() {
+		return getProject().file(mappedJar);
+	}
+
+	@OutputFile
+	public File getLinemappedJar() {
+		return getProject().file(linemappedJar);
+	}
+
+
+	public void setMappedJar(Object mappedJar) {
+		this.mappedJar = mappedJar;
+	}
+
+	public void setLinemappedJar(Object linemappedJar) {
+		this.linemappedJar = linemappedJar;
+	}
+
+	public static Path jarsBeforeLinemapping(LoomGradleExtension extension) {
+		return Paths.get(extension.getUserCache().getPath(), "jarsBeforeLinemapping");
+	}
+
+
+	@TaskAction
+	public void run() {
+		Path mappedJarPath = getMappedJar().toPath();
+		Path linemappedJarPath = getLinemappedJar().toPath();
+
+		if (Files.exists(linemappedJarPath)) {
+			try {
+				// The original jars without the linemapping needs to be saved for incremental decompilation
+				Files.copy(mappedJarPath, jarsBeforeLinemapping(getExtension()));
+				Files.deleteIfExists(mappedJarPath);
+				Files.copy(linemappedJarPath, mappedJarPath);
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+
+
 }

--- a/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
@@ -1,0 +1,4 @@
+package net.fabricmc.loom.task;
+
+public class ApplyLinemappedJarTask {
+}

--- a/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ApplyLinemappedJarTask.java
@@ -46,8 +46,9 @@ public class ApplyLinemappedJarTask extends AbstractLoomTask {
 
 		if (Files.exists(linemappedJarPath)) {
 			try {
+				Files.createDirectories(jarsBeforeLinemapping(getExtension()));
 				// The original jars without the linemapping needs to be saved for incremental decompilation
-				Files.copy(mappedJarPath, jarsBeforeLinemapping(getExtension()));
+				Files.copy(mappedJarPath, jarsBeforeLinemapping(getExtension()).resolve(mappedJarPath.getFileName()));
 				Files.deleteIfExists(mappedJarPath);
 				Files.copy(linemappedJarPath, mappedJarPath);
 			} catch (IOException e) {


### PR DESCRIPTION
Part of #170, I've split up this part so we can merge this earlier, and then sources generated since this PR was merged will be able to be used once #170 is merged. 