### PR TITLE
Allow IDEA run configs to be generated for non-root projects

### DIFF
--- a/src/main/java/net/fabricmc/loom/AbstractPlugin.java
+++ b/src/main/java/net/fabricmc/loom/AbstractPlugin.java
@@ -230,7 +230,7 @@ public class AbstractPlugin implements Plugin<Project> {
 			project1.getTasks().getByName("eclipse").finalizedBy(project1.getTasks().getByName("genEclipseRuns"));
 			project1.getTasks().getByName("cleanEclipse").finalizedBy(project1.getTasks().getByName("cleanEclipseRuns"));
 
-			if (extension.autoGenIDERuns && isRootProject(project1)) {
+			if (extension.autoGenIDERuns) {
 				SetupIntelijRunConfigs.setup(project1);
 			}
 

--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -223,7 +223,7 @@ public class LoomGradleExtension {
 	}
 
 	public File getDevLauncherConfig() {
-		return new File(getRootProjectPersistentCache(), "launch.cfg");
+		return new File(getProjectPersistentCache(), "launch.cfg");
 	}
 
 	@Nullable

--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -58,7 +58,7 @@ public class LoomGradleExtension {
 	public String refmapName;
 	public String loaderLaunchMethod;
 	public boolean remapMod = true;
-	public boolean autoGenIDERuns = true;
+	public boolean autoGenIDERuns;
 	public String customManifest = null;
 	public File accessWidener = null;
 	public Function<String, Object> intermediaryUrl = mcVer -> "https://maven.fabricmc.net/net/fabricmc/intermediary/" + mcVer + "/intermediary-" + mcVer + "-v2.jar";
@@ -93,6 +93,7 @@ public class LoomGradleExtension {
 
 	public LoomGradleExtension(Project project) {
 		this.project = project;
+		this.autoGenIDERuns = AbstractPlugin.isRootProject(project);
 		this.unmappedMods = project.files();
 	}
 

--- a/src/main/java/net/fabricmc/loom/util/RunConfig.java
+++ b/src/main/java/net/fabricmc/loom/util/RunConfig.java
@@ -24,6 +24,8 @@
 
 package net.fabricmc.loom.util;
 
+import static net.fabricmc.loom.AbstractPlugin.isRootProject;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -107,6 +109,7 @@ public class RunConfig {
 	}
 
 	private static void populate(Project project, LoomGradleExtension extension, RunConfig runConfig, String mode) {
+		runConfig.configName += isRootProject(project) ? "" : " (" + project.getPath() + ")";
 		runConfig.eclipseProjectName = project.getExtensions().getByType(EclipseModel.class).getProject().getName();
 		runConfig.ideaModuleName = getIdeaModuleName(project);
 		runConfig.runDir = "file://$PROJECT_DIR$/" + extension.runDir;
@@ -160,8 +163,8 @@ public class RunConfig {
 		MinecraftVersionInfo minecraftVersionInfo = minecraftProvider.getVersionInfo();
 
 		RunConfig ideaClient = new RunConfig();
-		populate(project, extension, ideaClient, "client");
 		ideaClient.configName = "Minecraft Client";
+		populate(project, extension, ideaClient, "client");
 		ideaClient.vmArgs += getOSClientJVMArgs();
 		ideaClient.vmArgs += " -Dfabric.dli.main=" + getMainClass("client", extension);
 
@@ -172,8 +175,8 @@ public class RunConfig {
 		LoomGradleExtension extension = project.getExtensions().getByType(LoomGradleExtension.class);
 
 		RunConfig ideaServer = new RunConfig();
-		populate(project, extension, ideaServer, "server");
 		ideaServer.configName = "Minecraft Server";
+		populate(project, extension, ideaServer, "server");
 		ideaServer.vmArgs += " -Dfabric.dli.main=" + getMainClass("server", extension);
 
 		return ideaServer;

--- a/src/main/java/net/fabricmc/loom/util/RunConfig.java
+++ b/src/main/java/net/fabricmc/loom/util/RunConfig.java
@@ -53,7 +53,8 @@ import net.fabricmc.loom.providers.MinecraftProvider;
 
 public class RunConfig {
 	public String configName;
-	public String projectName;
+	public String eclipseProjectName;
+	public String ideaModuleName;
 	public String mainClass;
 	public String runDir;
 	public String vmArgs;
@@ -63,7 +64,7 @@ public class RunConfig {
 		Element root = this.addXml(doc, "component", ImmutableMap.of("name", "ProjectRunConfigurationManager"));
 		root = addXml(root, "configuration", ImmutableMap.of("default", "false", "name", configName, "type", "Application", "factoryName", "Application"));
 
-		this.addXml(root, "module", ImmutableMap.of("name", projectName));
+		this.addXml(root, "module", ImmutableMap.of("name", ideaModuleName));
 		this.addXml(root, "option", ImmutableMap.of("name", "MAIN_CLASS_NAME", "value", mainClass));
 		this.addXml(root, "option", ImmutableMap.of("name", "WORKING_DIRECTORY", "value", runDir));
 
@@ -95,8 +96,19 @@ public class RunConfig {
 		return e;
 	}
 
+	private static String getIdeaModuleName(Project project) {
+		String module = project.getName() + ".main";
+
+		while ((project = project.getParent()) != null) {
+			module = project.getName() + "." + module;
+		}
+
+		return module;
+	}
+
 	private static void populate(Project project, LoomGradleExtension extension, RunConfig runConfig, String mode) {
-		runConfig.projectName = project.getExtensions().getByType(EclipseModel.class).getProject().getName();
+		runConfig.eclipseProjectName = project.getExtensions().getByType(EclipseModel.class).getProject().getName();
+		runConfig.ideaModuleName = getIdeaModuleName(project);
 		runConfig.runDir = "file://$PROJECT_DIR$/" + extension.runDir;
 		runConfig.vmArgs = "";
 
@@ -182,7 +194,8 @@ public class RunConfig {
 
 		dummyConfig = dummyConfig.replace("%NAME%", configName);
 		dummyConfig = dummyConfig.replace("%MAIN_CLASS%", mainClass);
-		dummyConfig = dummyConfig.replace("%MODULE%", projectName);
+		dummyConfig = dummyConfig.replace("%ECLIPSE_PROJECT%", eclipseProjectName);
+		dummyConfig = dummyConfig.replace("%IDEA_MODULE%", ideaModuleName);
 		dummyConfig = dummyConfig.replace("%PROGRAM_ARGS%", programArgs.replaceAll("\"", "&quot;"));
 		dummyConfig = dummyConfig.replace("%VM_ARGS%", vmArgs.replaceAll("\"", "&quot;"));
 

--- a/src/main/java/net/fabricmc/loom/util/SetupIntelijRunConfigs.java
+++ b/src/main/java/net/fabricmc/loom/util/SetupIntelijRunConfigs.java
@@ -39,7 +39,7 @@ public class SetupIntelijRunConfigs {
 	public static void setup(Project project) {
 		LoomGradleExtension extension = project.getExtensions().getByType(LoomGradleExtension.class);
 
-		File projectDir = project.file(".idea");
+		File projectDir = project.getRootProject().file(".idea");
 
 		if (!projectDir.exists()) {
 			return;
@@ -59,6 +59,7 @@ public class SetupIntelijRunConfigs {
 	}
 
 	private static void generate(Project project) throws IOException {
+		Project rootProject = project.getRootProject();
 		LoomGradleExtension extension = project.getExtensions().getByType(LoomGradleExtension.class);
 
 		if (extension.ideSync()) {
@@ -67,10 +68,12 @@ public class SetupIntelijRunConfigs {
 			MinecraftNativesProvider.provide(extension.getMinecraftProvider(), project);
 		}
 
-		File projectDir = project.file(".idea");
+		String projectPath = project == rootProject ? "" : project.getPath().replace(':', '_');
+
+		File projectDir = rootProject.file(".idea");
 		File runConfigsDir = new File(projectDir, "runConfigurations");
-		File clientRunConfigs = new File(runConfigsDir, "Minecraft_Client.xml");
-		File serverRunConfigs = new File(runConfigsDir, "Minecraft_Server.xml");
+		File clientRunConfigs = new File(runConfigsDir, "Minecraft_Client" + projectPath + ".xml");
+		File serverRunConfigs = new File(runConfigsDir, "Minecraft_Server" + projectPath + ".xml");
 
 		if (!runConfigsDir.exists()) {
 			runConfigsDir.mkdirs();

--- a/src/main/resources/eclipse_run_config_template.xml
+++ b/src/main/resources/eclipse_run_config_template.xml
@@ -10,7 +10,7 @@
     <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.buildship.core.classpathprovider"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="%MAIN_CLASS%"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="%PROGRAM_ARGS%"/>
-    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="%MODULE%"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="%ECLIPSE_PROJECT%"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="%VM_ARGS%"/>
     <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${project_loc:%MODULE%}/run"/>
 </launchConfiguration>

--- a/src/main/resources/idea_run_config_template.xml
+++ b/src/main/resources/idea_run_config_template.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="%NAME%" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="%MAIN_CLASS%" />
-    <module name="%MODULE%.main" />
+    <module name="%IDEA_MODULE%" />
     <option name="PROGRAM_PARAMETERS" value="%PROGRAM_ARGS%" />
     <option name="VM_PARAMETERS" value="%VM_ARGS%" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/run/" />


### PR DESCRIPTION
See individual commits.

Default behavior should be almost unchanged, only difference being that `autoGenIDERuns` now defaults to `false` for subprojects (for backwards compat) and only when it's set to `true`, will run configs be generated (as opposed to before where they were never generated).