### PR TITLE
Include exclusions in the poms generated for mods

### DIFF
--- a/src/main/java/net/fabricmc/loom/AbstractPlugin.java
+++ b/src/main/java/net/fabricmc/loom/AbstractPlugin.java
@@ -38,6 +38,8 @@ import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ExcludeRule;
+import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
@@ -397,6 +399,20 @@ public class AbstractPlugin implements Plugin<Project> {
 										depNode.appendNode("artifactId", dependency.getName());
 										depNode.appendNode("version", dependency.getVersion());
 										depNode.appendNode("scope", entry.getMavenScope());
+
+										if (dependency instanceof ModuleDependency) {
+											final Set<ExcludeRule> exclusions = ((ModuleDependency) dependency).getExcludeRules();
+
+											if (!exclusions.isEmpty()) {
+												Node exclusionsNode = depNode.appendNode("exclusions");
+
+												for (ExcludeRule rule : exclusions) {
+													Node exclusionNode = exclusionsNode.appendNode("exclusion");
+													exclusionNode.appendNode("groupId", rule.getGroup() == null ? "*" : rule.getGroup());
+													exclusionNode.appendNode("artifactId", rule.getModule() == null ? "*" : rule.getModule());
+												}
+											}
+										}
 									}
 								}));
 							}


### PR DESCRIPTION
As it says in the title -- for dependencies that loom takes over generation of, correctly include any transitive dependency exclusions that may be specified.

Longer-term I'd love to see loom not need to manually inject dependencies, but looking at gradle it seems like this could only properly happen if Loom went to using dependency transforms, and projects published the `java` `SoftwareComponent` rather than the individual artifacts they currently do.

An alternative longer-term implementation could use gradle internal API to create a loom-specific SoftwareComponent [to match gradle's JavaPlugin](https://github.com/gradle/gradle/blob/c47b67d46d38dfa42b009b45b6fbd52f74a29b65/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java#L367), but that would require gradle 5 and would need some wrangling to avoid using internal API. I *think* this approach would also require changes for mod developers doing publication.