### PR TITLE
Don't remapJar when running runClient or runServer

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
@@ -164,7 +164,7 @@ public class LoomGradlePlugin extends AbstractPlugin {
 		tasks.register("remapSourcesJar", RemapSourcesJarTask.class);
 
 		tasks.register("runClient", RunClientTask.class, t -> {
-			t.dependsOn("assemble", "downloadAssets");
+			t.dependsOn("classes", "downloadAssets");
 			t.setGroup("minecraftMapped");
 		});
 

--- a/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
@@ -164,12 +164,12 @@ public class LoomGradlePlugin extends AbstractPlugin {
 		tasks.register("remapSourcesJar", RemapSourcesJarTask.class);
 
 		tasks.register("runClient", RunClientTask.class, t -> {
-			t.dependsOn("classes", "downloadAssets");
+			t.dependsOn("jar", "downloadAssets");
 			t.setGroup("minecraftMapped");
 		});
 
 		tasks.register("runServer", RunServerTask.class, t -> {
-			t.dependsOn("classes");
+			t.dependsOn("jar");
 			t.setGroup("minecraftMapped");
 		});
 	}

--- a/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
@@ -169,7 +169,7 @@ public class LoomGradlePlugin extends AbstractPlugin {
 		});
 
 		tasks.register("runServer", RunServerTask.class, t -> {
-			t.dependsOn("assemble");
+			t.dependsOn("classes");
 			t.setGroup("minecraftMapped");
 		});
 	}


### PR DESCRIPTION
This saves about a second in a hello world project, probably a lot more in bigger projects.
Task graphs for reference:
![image](https://user-images.githubusercontent.com/25990014/81619426-42c81900-93f2-11ea-9c5e-6fd0299eea29.png)

Please discuss.