### PR TITLE
Don't apply access widener remapping to other source sets by default

### DIFF
--- a/src/main/java/net/fabricmc/loom/AbstractPlugin.java
+++ b/src/main/java/net/fabricmc/loom/AbstractPlugin.java
@@ -295,6 +295,7 @@ public class AbstractPlugin implements Plugin<Project> {
 
 				extension.addUnmappedMod(jarTask.getArchivePath().toPath());
 				remapJarTask.getAddNestedDependencies().set(true);
+				remapJarTask.getRemapAccessWidener().set(true);
 
 				project1.getArtifacts().add("archives", remapJarTask);
 				remapJarTask.dependsOn(jarTask);

--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -100,6 +100,10 @@ public class LoomGradleExtension {
 		return installerJson;
 	}
 
+	public void accessWidener(Object file) {
+		this.accessWidener = project.file(file);
+	}
+
 	public File getUserCache() {
 		File userCache = new File(project.getGradle().getGradleUserHomeDir(), "caches" + File.separator + "fabric-loom");
 

--- a/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
@@ -53,11 +53,13 @@ import net.fabricmc.tinyremapper.TinyUtils;
 public class RemapJarTask extends Jar {
 	private RegularFileProperty input;
 	private Property<Boolean> addNestedDependencies;
+	private Property<Boolean> remapAccessWidener;
 
 	public RemapJarTask() {
 		super();
 		input = GradleSupport.getfileProperty(getProject());
 		addNestedDependencies = getProject().getObjects().property(Boolean.class);
+		remapAccessWidener = getProject().getObjects().property(Boolean.class);
 	}
 
 	@TaskAction
@@ -129,7 +131,7 @@ public class RemapJarTask extends Jar {
 			}
 		}
 
-		if (extension.accessWidener != null) {
+		if (getRemapAccessWidener().getOrElse(false) && extension.accessWidener != null) {
 			extension.getJarProcessorManager().getByType(AccessWidenerJarProcessor.class).remapAccessWidener(output);
 		}
 
@@ -153,5 +155,10 @@ public class RemapJarTask extends Jar {
 	@Input
 	public Property<Boolean> getAddNestedDependencies() {
 		return addNestedDependencies;
+	}
+
+	@Input
+	public Property<Boolean> getRemapAccessWidener() {
+		return remapAccessWidener;
 	}
 }

--- a/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
@@ -60,6 +60,8 @@ public class RemapJarTask extends Jar {
 		input = GradleSupport.getfileProperty(getProject());
 		addNestedDependencies = getProject().getObjects().property(Boolean.class);
 		remapAccessWidener = getProject().getObjects().property(Boolean.class);
+		// false by default, I have no idea why I have to do it for this property and not the other one
+		remapAccessWidener.set(false);
 	}
 
 	@TaskAction


### PR DESCRIPTION
A temporary fix, before we expand to allow for multiple access wideners per project.
Also allows a nicer syntax for specifying access wideners:
```groovy
minecraft {
    accessWidener 'src/main/resources/modid.accesswidener'
}
```