### PR TITLE
Generate fabric.mod.json for included submodule jars

### DIFF
--- a/src/main/java/net/fabricmc/loom/build/NestedJars.java
+++ b/src/main/java/net/fabricmc/loom/build/NestedJars.java
@@ -255,7 +255,6 @@ public class NestedJars {
 	}
 
 	private static final class ProjectDependencyMetaExtractor implements DependencyMetaExtractor<ProjectDependency> {
-
 		@Override
 		public String group(ProjectDependency dependency) {
 			return dependency.getGroup();
@@ -273,7 +272,6 @@ public class NestedJars {
 	}
 
 	private static final class ResolvedDependencyMetaExtractor implements DependencyMetaExtractor<ResolvedDependency> {
-
 		@Override
 		public String group(ResolvedDependency dependency) {
 			return dependency.getModuleGroup();


### PR DESCRIPTION
When jij-ing subprojects, fabric.mod.json files are not generated like they are for other non-mod dependencies. This results in the jars being properly included but never being loaded.

This PR fixes that issue, although it's a bit ugly because  `ProjectDependency` and `ResolvedDependency` don't have a common parent.