### PR TITLE
Eclipse project fixes

### DIFF
--- a/src/main/java/net/fabricmc/loom/AbstractPlugin.java
+++ b/src/main/java/net/fabricmc/loom/AbstractPlugin.java
@@ -275,6 +275,7 @@ public class AbstractPlugin implements Plugin<Project> {
 
 			project1.getTasks().getByName("idea").finalizedBy(project1.getTasks().getByName("genIdeaWorkspace"));
 			project1.getTasks().getByName("eclipse").finalizedBy(project1.getTasks().getByName("genEclipseRuns"));
+			project1.getTasks().getByName("cleanEclipse").finalizedBy(project1.getTasks().getByName("cleanEclipseRuns"));
 
 			if (extension.autoGenIDERuns && isRootProject(project1)) {
 				SetupIntelijRunConfigs.setup(project1);

--- a/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
@@ -37,6 +37,7 @@ import org.gradle.api.tasks.TaskContainer;
 import net.fabricmc.loom.providers.MappingsProvider;
 import net.fabricmc.loom.providers.MinecraftLibraryProvider;
 import net.fabricmc.loom.task.AbstractDecompileTask;
+import net.fabricmc.loom.task.CleanEclipseRunsTask;
 import net.fabricmc.loom.task.CleanLoomBinaries;
 import net.fabricmc.loom.task.CleanLoomMappings;
 import net.fabricmc.loom.task.DownloadAssetsTask;
@@ -148,6 +149,10 @@ public class LoomGradlePlugin extends AbstractPlugin {
 
 		tasks.register("genEclipseRuns", GenEclipseRunsTask.class, t -> {
 			t.dependsOn("downloadAssets");
+			t.setGroup("ide");
+		});
+
+		tasks.register("cleanEclipseRuns", CleanEclipseRunsTask.class, t -> {
 			t.setGroup("ide");
 		});
 

--- a/src/main/java/net/fabricmc/loom/task/CleanEclipseRunsTask.java
+++ b/src/main/java/net/fabricmc/loom/task/CleanEclipseRunsTask.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.plugins.ide.eclipse.model.EclipseModel;
+
+public class CleanEclipseRunsTask extends AbstractLoomTask {
+	@TaskAction
+	public void cleanRuns() throws IOException {
+		EclipseModel eclipseModel = getProject().getExtensions().getByType(EclipseModel.class);
+		File clientRunConfigs = new File(getProject().getRootDir(), eclipseModel.getProject().getName() + "_client.launch");
+		File serverRunConfigs = new File(getProject().getRootDir(), eclipseModel.getProject().getName() + "_server.launch");
+
+		if (clientRunConfigs.exists()) {
+			clientRunConfigs.delete();
+		}
+
+		if (serverRunConfigs.exists()) {
+			serverRunConfigs.delete();
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/GenEclipseRunsTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenEclipseRunsTask.java
@@ -30,14 +30,16 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.plugins.ide.eclipse.model.EclipseModel;
 
 import net.fabricmc.loom.util.RunConfig;
 
 public class GenEclipseRunsTask extends AbstractLoomTask {
 	@TaskAction
 	public void genRuns() throws IOException {
-		File clientRunConfigs = new File(getProject().getRootDir(), getProject().getName() + "_client.launch");
-		File serverRunConfigs = new File(getProject().getRootDir(), getProject().getName() + "_server.launch");
+		EclipseModel eclipseModel = getProject().getExtensions().getByType(EclipseModel.class);
+		File clientRunConfigs = new File(getProject().getRootDir(), eclipseModel.getProject().getName() + "_client.launch");
+		File serverRunConfigs = new File(getProject().getRootDir(), eclipseModel.getProject().getName() + "_server.launch");
 
 		String clientRunConfig = RunConfig.clientRunConfig(getProject()).fromDummy("eclipse_run_config_template.xml");
 		String serverRunConfig = RunConfig.serverRunConfig(getProject()).fromDummy("eclipse_run_config_template.xml");

--- a/src/main/java/net/fabricmc/loom/util/RunConfig.java
+++ b/src/main/java/net/fabricmc/loom/util/RunConfig.java
@@ -46,6 +46,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.gradle.api.Project;
+import org.gradle.plugins.ide.eclipse.model.EclipseModel;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.providers.MinecraftProvider;
@@ -95,7 +96,7 @@ public class RunConfig {
 	}
 
 	private static void populate(Project project, LoomGradleExtension extension, RunConfig runConfig, String mode) {
-		runConfig.projectName = project.getName();
+		runConfig.projectName = project.getExtensions().getByType(EclipseModel.class).getProject().getName();
 		runConfig.runDir = "file://$PROJECT_DIR$/" + extension.runDir;
 		runConfig.vmArgs = "";
 


### PR DESCRIPTION
* Delete the launch configs after `cleanEclipse` task (same as they are generated after `eclipse` task)
* Use the actual project name, if it's been overridden in `build.gradle`.