### PR TITLE
Jar Processor Stages

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/processors/JarProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/JarProcessor.java
@@ -38,4 +38,12 @@ public interface JarProcessor {
 	 * Return true to make all jar processors run again, return false to use the existing results of jar processing.
 	 */
 	boolean isInvalid(File file);
+
+	default Stage getStage() {
+		return Stage.MAPPED;
+	}
+
+	enum Stage {
+		OBF, INTERMEDIARY, MAPPED;
+	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/processors/JarProcessorManager.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/JarProcessorManager.java
@@ -42,17 +42,23 @@ public class JarProcessorManager {
 		return !jarProcessors.isEmpty();
 	}
 
-	public boolean isInvalid(File file) {
+	boolean hasStage(JarProcessor.Stage stage) {
+		return jarProcessors.stream().anyMatch(jarProcessor -> stage == jarProcessor.getStage());
+	}
+
+	public boolean isInvalid(File file, JarProcessor.Stage stage) {
 		if (!file.exists()) {
 			return true;
 		}
 
-		return jarProcessors.stream().anyMatch(jarProcessor -> jarProcessor.isInvalid(file));
+		return jarProcessors.stream().filter(jarProcessor -> jarProcessor.getStage() == stage).anyMatch(jarProcessor -> jarProcessor.isInvalid(file));
 	}
 
-	public void process(File file) {
+	public void process(File file, JarProcessor.Stage stage) {
 		for (JarProcessor jarProcessor : jarProcessors) {
-			jarProcessor.process(file);
+			if (jarProcessor.getStage() == stage) {
+				jarProcessor.process(file);
+			}
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMappedProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMappedProvider.java
@@ -27,7 +27,6 @@ package net.fabricmc.loom.configuration.providers.minecraft;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Consumer;
 


### PR DESCRIPTION
Draft because this hasn't been extensively tested. I have confirmed that normal ("mapped") stage jar processors work as before, but the rest is mostly untested.
Also, the code is a bit of a mess.

Jar Processor stages allow a jar processor to pick if it wants to process an obf, intermediary, or mapped jar.

Justifications for adding the new stages:
- The **obf** stage is provided for things like using different modloaders over Loom. In this instance a jar processor can simply run the modloader's installer, revert the installer's output to obf, and then not have to duplicate any of looms' remapping work.
- The **intermediary** stage is for generic transformations (perhaps statically applied ASM transformations). It should be obvious why this is important--an author can write for the intermediary without having to do all the remapping logic themselves, or enforce a specific Yarn version.
- The **mapped** stage is what we already had.
