### PR TITLE
Update build version notations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,15 +13,15 @@ targetCompatibility = 1.8
 
 group = 'net.fabricmc'
 archivesBaseName = project.name
-version = '0.4'
+version = '0.4.3'
 
 def build = "local"
 def ENV = System.getenv()
 if (ENV.BUILD_NUMBER) {
 	build = "jenkins #${ENV.BUILD_NUMBER}"
-	version = version + "." + ENV.BUILD_NUMBER
+	version = version + "+build." + ENV.BUILD_NUMBER
 } else {
-	version = version + ".local"
+	version = version + "+build.local"
 }
 
 repositories {


### PR DESCRIPTION
The version numbers are definitely wrong here...
See https://maven.fabricmc.net/net/fabricmc/fabric-loom/ 's 0.4.1 and 0.4.2. Don't we reserve the third for minor bumps than for like each build?