### PR TITLE
Use a custom dev time log4j config. Enables color output and improves overall logging.

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -60,7 +60,6 @@ public class LoomGradleExtension {
 	public boolean extractJars = false;
 	public String customManifest = null;
 	public File accessWidener = null;
-	public boolean forceAnsiConsole = false;
 	public Function<String, Object> intermediaryUrl = mcVer -> "https://maven.fabricmc.net/net/fabricmc/intermediary/" + mcVer + "/intermediary-" + mcVer + "-v2.jar";
 
 	private List<Path> unmappedModsBuilt = new ArrayList<>();

--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -60,6 +60,7 @@ public class LoomGradleExtension {
 	public boolean extractJars = false;
 	public String customManifest = null;
 	public File accessWidener = null;
+	public boolean forceAnsiConsole = false;
 	public Function<String, Object> intermediaryUrl = mcVer -> "https://maven.fabricmc.net/net/fabricmc/intermediary/" + mcVer + "/intermediary-" + mcVer + "-v2.jar";
 
 	private List<Path> unmappedModsBuilt = new ArrayList<>();

--- a/src/main/java/net/fabricmc/loom/providers/LaunchProvider.java
+++ b/src/main/java/net/fabricmc/loom/providers/LaunchProvider.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,8 +62,10 @@ public class LaunchProvider extends DependencyProvider {
 				.argument("client", "--assetsDir")
 				.argument("client", new File(getExtension().getUserCache(), "assets").getAbsolutePath());
 
-		//Enable ansi by default for none eclipse users
-		if (!(new File(getProject().getRootDir(), ".project").exists() || new File(getProject().getRootDir(), ".classpath").exists())) {
+		//Enable ansi by default for idea and vscode
+		if (new File(getProject().getRootDir(), ".vscode").exists()
+				|| new File(getProject().getRootDir(), ".idea").exists()
+				|| (Arrays.stream(getProject().getRootDir().listFiles()).anyMatch(file -> file.getName().endsWith(".iws")))) {
 			launchConfig.property("fabric.log.disableAnsi", "false");
 		}
 

--- a/src/main/java/net/fabricmc/loom/providers/LaunchProvider.java
+++ b/src/main/java/net/fabricmc/loom/providers/LaunchProvider.java
@@ -61,9 +61,9 @@ public class LaunchProvider extends DependencyProvider {
 				.argument("client", "--assetsDir")
 				.argument("client", new File(getExtension().getUserCache(), "assets").getAbsolutePath());
 
-		//Disable ansi color output for eclipse users
-		if (!getExtension().forceAnsiConsole && (new File(getProject().getRootDir(), ".project").exists() || new File(getProject().getRootDir(), ".classpath").exists())) {
-			launchConfig.property("fabric.log.disableAnsi", "true");
+		//Enable ansi by default for none eclipse users
+		if (!(new File(getProject().getRootDir(), ".project").exists() || new File(getProject().getRootDir(), ".classpath").exists())) {
+			launchConfig.property("fabric.log.disableAnsi", "false");
 		}
 
 		writeLog4jConfig();

--- a/src/main/java/net/fabricmc/loom/providers/LaunchProvider.java
+++ b/src/main/java/net/fabricmc/loom/providers/LaunchProvider.java
@@ -26,7 +26,9 @@ package net.fabricmc.loom.providers;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -49,6 +51,7 @@ public class LaunchProvider extends DependencyProvider {
 	public void provide(DependencyInfo dependency, Consumer<Runnable> postPopulationScheduler) throws IOException {
 		final LaunchConfig launchConfig = new LaunchConfig()
 				.property("fabric.development", "true")
+				.property("log4j.configurationFile", getLog4jConfigFile().getAbsolutePath())
 
 				.property("client", "java.library.path", getExtension().getNativesDirectory().getAbsolutePath())
 				.property("client", "org.lwjgl.librarypath", getExtension().getNativesDirectory().getAbsolutePath())
@@ -58,9 +61,29 @@ public class LaunchProvider extends DependencyProvider {
 				.argument("client", "--assetsDir")
 				.argument("client", new File(getExtension().getUserCache(), "assets").getAbsolutePath());
 
+		//Disable ansi color output for eclipse users
+		if (!getExtension().forceAnsiConsole && (new File(getProject().getRootDir(), ".project").exists() || new File(getProject().getRootDir(), ".classpath").exists())) {
+			launchConfig.property("fabric.log.disableAnsi", "true");
+		}
+
+		writeLog4jConfig();
 		FileUtils.writeStringToFile(getExtension().getDevLauncherConfig(), launchConfig.asString(), StandardCharsets.UTF_8);
 
 		addDependency("net.fabricmc:dev-launch-injector:" + Constants.DEV_LAUNCH_INJECTOR_VERSION, "runtimeOnly");
+		addDependency("net.minecrell:terminalconsoleappender:" + Constants.TERMINAL_CONSOLE_APPENDER_VERSION, "runtimeOnly");
+	}
+
+	private File getLog4jConfigFile() {
+		return new File(getExtension().getDevLauncherConfig().getParentFile(), "log4j.xml");
+	}
+
+	private void writeLog4jConfig() {
+		try (InputStream is = LaunchProvider.class.getClassLoader().getResourceAsStream("log4j2.fabric.xml")) {
+			Files.deleteIfExists(getLog4jConfigFile().toPath());
+			Files.copy(is, getLog4jConfigFile().toPath());
+		} catch (IOException e) {
+			throw new RuntimeException("Failed to generate log4j config", e);
+		}
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -56,4 +56,5 @@ public class Constants {
 
 	public static final String MIXIN_COMPILE_EXTENSIONS_VERSION = "0.3.0.4";
 	public static final String DEV_LAUNCH_INJECTOR_VERSION = "0.2.0+build.6";
+	public static final String TERMINAL_CONSOLE_APPENDER_VERSION = "1.2.0";
 }

--- a/src/main/resources/log4j2.fabric.xml
+++ b/src/main/resources/log4j2.fabric.xml
@@ -5,9 +5,9 @@
 		<!--	System out	-->
 		<Console name="SysOut" target="SYSTEM_OUT">
 			<PatternLayout>
-				<LoggerNamePatternSelector defaultPattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(%logger{1})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}" disableAnsi="${sys:fabric.log.disableAnsi:-false}">
+				<LoggerNamePatternSelector defaultPattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(%logger{1})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}" disableAnsi="${sys:fabric.log.disableAnsi:-true}">
 					<!-- Dont show the logger name for minecraft classes-->
-					<PatternMatch key="net.minecraft.,com.mojang." pattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(Minecraft)}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}" disableAnsi="${sys:fabric.log.disableAnsi:-false}"/>
+					<PatternMatch key="net.minecraft.,com.mojang." pattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(Minecraft)}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}" disableAnsi="${sys:fabric.log.disableAnsi:-true}"/>
 				</LoggerNamePatternSelector>
 			</PatternLayout>
 		</Console>

--- a/src/main/resources/log4j2.fabric.xml
+++ b/src/main/resources/log4j2.fabric.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" packages="com.mojang.util,net.minecrell.terminalconsole.util">
+	<Appenders>
+
+		<!--	System out	-->
+		<Console name="SysOut" target="SYSTEM_OUT">
+			<PatternLayout>
+				<LoggerNamePatternSelector defaultPattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(%logger{1})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}" disableAnsi="${sys:fabric.log.disableAnsi:-false}">
+					<!-- Dont show the logger name for minecraft classes-->
+					<PatternMatch key="net.minecraft.,com.mojang." pattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(Minecraft)}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}" disableAnsi="${sys:fabric.log.disableAnsi:-false}"/>
+				</LoggerNamePatternSelector>
+			</PatternLayout>
+		</Console>
+
+		<!--	Vanilla server gui	-->
+		<Queue name="ServerGuiConsole" ignoreExceptions="true">
+			<PatternLayout>
+				<LoggerNamePatternSelector defaultPattern="[%d{HH:mm:ss} %level] (%logger{1}) %msg%n">
+					<!-- Dont show the logger name for minecraft classes-->
+					<PatternMatch key="net.minecraft.,com.mojang." pattern="[%d{HH:mm:ss} %level] %msg%n"/>
+				</LoggerNamePatternSelector>
+			</PatternLayout>
+		</Queue>
+
+		<!--	latest.log same as vanilla	-->
+		<RollingRandomAccessFile name="LatestFile" fileName="logs/latest.log" filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz">
+			<PatternLayout>
+				<LoggerNamePatternSelector defaultPattern="[%d{HH:mm:ss}] [%t/%level] (%logger{1}) %msg%n">
+					<!-- Dont show the logger name for minecraft classes-->
+					<PatternMatch key="net.minecraft.,com.mojang." pattern="[%d{HH:mm:ss}] [%t/%level] (Minecraft) %msg%n"/>
+				</LoggerNamePatternSelector>
+			</PatternLayout>
+			<Policies>
+				<TimeBasedTriggeringPolicy />
+				<OnStartupTriggeringPolicy />
+			</Policies>
+		</RollingRandomAccessFile>
+
+		<!--	Debug log file	-->
+		<RollingRandomAccessFile name="DebugFile" fileName="logs/debug.log" filePattern="logs/debug-%i.log.gz">
+			<PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level] (%logger) %msg%n" />
+
+			<!--	Keep 5 files max	-->
+			<DefaultRolloverStrategy max="5" fileIndex="min"/>
+
+			<Policies>
+				<SizeBasedTriggeringPolicy size="500MB"/>
+				<OnStartupTriggeringPolicy />
+			</Policies>
+
+		</RollingRandomAccessFile>
+	</Appenders>
+	<Loggers>
+		<Logger level="${sys:fabric.log.level:-info}" name="net.minecraft"/>
+		<Root level="all">
+			<AppenderRef ref="DebugFile" level="${sys:fabric.log.debug.level:-debug}"/>
+			<AppenderRef ref="SysOut" level="${sys:fabric.log.level:-info}"/>
+			<AppenderRef ref="LatestFile" level="${sys:fabric.log.level:-info}"/>
+			<AppenderRef ref="ServerGuiConsole" level="${sys:fabric.log.level:-info}"/>
+		</Root>
+	</Loggers>
+</Configuration>


### PR DESCRIPTION
Color output is not enabled by default for eclipse users.

This is based off https://github.com/FabricMC/fabric-loader/pull/216 Another solution for runtime logging will be looked at.

Color output tested in vscode, idea, cmd and eclipse (disabled)