### PR TITLE
Allow specification of namespaces to use in RemapJarTask

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
@@ -205,11 +205,11 @@ public class RemapJarTask extends Jar {
 
 		// Validate the namespaces are supported in the tiny tree
 		if (!namespaces.contains(fromM)) {
-			RemapJarTask.throwMissingNamespaceException(project, fromM, namespaces);
+			throwMissingNamespaceException(project, fromM, namespaces);
 		}
 
 		if (!namespaces.contains(toM)) {
-			RemapJarTask.throwMissingNamespaceException(project, toM, namespaces);
+			throwMissingNamespaceException(project, toM, namespaces);
 		}
 
 		if (extension.isRootProject()) {

--- a/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
@@ -108,11 +108,11 @@ public class RemapJarTask extends Jar {
 
 		// Validate the namespaces are supported in the tiny tree the namespaces are supported in the tiny tree
 		if (!namespaces.contains(fromM)) {
-			RemapJarTask.throwMissingNamespaceException(project, fromM, namespaces);
+			throwMissingNamespaceException(project, fromM, namespaces);
 		}
 
 		if (!namespaces.contains(toM)) {
-			RemapJarTask.throwMissingNamespaceException(project, toM, namespaces);
+			throwMissingNamespaceException(project, toM, namespaces);
 		}
 
 		Set<File> classpathFiles = new LinkedHashSet<>(

--- a/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
@@ -154,7 +154,7 @@ public class RemapJarTask extends Jar {
 		}
 
 		if (getRemapAccessWidener().getOrElse(false) && extension.accessWidener != null) {
-			extension.getJarProcessorManager().getByType(AccessWidenerJarProcessor.class).remapAccessWidener(output, remapper.getRemapper());
+			extension.getJarProcessorManager().getByType(AccessWidenerJarProcessor.class).remapAccessWidener(output, remapper.getRemapper(), toM);
 		}
 
 		remapper.finish();
@@ -241,7 +241,7 @@ public class RemapJarTask extends Jar {
 						byte[] data;
 
 						try {
-							data = accessWidenerJarProcessor.getRemappedAccessWidener(remapper);
+							data = accessWidenerJarProcessor.getRemappedAccessWidener(remapper, toM);
 						} catch (IOException e) {
 							throw new RuntimeException("Failed to remap access widener");
 						}

--- a/src/main/java/net/fabricmc/loom/util/accesswidener/AccessWidenerJarProcessor.java
+++ b/src/main/java/net/fabricmc/loom/util/accesswidener/AccessWidenerJarProcessor.java
@@ -126,8 +126,8 @@ public class AccessWidenerJarProcessor implements JarProcessor {
 	}
 
 	//Called when remapping the mod
-	public void remapAccessWidener(Path modJarPath, Remapper asmRemapper) throws IOException {
-		byte[] bytes = getRemappedAccessWidener(asmRemapper);
+	public void remapAccessWidener(Path modJarPath, Remapper asmRemapper, String toM) throws IOException {
+		byte[] bytes = getRemappedAccessWidener(asmRemapper, toM);
 
 		String path = getAccessWidenerPath(modJarPath);
 
@@ -142,8 +142,8 @@ public class AccessWidenerJarProcessor implements JarProcessor {
 		}
 	}
 
-	public byte[] getRemappedAccessWidener(Remapper asmRemapper) throws IOException {
-		AccessWidenerRemapper remapper = new AccessWidenerRemapper(accessWidener, asmRemapper, "intermediary");
+	public byte[] getRemappedAccessWidener(Remapper asmRemapper, String toM) throws IOException {
+		AccessWidenerRemapper remapper = new AccessWidenerRemapper(accessWidener, asmRemapper, toM);
 		AccessWidener remapped = remapper.remap();
 
 		try (StringWriter writer = new StringWriter()) {


### PR DESCRIPTION
This is a draft since setting `toM` as `official` has mapping conflicts, this is probably out of our control tbh.

But for the future this may have additional use for exporting to other mapping sets (such as mojmap) in the future.