### PR TITLE
Filter non-existent directories out of the Mercury classpath

### DIFF
--- a/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
+++ b/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
@@ -36,6 +36,7 @@ import org.cadixdev.lorenz.MappingSet;
 import org.cadixdev.mercury.Mercury;
 import org.cadixdev.mercury.remapper.MercuryRemapper;
 import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
 import org.zeroturnaround.zip.ZipUtil;
 
 import net.fabricmc.loom.LoomGradleExtension;
@@ -203,17 +204,23 @@ public class SourceRemapper {
 		Mercury m = new Mercury();
 
 		for (File file : project.getConfigurations().getByName(Constants.Configurations.MINECRAFT_DEPENDENCIES).getFiles()) {
-			m.getClassPath().add(file.toPath());
+			if (file.exists()) {
+				m.getClassPath().add(file.toPath());
+			}
 		}
 
 		if (!toNamed) {
-			for (File file : project.getConfigurations().getByName("compileClasspath").getFiles()) {
-				m.getClassPath().add(file.toPath());
+			for (File file : project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME).getFiles()) {
+				if (file.exists()) {
+					m.getClassPath().add(file.toPath());
+				}
 			}
 		} else {
 			for (RemappedConfigurationEntry entry : Constants.MOD_COMPILE_ENTRIES) {
 				for (File inputFile : project.getConfigurations().getByName(entry.getSourceConfiguration()).getFiles()) {
-					m.getClassPath().add(inputFile.toPath());
+					if (inputFile.exists()) {
+						m.getClassPath().add(inputFile.toPath());
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes CadixDev/Mercury#29

This issue was triggered by some of my customizations to loom settings that create separate source sets for mixins and accessors, and add those to the classpath. JDT will not accept classpath entries that don't exist and throws an error, while what's standard for most Gradle tasks is to ignore such classpath entries.

This change makes sure directories exist before they're added to the Mercury classpath. From testing on one of my affected project, this change appears to resolve the issue. However, I am unsure how this would react in a situation where the `Mercury` instance has been created (from `LoomGradleExtension#getOrCreateSrcMappingCache`), but some classpath entries are only created later. Is such a situation even possible?