### PR TITLE
Move to using gradle's standard plugin id conventions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,8 +106,12 @@ checkstyleMain {
 
 gradlePlugin {
 	plugins {
-		fabricLoom {
+		fabricLoomLegacy {
 			id = 'fabric-loom'
+			implementationClass = 'net.fabricmc.loom.LegacyLoomPlugin'
+		}
+		fabricLoom {
+			id = 'net.fabricmc.gradle.loom'
 			implementationClass = 'net.fabricmc.loom.LoomGradlePlugin'
 		}
 	}

--- a/src/main/java/net/fabricmc/loom/LegacyLoomPlugin.java
+++ b/src/main/java/net/fabricmc/loom/LegacyLoomPlugin.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package net.fabricmc.loom;
 
 import org.gradle.api.Plugin;

--- a/src/main/java/net/fabricmc/loom/LegacyLoomPlugin.java
+++ b/src/main/java/net/fabricmc/loom/LegacyLoomPlugin.java
@@ -1,0 +1,17 @@
+package net.fabricmc.loom;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+public final class LegacyLoomPlugin implements Plugin<Project> {
+	@Override
+	public void apply(Project project) {
+		project.getLogger().warn(String.format("Project \"%s\" is using the legacy plugin id for loom.", project.getName()));
+		project.getLogger().warn("The plugin id should change from `fabric-loom` to `net.fabricmc.gradle.loom`");
+		project.getLogger().warn("For Groovy DSL, change `id \"fabric-loom\"` to `id \"net.fabricmc.gradle.loom\"`");
+		project.getLogger().warn("For Kotlin DSL, change `id(\"fabric-loom\")` to `id(\"net.fabricmc.gradle.loom\")`");
+
+		// Apply new plugin
+		project.getPlugins().apply("net.fabricmc.gradle.loom");
+	}
+}


### PR DESCRIPTION
This adds a dummy plugin to continue allowing use of the old plugin id which applies a plugin under the new id.

I do not believe this publishes correctly so that will need a look