### PR TITLE
Set classpath before compileJava task (#330)

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
@@ -45,6 +45,9 @@ public abstract class AbstractRunTask extends JavaExec {
 		super();
 		setGroup("fabric");
 		this.configProvider = config;
+
+		classpath(getProject().getConfigurations().getByName("runtimeClasspath"));
+		classpath(this.getProject().getExtensions().getByType(LoomGradleExtension.class).getUnmappedModCollection());
 	}
 
 	@Override
@@ -52,9 +55,6 @@ public abstract class AbstractRunTask extends JavaExec {
 		if (config == null) {
 			config = configProvider.apply(getProject());
 		}
-
-		classpath(getProject().getConfigurations().getByName("runtimeClasspath"));
-		classpath(this.getProject().getExtensions().getByType(LoomGradleExtension.class).getUnmappedModCollection());
 
 		List<String> argsSplit = new ArrayList<>();
 		String[] args = config.programArgs.split(" ");


### PR DESCRIPTION
As of Loom 0.6.13, the `runClient` and `runServer` tasks do not compile or load the active mod classes. This is because the classpath of the project is set after the `compileJava` task, causing the mod classes to never be compiled. To fix this, I have moved setting the classpath to before the `compileJava` task, as done with versions 0.6.12 and earlier (see the change in 0.6.13 [here](https://github.com/FabricMC/fabric-loom/commit/792a64e2efecb850e4752a298a4e3d6f50f55a64#diff-128362915f1f370814294926952437205a6d7b36e7d08aa44bc55d727e782019)). This fixes #330.

Note that I have relatively little Java experience, so this fix could be wrong. However, it seems to have worked in my projects so far without issues.