### PR TITLE
Cache the checksum of asset index files.

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/assets/MinecraftAssetsProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/assets/MinecraftAssetsProvider.java
@@ -46,6 +46,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 
 import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.LoomGradlePlugin;
 import net.fabricmc.loom.configuration.providers.MinecraftProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftVersionInfo;
 import net.fabricmc.loom.util.Checksum;
@@ -126,7 +127,7 @@ public class MinecraftAssetsProvider {
 				}
 			});
 
-			if (localFileChecksum == null || !localFileChecksum.equals(sha1)) {
+			if (LoomGradlePlugin.refreshDeps || localFileChecksum == null || !localFileChecksum.equals(sha1)) {
 				if (offline) {
 					if (file.exists()) {
 						project.getLogger().warn("Outdated asset " + entry.getKey());
@@ -163,12 +164,8 @@ public class MinecraftAssetsProvider {
 							throw new RuntimeException("Failed to download: " + assetName, e);
 						}
 
-						try {
-							if (localFileChecksum == null) {
-								checksumInfos.put(entry.getKey(), Files.asByteSource(file).hash(Hashing.sha1()).toString());
-							}
-						} catch (IOException e) {
-							throw new RuntimeException("Failed to save checksum: " + assetName, e);
+						if (localFileChecksum == null) {
+							checksumInfos.put(entry.getKey(), sha1);
 						}
 
 						//Give this logger back

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/assets/MinecraftAssetsProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/assets/MinecraftAssetsProvider.java
@@ -26,16 +26,22 @@ package net.fabricmc.loom.configuration.providers.minecraft.assets;
 
 import java.io.File;
 import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.base.Stopwatch;
+import com.google.common.hash.Hashing;
+import com.google.common.io.Files;
 import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 
@@ -63,6 +69,7 @@ public class MinecraftAssetsProvider {
 		}
 
 		File assetsInfo = new File(assets, "indexes" + File.separator + assetIndex.getFabricId(minecraftProvider.getMinecraftVersion()) + ".json");
+		File checksumInfo = new File(assets, "checksum" + File.separator + minecraftProvider.getMinecraftVersion() + ".json");
 
 		if (!assetsInfo.exists() || !Checksum.equals(assetsInfo, assetIndex.sha1)) {
 			project.getLogger().lifecycle(":downloading asset index");
@@ -80,16 +87,27 @@ public class MinecraftAssetsProvider {
 			}
 		}
 
-		project.getLogger().lifecycle(":downloading assets...");
+		Gson gson = new Gson();
+		Map<String, String> checksumInfos = new HashMap<>();
+
+		if (checksumInfo.exists()) {
+			try (FileReader reader = new FileReader(checksumInfo)) {
+				checksumInfos.putAll(gson.fromJson(reader, new TypeToken<Map<String, String>>() {
+				}.getType()));
+			}
+		}
 
 		Deque<ProgressLogger> loggers = new ConcurrentLinkedDeque<>();
 		ExecutorService executor = Executors.newFixedThreadPool(Math.min(10, Math.max(Runtime.getRuntime().availableProcessors() / 2, 1)));
+		int toDownload = 0;
 
 		AssetIndex index;
 
 		try (FileReader fileReader = new FileReader(assetsInfo)) {
-			index = new Gson().fromJson(fileReader, AssetIndex.class);
+			index = gson.fromJson(fileReader, AssetIndex.class);
 		}
+
+		Stopwatch stopwatch = Stopwatch.createStarted();
 
 		Map<String, AssetObject> parent = index.getFileMap();
 
@@ -99,7 +117,16 @@ public class MinecraftAssetsProvider {
 			String filename = "objects" + File.separator + sha1.substring(0, 2) + File.separator + sha1;
 			File file = new File(assets, filename);
 
-			if (!file.exists() || !Checksum.equals(file, sha1)) {
+			String localFileChecksum = !file.exists() ? null : checksumInfos.computeIfAbsent(entry.getKey(), path -> {
+				try {
+					return Files.asByteSource(file).hash(Hashing.sha1()).toString();
+				} catch (IOException e) {
+					e.printStackTrace();
+					return null;
+				}
+			});
+
+			if (localFileChecksum == null || !localFileChecksum.equals(sha1)) {
 				if (offline) {
 					if (file.exists()) {
 						project.getLogger().warn("Outdated asset " + entry.getKey());
@@ -107,6 +134,7 @@ public class MinecraftAssetsProvider {
 						throw new GradleException("Asset " + entry.getKey() + " not found at " + file.getAbsolutePath());
 					}
 				} else {
+					toDownload++;
 					executor.execute(() -> {
 						ProgressLogger progressLogger;
 
@@ -135,11 +163,31 @@ public class MinecraftAssetsProvider {
 							throw new RuntimeException("Failed to download: " + assetName, e);
 						}
 
+						try {
+							if (localFileChecksum == null) {
+								checksumInfos.put(entry.getKey(), Files.asByteSource(file).hash(Hashing.sha1()).toString());
+							}
+						} catch (IOException e) {
+							throw new RuntimeException("Failed to save checksum: " + assetName, e);
+						}
+
 						//Give this logger back
 						loggers.add(progressLogger);
 					});
 				}
 			}
+		}
+
+		project.getLogger().info("Took " + stopwatch.stop() + " to iterate " + parent.size() + " asset index.");
+
+		if (toDownload > 0) {
+			project.getLogger().lifecycle(":downloading " + toDownload + " asset" + (toDownload == 1 ? "" : "s") + "...");
+		}
+
+		checksumInfo.getParentFile().mkdirs();
+
+		try (FileWriter writer = new FileWriter(checksumInfo)) {
+			gson.toJson(checksumInfos, writer);
 		}
 
 		//Wait for the assets to all download


### PR DESCRIPTION
Since IDEA sync will "download" the assets again, I think it is good to make this faster. Without caching, this operation takes a second, this will take it down to an average of 10ms.