### PR TITLE
Mark auto-generated mods with a custom value

### DIFF
--- a/src/main/java/net/fabricmc/loom/util/NestedJars.java
+++ b/src/main/java/net/fabricmc/loom/util/NestedJars.java
@@ -212,7 +212,7 @@ public class NestedJars {
 		jsonObject.addProperty("name", dependency.getModuleName());
 
 		JsonObject custom = new JsonObject();
-		custom.addProperty("modmenu:api", true);
+		custom.addProperty("fabric-loom:generated", true);
 		jsonObject.add("custom", custom);
 
 		return GSON.toJson(jsonObject);

--- a/src/main/java/net/fabricmc/loom/util/NestedJars.java
+++ b/src/main/java/net/fabricmc/loom/util/NestedJars.java
@@ -211,6 +211,10 @@ public class NestedJars {
 		jsonObject.addProperty("version", dependency.getModuleVersion());
 		jsonObject.addProperty("name", dependency.getModuleName());
 
+		JsonObject custom = new JsonObject();
+		custom.addProperty("modmenu:api", true);
+		jsonObject.add("custom", custom);
+
 		return GSON.toJson(jsonObject);
 	}
 


### PR DESCRIPTION
Make the barebones `fabric.mod.json` generated for non-mod dependencies an API for ModMenu purposes to prevent mods with a large number of dependencies from cluttering the menu.