### PR TITLE
Refactor and fix game/loader library handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 
 	// decompilers
 	implementation ('net.fabricmc:procyon-fabric-compilertools:0.5.35.13')
-	implementation ('org.jetbrains:intellij-fernflower:1.2.1.16')
+	implementation ('net.fabricmc:fabric-fernflower:1.3.0')
 	implementation ('org.benf:cfr:0.150')
 
 	// source code remapping

--- a/src/main/java/net/fabricmc/loom/AbstractPlugin.java
+++ b/src/main/java/net/fabricmc/loom/AbstractPlugin.java
@@ -119,6 +119,8 @@ public class AbstractPlugin implements Plugin<Project> {
 		minecraftNamedConfig.setTransitive(false); // The launchers do not recurse dependencies
 		Configuration minecraftDependenciesConfig = project.getConfigurations().maybeCreate(Constants.Configurations.MINECRAFT_DEPENDENCIES);
 		minecraftDependenciesConfig.setTransitive(false);
+		Configuration loaderDependenciesConfig = project.getConfigurations().maybeCreate(Constants.Configurations.LOADER_DEPENDENCIES);
+		loaderDependenciesConfig.setTransitive(false);
 		Configuration minecraftConfig = project.getConfigurations().maybeCreate(Constants.Configurations.MINECRAFT);
 		minecraftConfig.setTransitive(false);
 
@@ -147,7 +149,8 @@ public class AbstractPlugin implements Plugin<Project> {
 		extendsFrom("testCompileClasspath", Constants.Configurations.MINECRAFT_NAMED);
 		extendsFrom("testRuntimeClasspath", Constants.Configurations.MINECRAFT_NAMED);
 
-		extendsFrom(Constants.Configurations.MINECRAFT_NAMED, Constants.Configurations.MINECRAFT_DEPENDENCIES);
+		extendsFrom(Constants.Configurations.LOADER_DEPENDENCIES, Constants.Configurations.MINECRAFT_DEPENDENCIES);
+		extendsFrom(Constants.Configurations.MINECRAFT_NAMED, Constants.Configurations.LOADER_DEPENDENCIES);
 
 		extendsFrom("compile", Constants.Configurations.MAPPINGS_FINAL);
 

--- a/src/main/java/net/fabricmc/loom/providers/LaunchProvider.java
+++ b/src/main/java/net/fabricmc/loom/providers/LaunchProvider.java
@@ -104,7 +104,7 @@ public class LaunchProvider extends DependencyProvider {
 
 	private void writeRemapClassPath() {
 		List<String> inputConfigurations = new ArrayList<>();
-		inputConfigurations.add(Constants.Configurations.MINECRAFT_DEPENDENCIES);
+		inputConfigurations.add(Constants.Configurations.LOADER_DEPENDENCIES);
 		inputConfigurations.addAll(Constants.MOD_COMPILE_ENTRIES.stream().map(RemappedConfigurationEntry::getSourceConfiguration).collect(Collectors.toList()));
 
 		List<File> remapClasspath = new ArrayList<>();

--- a/src/main/java/net/fabricmc/loom/providers/MinecraftLibraryProvider.java
+++ b/src/main/java/net/fabricmc/loom/providers/MinecraftLibraryProvider.java
@@ -25,8 +25,6 @@
 package net.fabricmc.loom.providers;
 
 import java.io.File;
-import java.util.Collection;
-import java.util.HashSet;
 
 import org.gradle.api.Project;
 
@@ -36,8 +34,6 @@ import net.fabricmc.loom.util.MinecraftVersionInfo;
 
 public class MinecraftLibraryProvider {
 	public File MINECRAFT_LIBS;
-
-	private final Collection<File> libs = new HashSet<>();
 
 	public void provide(MinecraftProvider minecraftProvider, Project project) {
 		MinecraftVersionInfo versionInfo = minecraftProvider.getVersionInfo();
@@ -58,10 +54,6 @@ public class MinecraftLibraryProvider {
 				project.getDependencies().add(Constants.Configurations.MINECRAFT_DEPENDENCIES, project.getDependencies().module(library.getArtifactName()));
 			}
 		}
-	}
-
-	public Collection<File> getLibraries() {
-		return libs;
 	}
 
 	private void initFiles(Project project, MinecraftProvider minecraftProvider) {

--- a/src/main/java/net/fabricmc/loom/providers/MinecraftMappedProvider.java
+++ b/src/main/java/net/fabricmc/loom/providers/MinecraftMappedProvider.java
@@ -28,7 +28,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -135,7 +134,8 @@ public class MinecraftMappedProvider extends DependencyProvider {
 	}
 
 	public Path[] getRemapClasspath() {
-		return getMapperPaths().stream().map(File::toPath).toArray(Path[]::new);
+		return getProject().getConfigurations().getByName(Constants.Configurations.MINECRAFT_DEPENDENCIES).getFiles()
+				.stream().map(File::toPath).toArray(Path[]::new);
 	}
 
 	protected void addDependencies(DependencyInfo dependency, Consumer<Runnable> postPopulationScheduler) {
@@ -157,10 +157,6 @@ public class MinecraftMappedProvider extends DependencyProvider {
 
 	protected String getJarVersionString(String type) {
 		return String.format("%s-%s-%s-%s", minecraftProvider.getMinecraftVersion(), type, getExtension().getMappingsProvider().mappingsName, getExtension().getMappingsProvider().mappingsVersion);
-	}
-
-	public Collection<File> getMapperPaths() {
-		return minecraftProvider.getLibraryProvider().getLibraries();
 	}
 
 	public File getIntermediaryJar() {

--- a/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
@@ -36,6 +36,7 @@ import javax.inject.Inject;
 
 import org.gradle.api.tasks.TaskAction;
 
+import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.LoomGradlePlugin;
 import net.fabricmc.loom.api.decompilers.DecompilationMetadata;
 import net.fabricmc.loom.api.decompilers.LoomDecompiler;
@@ -58,7 +59,7 @@ public class GenerateSourcesTask extends AbstractLoomTask {
 	public void doTask() throws Throwable {
 		int threads = Runtime.getRuntime().availableProcessors();
 		Path javaDocs = getExtension().getMappingsProvider().tinyMappings.toPath();
-		Collection<Path> libraries = getExtension().getMinecraftProvider().getLibraryProvider().getLibraries()
+		Collection<Path> libraries = getProject().getConfigurations().getByName(Constants.Configurations.MINECRAFT_DEPENDENCIES).getFiles()
 						.stream().map(File::toPath).collect(Collectors.toSet());
 
 		DecompilationMetadata metadata = new DecompilationMetadata(threads, javaDocs, libraries);

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -55,9 +55,11 @@ public class Constants {
 		public static final String INCLUDE = "include";
 		public static final String MINECRAFT = "minecraft";
 		public static final String MINECRAFT_DEPENDENCIES = "minecraftLibraries";
+		public static final String MINECRAFT_REMAP_CLASSPATH = "minecraftRemapClasspath";
 		public static final String MINECRAFT_NAMED = "minecraftNamed";
 		public static final String MAPPINGS = "mappings";
 		public static final String MAPPINGS_FINAL = "mappingsFinal";
+		public static final String LOADER_DEPENDENCIES = "loaderLibraries";
 
 		private Configurations() {
 		}

--- a/src/main/java/net/fabricmc/loom/util/LoomDependencyManager.java
+++ b/src/main/java/net/fabricmc/loom/util/LoomDependencyManager.java
@@ -134,8 +134,6 @@ public class LoomDependencyManager {
 		SourceRemapper sourceRemapper = new SourceRemapper(project, true);
 		String mappingsKey = mappingsProvider.mappingsName + "." + mappingsProvider.minecraftVersion.replace(' ', '_').replace('.', '_').replace('-', '_') + "." + mappingsProvider.mappingsVersion;
 
-		ModCompileRemapper.remapDependencies(project, mappingsKey, extension, sourceRemapper);
-
 		if (extension.getInstallerJson() == null) {
 			//If we've not found the installer JSON we've probably skipped remapping Fabric loader, let's go looking
 			project.getLogger().info("Searching through modCompileClasspath for installer JSON");
@@ -152,15 +150,16 @@ public class LoomDependencyManager {
 
 					project.getLogger().info("Found installer JSON in " + input);
 					extension.setInstallerJson(jsonObject);
+					handleInstallerJson(extension.getInstallerJson(), project);
 				}
 			}
 		}
 
-		if (extension.getInstallerJson() != null) {
-			handleInstallerJson(extension.getInstallerJson(), project);
-		} else {
+		if (extension.getInstallerJson() == null) {
 			project.getLogger().warn("fabric-installer.json not found in classpath!");
 		}
+
+		ModCompileRemapper.remapDependencies(project, mappingsKey, extension, sourceRemapper);
 
 		sourceRemapper.remapAll();
 
@@ -173,7 +172,7 @@ public class LoomDependencyManager {
 		LoomGradleExtension extension = project.getExtensions().getByType(LoomGradleExtension.class);
 
 		JsonObject libraries = jsonObject.get("libraries").getAsJsonObject();
-		Configuration mcDepsConfig = project.getConfigurations().getByName(Constants.Configurations.MINECRAFT_DEPENDENCIES);
+		Configuration loaderDepsConfig = project.getConfigurations().getByName(Constants.Configurations.LOADER_DEPENDENCIES);
 		Configuration apDepsConfig = project.getConfigurations().getByName("annotationProcessor");
 
 		libraries.get("common").getAsJsonArray().forEach(jsonElement -> {
@@ -181,7 +180,7 @@ public class LoomDependencyManager {
 
 			ExternalModuleDependency modDep = (ExternalModuleDependency) project.getDependencies().create(name);
 			modDep.setTransitive(false);
-			mcDepsConfig.getDependencies().add(modDep);
+			loaderDepsConfig.getDependencies().add(modDep);
 
 			if (!extension.ideSync()) {
 				apDepsConfig.getDependencies().add(modDep);

--- a/src/main/java/net/fabricmc/loom/util/ModProcessor.java
+++ b/src/main/java/net/fabricmc/loom/util/ModProcessor.java
@@ -132,7 +132,8 @@ public class ModProcessor {
 		MappingsProvider mappingsProvider = extension.getMappingsProvider();
 
 		Path mc = mappedProvider.getIntermediaryJar().toPath();
-		Path[] mcDeps = mappedProvider.getMapperPaths().stream().map(File::toPath).toArray(Path[]::new);
+		Path[] mcDeps = project.getConfigurations().getByName(Constants.Configurations.LOADER_DEPENDENCIES).getFiles()
+							.stream().map(File::toPath).toArray(Path[]::new);
 
 		List<ModDependencyInfo> remapList = processList.stream().filter(ModDependencyInfo::requiresRemapping).collect(Collectors.toList());
 

--- a/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
+++ b/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
@@ -213,7 +213,7 @@ public class SourceRemapper {
 	public static Mercury createMercuryWithClassPath(Project project, boolean toNamed) {
 		Mercury m = new Mercury();
 
-		for (File file : project.getConfigurations().getByName(Constants.Configurations.MINECRAFT_DEPENDENCIES).getFiles()) {
+		for (File file : project.getConfigurations().getByName(Constants.Configurations.LOADER_DEPENDENCIES).getFiles()) {
 			m.getClassPath().add(file.toPath());
 		}
 


### PR DESCRIPTION
The game libraries were never getting passed to tiny remapper when remapping the mc jars, or to fernflower when decompling.

This PR fixes that, as a result the loader libraries needed to be moved to their own configuration.

The fernflower update includes a handful of upstream changes, and an upstream PR fixing https://youtrack.jetbrains.com/issue/IDEA-245329