### PR TITLE
fix build number not being expanded to proper value

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ def baseVersion = '0.5'
 def build = 'local'
 def ENV = System.getenv()
 if (ENV.BUILD_NUMBER) {
-	build = 'jenkins #${ENV.BUILD_NUMBER}'
+	build = "jenkins #${ENV.BUILD_NUMBER}"
 	version = baseVersion + '.' + ENV.BUILD_NUMBER
 } else {
 	version = baseVersion + '.local'


### PR DESCRIPTION
convert String to GString so that the value is interpolated properly
(Bug was introduced in https://github.com/FabricMC/fabric-loom/commit/1955bcb2eac52c3b71c689756b0b8e2b94c1d0dc when converting all GStrings to Strings in `build.gradle` file.)