### PR TITLE
workaround for duplicate client modules

### DIFF
--- a/src/main/java/net/fabricmc/loom/processors/dependency/ModDependencyInfo.java
+++ b/src/main/java/net/fabricmc/loom/processors/dependency/ModDependencyInfo.java
@@ -90,7 +90,7 @@ public class ModDependencyInfo {
 
 	@Override
 	public String toString() {
-		return String.format("%s:%s:%s:%s", group, name, version, classifier);
+		return String.format("%s:%s:%s%s", group, name, version, classifier);
 	}
 
 	public String getAccessWidener() throws IOException {

--- a/src/main/java/net/fabricmc/loom/processors/dependency/ModDependencyInfo.java
+++ b/src/main/java/net/fabricmc/loom/processors/dependency/ModDependencyInfo.java
@@ -61,11 +61,11 @@ public class ModDependencyInfo {
 	}
 
 	public String getRemappedNotation() {
-		return String.format("%s:%s:%s@%s%s", group, name, version, remapData.mappingsSuffix, classifier);
+		return String.format("%s:%s%s:%s@%s", group, name, classifier.replace(':', '-'), version, remapData.mappingsSuffix);
 	}
 
 	public String getRemappedFilename() {
-		return String.format("%s-%s@%s", name, version, remapData.mappingsSuffix + classifier.replace(':', '-'));
+		return String.format("%s%s-%s@%s", name, classifier.replace(':', '-'), version, remapData.mappingsSuffix);
 	}
 
 	public File getRemappedOutput() {


### PR DESCRIPTION
This PR fixes an issue with IDEA's Gradle integration throwing an error for duplicate client modules when refreshing.
It does so by moving the classifier into the artifact ID, effectively deduplicating the module.

Example Error message:
```
<ij_msg_gr>Dependency graph model errors<ij_msg_gr><ij_nav>D:\Workspace\fabric\Epicurean\build.gradle<ij_nav><i><b>root project 'Epicurean'</b><eol>Details: org.gradle.api.artifacts.ResolveException: Could not resolve all dependencies for configuration ':compileClasspath'.<eol>Caused by: org.gradle.api.InvalidUserDataException: io.github.GlassPane:Mesh:0.1.0-alpha.1@net.fabricmc.yarn.1_16_2_rc1.1.16.2-rc1+build.6-v2 has more than one client module definitions.</i>
```

_**Note:** This opens up a rare edge case issue incase the artifact ID + classifier combination of one dependency is equivalent to the artifact ID of another dependency with the same group, however I think this is negligible._

---

The PR also fixes a small oversight in `ModDependencyInfo#toString()`: the classifier string already contains a colon, so without this fix the result of toString() for artifacts with classifier would be `group:artifact:version::classifier` (two colons before the classifier)



