### PR TITLE
Add log4jConfigs to Loom extension

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -66,6 +66,7 @@ public class LoomGradleExtension {
 	public boolean shareCaches = false;
 
 	private final ConfigurableFileCollection unmappedMods;
+	private final ConfigurableFileCollection log4jConfigs;
 
 	final List<LoomDecompiler> decompilers = new ArrayList<>();
 	private final List<JarProcessor> jarProcessors = new ArrayList<>();
@@ -117,6 +118,7 @@ public class LoomGradleExtension {
 		this.unmappedMods = project.files();
 		this.runConfigs = project.container(RunConfigSettings.class,
 				baseName -> new RunConfigSettings(project, baseName));
+		this.log4jConfigs = project.files(getDefaultLog4jConfigFile());
 	}
 
 	/**
@@ -346,6 +348,14 @@ public class LoomGradleExtension {
 
 	public List<LoomDecompiler> getDecompilers() {
 		return decompilers;
+	}
+
+	public File getDefaultLog4jConfigFile() {
+		return new File(getProjectPersistentCache(), "log4j.xml");
+	}
+
+	public ConfigurableFileCollection getLog4jConfigs() {
+		return log4jConfigs;
 	}
 
 	@ApiStatus.Experimental

--- a/src/main/java/net/fabricmc/loom/configuration/providers/LaunchProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/LaunchProvider.java
@@ -59,7 +59,7 @@ public class LaunchProvider extends DependencyProvider {
 		final LaunchConfig launchConfig = new LaunchConfig()
 				.property("fabric.development", "true")
 				.property("fabric.remapClasspathFile", getRemapClasspathFile().getAbsolutePath())
-				.property("log4j.configurationFile", getLog4jConfigFile().getAbsolutePath())
+				.property("log4j.configurationFile", getAllLog4JConfigFiles())
 
 				.property("client", "java.library.path", getExtension().getNativesDirectory().getAbsolutePath())
 				.property("client", "org.lwjgl.librarypath", getExtension().getNativesDirectory().getAbsolutePath())
@@ -87,7 +87,13 @@ public class LaunchProvider extends DependencyProvider {
 	}
 
 	private File getLog4jConfigFile() {
-		return new File(getExtension().getDevLauncherConfig().getParentFile(), "log4j.xml");
+		return getExtension().getDefaultLog4jConfigFile();
+	}
+
+	private String getAllLog4JConfigFiles() {
+		return getExtension().getLog4jConfigs().getFiles().stream()
+				.map(File::getAbsolutePath)
+				.collect(Collectors.joining(","));
 	}
 
 	private File getRemapClasspathFile() {


### PR DESCRIPTION
Allows mod build scripts to specify custom Log4j config files that will
be combined together when running Minecraft in the dev-env. For example:

    minecraft {
        log4jConfigs.from "MyCustomConfig.xml"
    }

See: https://logging.apache.org/log4j/2.x/manual/configuration.html#CompositeConfiguration

I haven't done much work on Gradle plugins, so there may very well be a better way of doing this.