### PR TITLE
Pretty-print the modified fabric.mod.json in ModResolver

### DIFF
--- a/src/main/java/net/fabricmc/loom/util/ModProcessor.java
+++ b/src/main/java/net/fabricmc/loom/util/ModProcessor.java
@@ -38,6 +38,7 @@ import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import org.apache.commons.io.IOUtils;
@@ -56,7 +57,7 @@ import net.fabricmc.tinyremapper.OutputConsumerPath;
 import net.fabricmc.tinyremapper.TinyRemapper;
 
 public class ModProcessor {
-	private static final Gson GSON = new Gson();
+	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 
 	public static void processMod(File input, File output, Project project, Configuration config, ResolvedArtifact artifact) throws IOException {
 		if (output.exists()) {


### PR DESCRIPTION
...Because this one didn't used to, and it's a lot nicer to read than if it's on a single line.

If there's any reason why this *isn't* wanted then I'd quite like to add a comment here, as it's probably going to annoy me again in the future :p