### PR TITLE
Add ability to configure a separate testmod source set

### DIFF
--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -63,6 +63,13 @@ public class Constants {
 		}
 	}
 
+	public static final class SourceSets {
+		public static final String TEST_MOD = "testmod";
+
+		private SourceSets() {
+		}
+	}
+
 	/**
 	 * Constants related to dependencies.
 	 */

--- a/src/main/java/net/fabricmc/loom/util/RunConfig.java
+++ b/src/main/java/net/fabricmc/loom/util/RunConfig.java
@@ -41,6 +41,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.gradle.api.tasks.SourceSet;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -94,8 +95,8 @@ public class RunConfig {
 		return e;
 	}
 
-	private static String getIdeaModuleName(Project project) {
-		String module = project.getName() + ".main";
+	private static String getIdeaModuleName(Project project, String sourceSet) {
+		String module = project.getName() + "." + sourceSet;
 
 		while ((project = project.getParent()) != null) {
 			module = project.getName() + "." + module;
@@ -104,10 +105,10 @@ public class RunConfig {
 		return module;
 	}
 
-	private static void populate(Project project, LoomGradleExtension extension, RunConfig runConfig, String mode) {
+	private static void populate(Project project, LoomGradleExtension extension, RunConfig runConfig, String mode, String sourceSet) {
 		runConfig.configName += isRootProject(project) ? "" : " (" + project.getPath() + ")";
 		runConfig.eclipseProjectName = project.getExtensions().getByType(EclipseModel.class).getProject().getName();
-		runConfig.ideaModuleName = getIdeaModuleName(project);
+		runConfig.ideaModuleName = getIdeaModuleName(project, sourceSet);
 		runConfig.runDir = "file://$PROJECT_DIR$/" + extension.runDir;
 		runConfig.vmArgs = "";
 
@@ -155,7 +156,7 @@ public class RunConfig {
 
 		RunConfig ideaClient = new RunConfig();
 		ideaClient.configName = "Minecraft Client";
-		populate(project, extension, ideaClient, "client");
+		populate(project, extension, ideaClient, "client", extension.isUsingTestmod() ? Constants.SourceSets.TEST_MOD : SourceSet.MAIN_SOURCE_SET_NAME);
 		ideaClient.vmArgs += getOSClientJVMArgs();
 		ideaClient.vmArgs += " -Dfabric.dli.main=" + getMainClass("client", extension);
 
@@ -167,7 +168,7 @@ public class RunConfig {
 
 		RunConfig ideaServer = new RunConfig();
 		ideaServer.configName = "Minecraft Server";
-		populate(project, extension, ideaServer, "server");
+		populate(project, extension, ideaServer, "server", extension.isUsingTestmod() ? Constants.SourceSets.TEST_MOD : SourceSet.MAIN_SOURCE_SET_NAME);
 		ideaServer.vmArgs += " -Dfabric.dli.main=" + getMainClass("server", extension);
 
 		return ideaServer;


### PR DESCRIPTION
This is a common build element in library mods, including fabric API. The test mod is designed for easily testing functionality at dev time.

A modified version of the example mod that uses this functionality is [available here](https://github.com/FabricMC/fabric-example-mod/compare/master...zml2008:feature/testmod)

This is based on the configurations that [myself](https://github.com/zml2008/gradle-plugins/blob/73d5db701471201c1ae5a6048e6b6cc6ce2f4bbd/opinionated-fabric/src/main/kotlin/ca/stellardrift/build/fabric/OpinionatedFabric.kt#L56) and [i509](https://github.com/i509VCB/Escalate/blob/master/escalate-fabric/src/main/kotlin/me/i509/build/fabric/EscalateFabricExtension.kt#L72) have done for our own mods. The main addition here is the beginnings of support for producing a remapped jar for testmods. This is also the part that is currently incomplete.

The main blocker for remapped jars is properly configuring the Mixin annotation processor to generate different refmaps per source set. Currently the same refmap is written to for each compile task, so when creating a production jar one of the main or testmod jars will be invalid. This will involve deprecating and replacing the `refmapName` field on LoomGradleExtension, and figuring out a way to link compile tasks with remap tasks. Perhaps the AP invokers should get a bit of a redesign...

One other limitation that will be complicated to resolve is testmod-specific dependencies and JiJ. To avoid that, `Constants.MOD_COMPILE_ENTRIES` would have to be replaced with something that dynamically creates the `mod*` configurations for new source sets. However, most testmods don't need their own dependencies, so that can be kicked down the road a bit.

testmod-specific access wideners are also not supported, and would need further refactoring to support. I don't think it's worth the effort, since that substantial of a test mod probably warrants a subproject.