### PR TITLE
Configure build task dependencies as each subproject comes up.

### DIFF
--- a/src/main/java/net/fabricmc/loom/AbstractPlugin.java
+++ b/src/main/java/net/fabricmc/loom/AbstractPlugin.java
@@ -304,17 +304,15 @@ public class AbstractPlugin implements Plugin<Project> {
 								}
 							});
 						});
-
-						for (Project subProject : rootProject.getAllprojects()) {
-							subProject.getTasks().getByName("build").dependsOn(parentTask);
-							subProject.getTasks().getByName("build").dependsOn(rootProject.getTasks().getByName("remapAllJars"));
-							rootProject.getTasks().getByName("remapAllJars").dependsOn(subProject.getTasks().getByName("remapJar"));
-						}
 					} else {
 						parentTask = rootProject.getTasks().getByName("remapAllSources");
 						remapper = ((RemapAllSourcesTask) parentTask).sourceRemapper;
 
 						remapJarTask.jarRemapper = ((RemapJarTask) rootProject.getTasks().getByName("remapJar")).jarRemapper;
+
+						project1.getTasks().getByName("build").dependsOn(parentTask);
+						project1.getTasks().getByName("build").dependsOn(rootProject.getTasks().getByName("remapAllJars"));
+						rootProject.getTasks().getByName("remapAllJars").dependsOn(project1.getTasks().getByName("remapJar"));
 					}
 				}
 


### PR DESCRIPTION
Arguably this makes more sense (and allows for subprojects that don't use loom), and it also fixes an issue I was running into with a subproject configuration where the build task for the subprojects didn't exist yet.

I did also quickly test with a regular subproject setup (i.e. what fabric-api uses). granted, i haven't actually tested the output jars.