### PR TITLE
Make tiny remapper used by loom fix package access for named namespace

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMappedProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMappedProvider.java
@@ -127,11 +127,16 @@ public class MinecraftMappedProvider extends DependencyProvider {
 	}
 
 	public TinyRemapper getTinyRemapper(String fromM, String toM) throws IOException {
+		return getTinyRemapper(fromM, toM, "named".equals(toM));
+	}
+
+	public TinyRemapper getTinyRemapper(String fromM, String toM, boolean fixPackageAccess) throws IOException {
 		return TinyRemapper.newRemapper()
 				.withMappings(TinyRemapperMappingsHelper.create(getExtension().getMappingsProvider().getMappings(), fromM, toM, true))
 				.withMappings(out -> JSR_TO_JETBRAINS.forEach(out::acceptClass))
 				.renameInvalidLocals(true)
 				.rebuildSourceFilenames(true)
+				.fixPackageAccess(fixPackageAccess)
 				.build();
 	}
 


### PR DESCRIPTION
Properly fix FabricMC/yarn#2057
Also see FabricMC/yarn#2078

Signed-off-by: liach <liach@users.noreply.github.com>