### PR TITLE
Update to use threaded fernflower

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
 
 	// decompilers
 	implementation ('net.fabricmc:procyon-fabric-compilertools:0.5.35.13')
-	implementation ('org.jetbrains:intellij-fernflower:1.1.0.11')
+	implementation ('org.jetbrains:intellij-fernflower:1.2.0')
 
 	// source code remapping
 	implementation ('org.cadixdev:mercury:0.1.0.fabric-SNAPSHOT')

--- a/src/main/java/net/fabricmc/loom/task/fernflower/FernFlowerTask.java
+++ b/src/main/java/net/fabricmc/loom/task/fernflower/FernFlowerTask.java
@@ -66,6 +66,7 @@ public class FernFlowerTask extends AbstractDecompileTask implements ForkingJava
 		options.put(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, "1");
 		options.put(IFernflowerPreferences.REMOVE_SYNTHETIC, "1");
 		options.put(IFernflowerPreferences.LOG_LEVEL, "trace");
+		options.put(IFernflowerPreferences.THREADS, getNumThreads());
 		getLogging().captureStandardOutput(LogLevel.LIFECYCLE);
 
 		List<String> args = new ArrayList<>();
@@ -78,7 +79,6 @@ public class FernFlowerTask extends AbstractDecompileTask implements ForkingJava
 			args.add("-l=" + getLineMapFile().getAbsolutePath());
 		}
 
-		args.add("-t=" + getNumThreads());
 		args.add("-m=" + getExtension().getMappingsProvider().tinyMappings.getAbsolutePath());
 
 		//TODO, Decompiler breaks on jemalloc, J9 module-info.class?

--- a/src/main/java/net/fabricmc/loom/task/fernflower/ForkedFFExecutor.java
+++ b/src/main/java/net/fabricmc/loom/task/fernflower/ForkedFFExecutor.java
@@ -53,7 +53,6 @@ public class ForkedFFExecutor {
 		File lineMap = null;
 		File mappings = null;
 		List<File> libraries = new ArrayList<>();
-		int numThreads = 0;
 
 		boolean isOption = true;
 
@@ -91,8 +90,6 @@ public class ForkedFFExecutor {
 					}
 
 					mappings = new File(arg.substring(3));
-				} else if (arg.startsWith("-t=")) {
-					numThreads = Integer.parseInt(arg.substring(3));
 				} else {
 					if (input != null) {
 						throw new RuntimeException("Unable to set more than one input.");

--- a/src/main/java/net/fabricmc/loom/task/fernflower/ThreadIDFFLogger.java
+++ b/src/main/java/net/fabricmc/loom/task/fernflower/ThreadIDFFLogger.java
@@ -92,15 +92,11 @@ public class ThreadIDFFLogger extends IFernflowerLogger {
 
 	@Override
 	public void startMethod(String methodName) {
-		String className = workingClass.get().peek();
-		line.get().push("Decompiling " + className + "." + methodName.substring(0, methodName.indexOf(" ")));
-		print();
+		//No need to print out methods
 	}
 
 	@Override
 	public void endMethod() {
-		line.get().pop();
-		print();
 	}
 
 	@Override


### PR DESCRIPTION
![](https://ss.modmuss50.me/2020-04-24_13-23-34.gif)

Requires: https://github.com/FabricMC/intellij-fernflower/pull/6

The max number of threads can be set in the build.gradle using the following:

```groovy
genSourcesDecompile {
	numThreads = 4
}
```

This may produce slighly diffrent results to source, however im not sure if this is cuased by running it multithreaded, or an existing issue in ff.

On my machine (i9-7900x) this shows a 10x decrease in decompile time.

A lot of the ground work for this was already in loom thanks to covers1624.