### PR TITLE
Make the Minecraft dependency non-transitive to subprojects

### DIFF
--- a/src/main/java/net/fabricmc/loom/AbstractPlugin.java
+++ b/src/main/java/net/fabricmc/loom/AbstractPlugin.java
@@ -124,7 +124,8 @@ public class AbstractPlugin implements Plugin<Project> {
 			}
 		}
 
-		extendsFrom("compile", Constants.MINECRAFT_NAMED);
+		extendsFrom("compileClasspath", Constants.MINECRAFT_NAMED);
+		extendsFrom("runtimeClasspath", Constants.MINECRAFT_NAMED);
 
 		if (!extension.ideSync()) {
 			extendsFrom("annotationProcessor", Constants.MINECRAFT_NAMED);


### PR DESCRIPTION
Fixes #187. This is literally shorter than the workaround 😛 

Tested with FabLabs' `ScreenHandlers` and my Fabric API `ScreenHandler` PR by removing all of the workaround exclusions, and it seems to work fine.