### PR TITLE
Gradle 7 support

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -107,7 +107,7 @@ public final class CompileConfiguration {
 		extendsFrom(Constants.Configurations.LOADER_DEPENDENCIES, Constants.Configurations.MINECRAFT_DEPENDENCIES, project);
 		extendsFrom(Constants.Configurations.MINECRAFT_NAMED, Constants.Configurations.LOADER_DEPENDENCIES, project);
 
-		extendsFrom(JavaPlugin.COMPILE_CONFIGURATION_NAME, Constants.Configurations.MAPPINGS_FINAL, project);
+		extendsFrom(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, Constants.Configurations.MAPPINGS_FINAL, project);
 	}
 
 	/**

--- a/src/main/java/net/fabricmc/loom/configuration/DependencyProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/DependencyProvider.java
@@ -63,10 +63,6 @@ public abstract class DependencyProvider {
 
 	public abstract String getTargetConfig();
 
-	public void addDependency(Object object) {
-		addDependency(object, "compile");
-	}
-
 	public Dependency addDependency(Object object, String target) {
 		if (object instanceof File) {
 			object = project.files(object);

--- a/src/main/java/net/fabricmc/loom/configuration/RemappedConfigurationEntry.java
+++ b/src/main/java/net/fabricmc/loom/configuration/RemappedConfigurationEntry.java
@@ -25,6 +25,9 @@
 package net.fabricmc.loom.configuration;
 
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.plugins.JavaPlugin;
+
+import net.fabricmc.loom.util.gradle.GradleSupport;
 
 public class RemappedConfigurationEntry {
 	private final String sourceConfiguration;
@@ -61,7 +64,7 @@ public class RemappedConfigurationEntry {
 
 	public String getTargetConfiguration(ConfigurationContainer container) {
 		if (container.findByName(targetConfiguration) == null) {
-			return "compile";
+			return GradleSupport.IS_GRADLE_7_OR_NEWER ? JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME : "compile";
 		}
 
 		return targetConfiguration;

--- a/src/main/java/net/fabricmc/loom/configuration/RemappedConfigurationEntry.java
+++ b/src/main/java/net/fabricmc/loom/configuration/RemappedConfigurationEntry.java
@@ -27,6 +27,7 @@ package net.fabricmc.loom.configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.plugins.JavaPlugin;
 
+import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.gradle.GradleSupport;
 
 public class RemappedConfigurationEntry {
@@ -64,7 +65,7 @@ public class RemappedConfigurationEntry {
 
 	public String getTargetConfiguration(ConfigurationContainer container) {
 		if (container.findByName(targetConfiguration) == null) {
-			return GradleSupport.IS_GRADLE_7_OR_NEWER ? JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME : "compile";
+			return GradleSupport.IS_GRADLE_7_OR_NEWER ? JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME : Constants.Configurations.COMPILE;
 		}
 
 		return targetConfiguration;

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -27,9 +27,11 @@ package net.fabricmc.loom.util;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.plugins.JavaPlugin;
 import org.objectweb.asm.Opcodes;
 
 import net.fabricmc.loom.configuration.RemappedConfigurationEntry;
+import net.fabricmc.loom.util.gradle.GradleSupport;
 
 public class Constants {
 	public static final String LIBRARIES_BASE = "https://libraries.minecraft.net/";
@@ -40,13 +42,22 @@ public class Constants {
 
 	public static final int ASM_VERSION = Opcodes.ASM9;
 
-	public static final List<RemappedConfigurationEntry> MOD_COMPILE_ENTRIES = ImmutableList.of(
+	private static final List<RemappedConfigurationEntry> LEGACY_MOD_COMPILE_ENTRIES = ImmutableList.of(
 			new RemappedConfigurationEntry("modCompile", "compile", true, "compile"),
-			new RemappedConfigurationEntry("modApi", "api", true, "compile"),
-			new RemappedConfigurationEntry("modImplementation", "implementation", true, "runtime"),
-			new RemappedConfigurationEntry("modRuntime", "runtimeOnly", false, ""),
-			new RemappedConfigurationEntry("modCompileOnly", "compileOnly", true, "")
+			new RemappedConfigurationEntry("modApi", JavaPlugin.API_CONFIGURATION_NAME, true, "compile"),
+			new RemappedConfigurationEntry("modImplementation", JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, true, "runtime"),
+			new RemappedConfigurationEntry("modRuntime", JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, false, ""),
+			new RemappedConfigurationEntry("modCompileOnly", JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME, true, "")
 	);
+
+	private static final List<RemappedConfigurationEntry> MODERN_MOD_COMPILE_ENTRIES = ImmutableList.of(
+			new RemappedConfigurationEntry("modApi", JavaPlugin.API_CONFIGURATION_NAME, true, "compile"),
+			new RemappedConfigurationEntry("modImplementation", JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, true, "runtime"),
+			new RemappedConfigurationEntry("modRuntime", JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, false, ""),
+			new RemappedConfigurationEntry("modCompileOnly", JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME, true, "")
+	);
+
+	public static final List<RemappedConfigurationEntry> MOD_COMPILE_ENTRIES = GradleSupport.IS_GRADLE_7_OR_NEWER ? MODERN_MOD_COMPILE_ENTRIES : LEGACY_MOD_COMPILE_ENTRIES;
 
 	private Constants() {
 	}

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -43,7 +43,7 @@ public class Constants {
 	public static final int ASM_VERSION = Opcodes.ASM9;
 
 	private static final List<RemappedConfigurationEntry> LEGACY_MOD_COMPILE_ENTRIES = ImmutableList.of(
-			new RemappedConfigurationEntry("modCompile", "compile", true, "compile"),
+			new RemappedConfigurationEntry("modCompile", Configurations.COMPILE, true, "compile"),
 			new RemappedConfigurationEntry("modApi", JavaPlugin.API_CONFIGURATION_NAME, true, "compile"),
 			new RemappedConfigurationEntry("modImplementation", JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, true, "runtime"),
 			new RemappedConfigurationEntry("modRuntime", JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, false, ""),
@@ -76,6 +76,8 @@ public class Constants {
 		public static final String MAPPINGS = "mappings";
 		public static final String MAPPINGS_FINAL = "mappingsFinal";
 		public static final String LOADER_DEPENDENCIES = "loaderLibraries";
+		@Deprecated // Not to be used in gradle 7+
+		public static final String COMPILE = "compile";
 
 		private Configurations() {
 		}

--- a/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
+++ b/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
@@ -38,6 +38,7 @@ import org.cadixdev.mercury.Mercury;
 import org.cadixdev.mercury.remapper.MercuryRemapper;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.plugins.JavaPlugin;
 import org.zeroturnaround.zip.ZipUtil;
 
 import net.fabricmc.loom.LoomGradleExtension;
@@ -192,7 +193,7 @@ public class SourceRemapper {
 			m.getClassPath().add(extension.getMinecraftMappedProvider().getIntermediaryJar().toPath());
 
 			Dependency annotationDependency = extension.getDependencyManager().getProvider(LaunchProvider.class).annotationDependency;
-			Set<File> files = project.getConfigurations().getByName("compileOnly")
+			Set<File> files = project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
 					.files(annotationDependency);
 
 			for (File file : files) {

--- a/src/main/java/net/fabricmc/loom/util/gradle/GradleSupport.java
+++ b/src/main/java/net/fabricmc/loom/util/gradle/GradleSupport.java
@@ -28,9 +28,12 @@ import java.lang.reflect.Method;
 
 import org.gradle.api.Project;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.util.GradleVersion;
 
 // This is used to bridge the gap over large gradle api changes.
 public class GradleSupport {
+	public static final boolean IS_GRADLE_7_OR_NEWER = isIsGradle7OrNewer();
+
 	public static RegularFileProperty getfileProperty(Project project) {
 		try {
 			// First try the new method, if that fails fall back.
@@ -58,5 +61,10 @@ public class GradleSupport {
 		Method method = object.getClass().getDeclaredMethod("fileProperty");
 		method.setAccessible(true);
 		return (RegularFileProperty) method.invoke(object);
+	}
+
+	public static boolean isIsGradle7OrNewer() {
+		String version = GradleVersion.current().getVersion();
+		return Integer.parseInt(version.substring(0, version.indexOf("."))) >= 7;
 	}
 }

--- a/src/test/groovy/net/fabricmc/loom/BuildUtils.groovy
+++ b/src/test/groovy/net/fabricmc/loom/BuildUtils.groovy
@@ -24,10 +24,10 @@ dependencies {
 	//to change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:\${project.minecraft_version}"
 	mappings ${mappingsDep}
-	modCompile "net.fabricmc:fabric-loader:\${project.loader_version}"
+	modImplementation "net.fabricmc:fabric-loader:\${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
-	modCompile "net.fabricmc.fabric-api:fabric-api:\${project.fabric_version}"
+	modImplementation "net.fabricmc.fabric-api:fabric-api:\${project.fabric_version}"
 
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.
@@ -36,13 +36,8 @@ dependencies {
 processResources {
 	inputs.property "version", project.version
 
-	from(sourceSets.main.resources.srcDirs) {
-		include "fabric.mod.json"
+	filesMatching("fabric.mod.json") {
 		expand "version": project.version
-	}
-
-	from(sourceSets.main.resources.srcDirs) {
-		exclude "fabric.mod.json"
 	}
 }
 


### PR DESCRIPTION
Gradle 7 is nearing release candidate with some major breaking changes.

I was bored, so decided to have a quite crack at fixing loom.

This clearly might break again before the final release. (Used the latest nightly).

When running on gradle 7 or newer `modCompile` will not added.

_Also fixes gradle 8 deprecation warnings_