### PR TITLE
Inject stitch annotations as a Minecraft dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 	implementation ('com.google.guava:guava:28.0-jre')
 
 	// game handling utils
-	implementation ('net.fabricmc:stitch:0.4.6+build.74') {
+	implementation ('net.fabricmc:stitch:0.5.1+local') {
 		exclude module: 'enigma'
 	}
 

--- a/src/main/java/net/fabricmc/loom/providers/LaunchProvider.java
+++ b/src/main/java/net/fabricmc/loom/providers/LaunchProvider.java
@@ -32,8 +32,10 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.StringJoiner;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -46,8 +48,10 @@ import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.DependencyProvider;
 import net.fabricmc.loom.util.RemappedConfigurationEntry;
 
+import org.gradle.api.plugins.JavaPlugin;
+
 public class LaunchProvider extends DependencyProvider {
-	public Dependency annotationDependency;
+	public final Set<Dependency> annotationDependencies = new HashSet<>();
 
 	public LaunchProvider(Project project) {
 		super(project);
@@ -78,9 +82,10 @@ public class LaunchProvider extends DependencyProvider {
 		writeLog4jConfig();
 		FileUtils.writeStringToFile(getExtension().getDevLauncherConfig(), launchConfig.asString(), StandardCharsets.UTF_8);
 
-		addDependency(Constants.Dependencies.DEV_LAUNCH_INJECTOR + Constants.Dependencies.Versions.DEV_LAUNCH_INJECTOR, "runtimeOnly");
-		addDependency(Constants.Dependencies.TERMINAL_CONSOLE_APPENDER + Constants.Dependencies.Versions.TERMINAL_CONSOLE_APPENDER, "runtimeOnly");
-		annotationDependency = addDependency(Constants.Dependencies.JETBRAINS_ANNOTATIONS + Constants.Dependencies.Versions.JETBRAINS_ANNOTATIONS, "compileOnly");
+		addDependency(Constants.Dependencies.DEV_LAUNCH_INJECTOR + Constants.Dependencies.Versions.DEV_LAUNCH_INJECTOR, JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME);
+		addDependency(Constants.Dependencies.TERMINAL_CONSOLE_APPENDER + Constants.Dependencies.Versions.TERMINAL_CONSOLE_APPENDER, JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME);
+		annotationDependencies.add(addDependency(Constants.Dependencies.JETBRAINS_ANNOTATIONS + Constants.Dependencies.Versions.JETBRAINS_ANNOTATIONS, JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME));
+		annotationDependencies.add(addDependency(Constants.Dependencies.STITCH_ANNOTATIONS + Constants.Dependencies.Versions.STITCH_ANNOTATIONS, JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME));
 
 		postPopulationScheduler.accept(this::writeRemapClassPath);
 	}

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -76,6 +76,7 @@ public class Constants {
 		public static final String DEV_LAUNCH_INJECTOR = "net.fabricmc:dev-launch-injector:";
 		public static final String TERMINAL_CONSOLE_APPENDER = "net.minecrell:terminalconsoleappender:";
 		public static final String JETBRAINS_ANNOTATIONS = "org.jetbrains:annotations:";
+		public static final String STITCH_ANNOTATIONS = "net.fabricmc:stitch-annotations:";
 
 		private Dependencies() {
 		}
@@ -88,6 +89,7 @@ public class Constants {
 			public static final String DEV_LAUNCH_INJECTOR = "0.2.1+build.8";
 			public static final String TERMINAL_CONSOLE_APPENDER = "1.2.0";
 			public static final String JETBRAINS_ANNOTATIONS = "19.0.0";
+			public static final String STITCH_ANNOTATIONS = "0.5.1+local";
 
 			private Versions() {
 			}

--- a/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
+++ b/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
@@ -185,9 +185,9 @@ public class SourceRemapper {
 			m.getClassPath().add(extension.getMinecraftMappedProvider().getMappedJar().toPath());
 			m.getClassPath().add(extension.getMinecraftMappedProvider().getIntermediaryJar().toPath());
 
-			Dependency annotationDependency = extension.getDependencyManager().getProvider(LaunchProvider.class).annotationDependency;
+			Set<Dependency> annotationDependencies = extension.getDependencyManager().getProvider(LaunchProvider.class).annotationDependencies;
 			Set<File> files = project.getConfigurations().getByName("compileOnly")
-					.files(annotationDependency);
+					.files(annotationDependencies.toArray(new Dependency[0]));
 
 			for (File file : files) {
 				m.getClassPath().add(file.toPath());


### PR DESCRIPTION
[Stitch](https://github.com/FabricMC/stitch/pull/36) | [Loader](https://github.com/FabricMC/fabric-loader/pull/351) | **Loom**

This is a (technically optional) companion to the Stitch PR to split environment annotations, to inject the stitch annotations as a compile dependency the same way jetbrains annotations are.

While loader could bring these in in most cases, having them injected makes the setup more fool-proof.

As with loader, this PR depends on the one in Stitch and won't build without a published version of stitch with changes applied.