### PR TITLE
Move remapped mods into a full local maven repo

### DIFF
--- a/src/main/java/net/fabricmc/loom/AbstractPlugin.java
+++ b/src/main/java/net/fabricmc/loom/AbstractPlugin.java
@@ -207,9 +207,9 @@ public class AbstractPlugin implements Plugin<Project> {
 				flatDirectoryArtifactRepository.setName("UserLocalCacheFiles");
 			});
 
-			project1.getRepositories().flatDir(flatDirectoryArtifactRepository -> {
-				flatDirectoryArtifactRepository.dir(extension.getRemappedModCache());
-				flatDirectoryArtifactRepository.setName("UserLocalRemappedMods");
+			project1.getRepositories().maven(mavenArtifactRepository -> {
+				mavenArtifactRepository.setUrl(extension.getRemappedModCache());
+				mavenArtifactRepository.setName("UserLocalRemappedMods");
 			});
 
 			project1.getRepositories().maven(mavenArtifactRepository -> {

--- a/src/main/java/net/fabricmc/loom/providers/MappingsProvider.java
+++ b/src/main/java/net/fabricmc/loom/providers/MappingsProvider.java
@@ -331,4 +331,8 @@ public class MappingsProvider extends DependencyProvider {
 
 		return intermediaryTiny;
 	}
+
+	public String getMappingsKey() {
+		return mappingsName + "." + minecraftVersion.replace(' ', '_').replace('.', '_').replace('-', '_') + "." + mappingsVersion;
+	}
 }

--- a/src/main/java/net/fabricmc/loom/util/LoomDependencyManager.java
+++ b/src/main/java/net/fabricmc/loom/util/LoomDependencyManager.java
@@ -54,7 +54,7 @@ public class LoomDependencyManager {
 
 	private final List<DependencyProvider> dependencyProviderList = new ArrayList<>();
 
-	public void addProvider(DependencyProvider provider) {
+	public <T extends DependencyProvider> T addProvider(T provider) {
 		if (dependencyProviderList.contains(provider)) {
 			throw new RuntimeException("Provider is already registered");
 		}
@@ -65,6 +65,7 @@ public class LoomDependencyManager {
 
 		provider.register(this);
 		dependencyProviderList.add(provider);
+		return provider;
 	}
 
 	public <T> T getProvider(Class<T> clazz) {
@@ -132,7 +133,7 @@ public class LoomDependencyManager {
 		}
 
 		SourceRemapper sourceRemapper = new SourceRemapper(project, true);
-		String mappingsKey = mappingsProvider.mappingsName + "." + mappingsProvider.minecraftVersion.replace(' ', '_').replace('.', '_').replace('-', '_') + "." + mappingsProvider.mappingsVersion;
+		String mappingsKey = mappingsProvider.getMappingsKey();
 
 		ModCompileRemapper.remapDependencies(project, mappingsKey, extension, sourceRemapper);
 

--- a/src/main/java/net/fabricmc/loom/util/ModCompileRemapper.java
+++ b/src/main/java/net/fabricmc/loom/util/ModCompileRemapper.java
@@ -92,7 +92,7 @@ public class ModCompileRemapper {
 				project.getLogger().info(":providing " + remappedLog);
 
 				if (sources != null) {
-					scheduleSourcesRemapping(project, sourceRemapper, info.sourcesFile, info.getRemappedNotation(), info.getRemappedFilename(), modStore);
+					scheduleSourcesRemapping(project, sourceRemapper, info.sourcesFile, info.getRemappedNotation(), info.getRemappedOutput(), modStore);
 				}
 			}
 
@@ -156,10 +156,10 @@ public class ModCompileRemapper {
 		return null;
 	}
 
-	private static void scheduleSourcesRemapping(Project project, SourceRemapper sourceRemapper, File sources, String remappedLog, String remappedFilename, File modStore) {
+	private static void scheduleSourcesRemapping(Project project, SourceRemapper sourceRemapper, File sources, String remappedLog, File remappedJar, File modStore) {
 		project.getLogger().debug(":providing " + remappedLog + " sources");
 
-		File remappedSources = new File(modStore, remappedFilename + "-sources.jar");
+		File remappedSources = new File(remappedJar.getAbsolutePath().replace(".jar", "-sources.jar"));
 		boolean refreshDeps = project.getGradle().getStartParameter().isRefreshDependencies();
 
 		if (!remappedSources.exists() || sources.lastModified() <= 0 || sources.lastModified() > remappedSources.lastModified() || refreshDeps) {

--- a/src/main/java/net/fabricmc/loom/util/ModProcessor.java
+++ b/src/main/java/net/fabricmc/loom/util/ModProcessor.java
@@ -192,6 +192,8 @@ public class ModProcessor {
 			if (accessWidener != null) {
 				ZipUtil.replaceEntry(info.getRemappedOutput(), info.getAccessWidener(), accessWidener);
 			}
+
+			info.finaliseRemapping();
 		}
 	}
 

--- a/src/main/resources/mod_compile_template.pom
+++ b/src/main/resources/mod_compile_template.pom
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>%GROUP%</groupId>
+	<artifactId>%NAME%</artifactId>
+	<version>%VERSION%</version>
+</project>


### PR DESCRIPTION
This vastly improves idea auto attaching sources.

I had hoped I would have been able to keep the full maven group + name + version the same, and use https://docs.gradle.org/5.1/userguide/declaring_repositories.html#sec::matching_repositories_to_dependencies to ensure that the remapped dep was selected in oreder to fix composite builds. I failed to get any noticeable action from this.

Here is the reflection I did to allow this to build on older gradle's: https://gist.github.com/modmuss50/78ff650abc7182aae26cc4798e6b806b

I think fixing composite builds needs further work, as it would be awesome to fix.

This PR should be a drop in upgrade, it will just remap the mods after the upgrade, needs some more testing before it should be merged.