### PR TITLE
Supply the configuration to the run Exec directly

### DIFF
--- a/src/main/java/net/fabricmc/loom/AbstractPlugin.java
+++ b/src/main/java/net/fabricmc/loom/AbstractPlugin.java
@@ -49,12 +49,14 @@ import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.plugins.ide.idea.model.IdeaModel;
 
 import net.fabricmc.loom.providers.LaunchProvider;
+import net.fabricmc.loom.providers.MappingsCache;
 import net.fabricmc.loom.providers.MappingsProvider;
 import net.fabricmc.loom.providers.MinecraftProvider;
-import net.fabricmc.loom.providers.MappingsCache;
 import net.fabricmc.loom.task.RemapJarTask;
 import net.fabricmc.loom.task.RemapSourcesJarTask;
 import net.fabricmc.loom.util.Constants;
+import net.fabricmc.loom.util.DownloadUtil;
+import net.fabricmc.loom.util.FabricApiExtension;
 import net.fabricmc.loom.util.GroovyXmlUtil;
 import net.fabricmc.loom.util.LoomDependencyManager;
 import net.fabricmc.loom.util.NestedJars;
@@ -63,8 +65,6 @@ import net.fabricmc.loom.util.SetupIntelijRunConfigs;
 import net.fabricmc.loom.util.mixin.JavaApInvoker;
 import net.fabricmc.loom.util.mixin.KaptApInvoker;
 import net.fabricmc.loom.util.mixin.ScalaApInvoker;
-import net.fabricmc.loom.util.FabricApiExtension;
-import net.fabricmc.loom.util.DownloadUtil;
 
 public class AbstractPlugin implements Plugin<Project> {
 	protected Project project;
@@ -247,7 +247,7 @@ public class AbstractPlugin implements Plugin<Project> {
 					remapJarTask.getInput().set(jarTask.getArchivePath());
 				}
 
-				extension.addUnmappedMod(jarTask.getArchivePath().toPath());
+				extension.getUnmappedModCollection().from(jarTask);
 				remapJarTask.getAddNestedDependencies().set(true);
 				remapJarTask.getRemapAccessWidener().set(true);
 
@@ -282,7 +282,7 @@ public class AbstractPlugin implements Plugin<Project> {
 				}
 			} else {
 				AbstractArchiveTask jarTask = (AbstractArchiveTask) project1.getTasks().getByName("jar");
-				extension.addUnmappedMod(jarTask.getArchivePath().toPath());
+				extension.getUnmappedModCollection().from(jarTask);
 			}
 
 			project.getLogger().lifecycle("Configuring compiler arguments for Java");

--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -28,12 +28,12 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -43,6 +43,7 @@ import org.cadixdev.mercury.Mercury;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.plugins.BasePluginConvention;
 
 import net.fabricmc.loom.api.decompilers.LoomDecompiler;
