### PR TITLE
Replace dots in artifact names when generating mod jsons for JIJ

### DIFF
--- a/src/main/java/net/fabricmc/loom/util/NestedJars.java
+++ b/src/main/java/net/fabricmc/loom/util/NestedJars.java
@@ -194,7 +194,7 @@ public class NestedJars {
 	private static String getMod(Dependency dependency) {
 		JsonObject jsonObject = new JsonObject();
 		jsonObject.addProperty("schemaVersion", 1);
-		jsonObject.addProperty("id", (dependency.getGroup().replaceAll("\\.", "_") + "_" + dependency.getName()).toLowerCase(Locale.ENGLISH));
+		jsonObject.addProperty("id", (dependency.getGroup() + "_" + dependency.getName()).replaceAll("\\.", "_").toLowerCase(Locale.ENGLISH));
 		jsonObject.addProperty("version", dependency.getVersion());
 		jsonObject.addProperty("name", dependency.getName());
 


### PR DESCRIPTION
This should fix using deps like `org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.0`.