### PR TITLE
eclipse: Fix run configuration generation

### DIFF
--- a/src/main/resources/eclipse_run_config_template.xml
+++ b/src/main/resources/eclipse_run_config_template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-        <listEntry value="/%MODULE%"/>
+        <listEntry value="/%ECLIPSE_PROJECT%"/>
     </listAttribute>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="4"/>
@@ -12,5 +12,5 @@
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="%PROGRAM_ARGS%"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="%ECLIPSE_PROJECT%"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="%VM_ARGS%"/>
-    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${project_loc:%MODULE%}/run"/>
+    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:%ECLIPSE_PROJECT%}/run"/>
 </launchConfiguration>


### PR DESCRIPTION
Fixes #283

Main issue here is it looks like someone changed the placeholders the run config generator uses without updating the template.

I've also changed to `workspace_loc` rather than `project_loc` -- which may make no difference, but may make things more reliable if eclipse deselects the project associated with the run config somehow.