@@ -62,12 +63,12 @@ public class LoomGradleExtension {
 	public File accessWidener = null;
 	public Function<String, Object> intermediaryUrl = mcVer -> "https://maven.fabricmc.net/net/fabricmc/intermediary/" + mcVer + "/intermediary-" + mcVer + "-v2.jar";
 
-	private List<Path> unmappedModsBuilt = new ArrayList<>();
+	private final ConfigurableFileCollection unmappedMods;
 
 	final List<LoomDecompiler> decompilers = new ArrayList<>();
 
 	//Not to be set in the build.gradle
-	private Project project;
+	private final Project project;
 	private LoomDependencyManager dependencyManager;
 	private JarProcessorManager jarProcessorManager;
 	private JsonObject installerJson;
@@ -92,14 +93,30 @@ public class LoomGradleExtension {
 
 	public LoomGradleExtension(Project project) {
 		this.project = project;
+		this.unmappedMods = project.files();
 	}
 
+	/**
+	 * @see ConfigurableFileCollection#from(Object...)
+	 * @deprecated use {@link #getUnmappedModCollection()}{@code .from()} instead
+	 */
+	@Deprecated
 	public void addUnmappedMod(Path file) {
-		unmappedModsBuilt.add(file);
+		getUnmappedModCollection().from(file);
 	}
 
+	/**
+	 * @deprecated use {@link #getUnmappedModCollection()} instead
+	 */
+	@Deprecated
 	public List<Path> getUnmappedMods() {
-		return Collections.unmodifiableList(unmappedModsBuilt);
+		return unmappedMods.getFiles().stream()
+			.map(File::toPath)
+			.collect(Collectors.toList());
+	}
+
+	public ConfigurableFileCollection getUnmappedModCollection() {
+		return unmappedMods;
 	}
 
 	public void setInstallerJson(JsonObject object) {

--- a/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
@@ -116,13 +116,12 @@ public class LoomGradlePlugin extends AbstractPlugin {
 
 		tasks.register("runClient", RunClientTask.class, t -> {
 			t.setDescription("Starts a development version of the Minecraft client.");
-			t.dependsOn("jar", "downloadAssets");
+			t.dependsOn("downloadAssets");
 			t.setGroup("fabric");
 		});
 
 		tasks.register("runServer", RunServerTask.class, t -> {
 			t.setDescription("Starts a development version of the Minecraft server.");
-			t.dependsOn("jar");
 			t.setGroup("fabric");
 		});
 

--- a/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
@@ -37,8 +37,6 @@ import org.gradle.api.Project;
 import org.gradle.api.tasks.JavaExec;
 
 import net.fabricmc.loom.LoomGradleExtension;
-import net.fabricmc.loom.providers.MappingsProvider;
-import net.fabricmc.loom.util.MinecraftVersionInfo;
 import net.fabricmc.loom.util.RunConfig;
 
 public abstract class AbstractRunTask extends JavaExec {
@@ -58,22 +56,15 @@ public abstract class AbstractRunTask extends JavaExec {
 		}
 
 		LoomGradleExtension extension = this.getProject().getExtensions().getByType(LoomGradleExtension.class);
-		MinecraftVersionInfo minecraftVersionInfo = extension.getMinecraftProvider().getVersionInfo();
-		MappingsProvider mappingsProvider = extension.getMappingsProvider();
 
-		List<String> libs = new ArrayList<>();
-
-		for (File file : getProject().getConfigurations().getByName("runtimeClasspath").getFiles()) {
-			libs.add(file.getAbsolutePath());
-		}
+		classpath(getProject().getConfigurations().getByName("runtimeClasspath"));
 
 		for (Path file : extension.getUnmappedMods()) {
 			if (Files.isRegularFile(file)) {
-				libs.add(file.toFile().getAbsolutePath());
+				classpath(file);
 			}
 		}
 
-		classpath(libs);
 		List<String> argsSplit = new ArrayList<>();
 		String[] args = config.programArgs.split(" ");
 		int partPos = -1;
@@ -136,7 +127,6 @@ public abstract class AbstractRunTask extends JavaExec {
 			config = configProvider.apply(getProject());
 		}
 
-		LoomGradleExtension extension = this.getProject().getExtensions().getByType(LoomGradleExtension.class);
 		List<String> superArgs = super.getJvmArgs();
 		List<String> args = new ArrayList<>(superArgs != null ? superArgs : Collections.emptyList());
 		args.addAll(Arrays.asList(config.vmArgs.split(" ")));

--- a/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
@@ -25,8 +25,6 @@
 package net.fabricmc.loom.task;
 
 import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,22 +45,15 @@ public abstract class AbstractRunTask extends JavaExec {
 		super();
 		setGroup("fabric");
 		this.configProvider = config;
+
+		classpath(getProject().getConfigurations().getByName("runtimeClasspath"));
+		classpath(this.getProject().getExtensions().getByType(LoomGradleExtension.class).getUnmappedModCollection());
 	}
 
 	@Override
 	public void exec() {
 		if (config == null) {
 			config = configProvider.apply(getProject());
-		}
-
-		LoomGradleExtension extension = this.getProject().getExtensions().getByType(LoomGradleExtension.class);
-
-		classpath(getProject().getConfigurations().getByName("runtimeClasspath"));
-
-		for (Path file : extension.getUnmappedMods()) {
-			if (Files.isRegularFile(file)) {
-				classpath(file);
-			}
 		}
 
 		List<String> argsSplit = new ArrayList<>();
@@ -94,6 +85,7 @@ public abstract class AbstractRunTask extends JavaExec {
 		}
 
 		args(argsSplit);
+		LoomGradleExtension extension = this.getProject().getExtensions().getByType(LoomGradleExtension.class);
 		setWorkingDir(new File(getProject().getRootDir(), extension.runDir));
 
 		super.exec();

--- a/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
+++ b/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
@@ -165,9 +165,11 @@ public class SourceRemapper {
 		Mercury mercury = extension.getOrCreateSrcMercuryCache(toNamed ? 1 : 0, () -> {
 			Mercury m = createMercuryWithClassPath(project, toNamed);
 
-			for (Path file : extension.getUnmappedMods()) {
-				if (Files.isRegularFile(file)) {
-					m.getClassPath().add(file);
+			for (File file : extension.getUnmappedModCollection()) {
+				Path path = file.toPath();
+
+				if (Files.isRegularFile(path)) {
+					m.getClassPath().add(path);
 				}
 			}
 


### PR DESCRIPTION
This allows the implicit task dependencies from project() dependencies to flow into the run tasks.

For example, if you did `implementation(project("worldedit-core"))`, it would not build `worldedit-core.jar`, despite using it on the classpath. Gradle tracks this information, so using the Configuration directly also adds the `worldedit-core:jar` task as a dependency. This also allows us to remove the dependency on the `jar` task.