### PR TITLE
Fix name comparision in GroovyXmlUtil

### DIFF
--- a/src/main/java/net/fabricmc/loom/util/GroovyXmlUtil.java
+++ b/src/main/java/net/fabricmc/loom/util/GroovyXmlUtil.java
@@ -29,13 +29,14 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import groovy.util.Node;
+import groovy.xml.QName;
 
 public final class GroovyXmlUtil {
 	private GroovyXmlUtil() { }
 
 	public static Node getOrCreateNode(Node parent, String name) {
 		for (Object object : parent.children()) {
-			if (object instanceof Node && name.equals(((Node) object).name())) {
+			if (object instanceof Node && isSameName(((Node) object).name(), name)) {
 				return (Node) object;
 			}
 		}
@@ -45,12 +46,24 @@ public final class GroovyXmlUtil {
 
 	public static Optional<Node> getNode(Node parent, String name) {
 		for (Object object : parent.children()) {
-			if (object instanceof Node && name.equals(((Node) object).name())) {
+			if (object instanceof Node && isSameName(((Node) object).name(), name)) {
 				return Optional.of((Node) object);
 			}
 		}
 
 		return Optional.empty();
+	}
+
+	private static boolean isSameName(Object nodeName, String givenName) {
+		if (nodeName instanceof String) {
+			return nodeName.equals(givenName);
+		}
+
+		if (nodeName instanceof QName) {
+			return ((QName) nodeName).matches(givenName);
+		}
+
+		throw new UnsupportedOperationException("Cannot determine if " + nodeName.getClass() + " is the same as a String");
 	}
 
 	public static Stream<Node> childrenNodesStream(Node node) {

--- a/src/test/groovy/net/fabricmc/loom/GroovyXmlUtilTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/GroovyXmlUtilTest.groovy
@@ -1,0 +1,74 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom
+
+import groovy.xml.QName
+import net.fabricmc.loom.util.GroovyXmlUtil
+import spock.lang.Specification
+
+class GroovyXmlUtilTest extends Specification {
+    def "getOrCreateNode finds existing node"() {
+        when:
+            def xmlTree = new XmlParser().parseText(text)
+            def existingNode = xmlTree[innerName]
+            def actualNode = GroovyXmlUtil.getOrCreateNode(xmlTree, innerName)
+
+        then:
+            existingNode.text() == actualNode.text()
+
+        where:
+            innerName          | text
+            "bar"              | "<foo><bar>inner content to ensure correct</bar></foo>"
+            "dependencies"     | "<project xmlns=\"http://maven.apache.org/POM/4.0.0\"><dependencies>inner content to ensure correct</dependencies></project>"
+    }
+
+    def "getOrCreateNode creates a node if needed"() {
+        when:
+            def xmlTree = new XmlParser().parseText(text)
+            def actualNode = GroovyXmlUtil.getOrCreateNode(xmlTree, innerName)
+
+        then:
+            xmlTree[QName.valueOf(actualNode.name().toString())] != null
+
+        where:
+            innerName          | text
+            "bar"              | "<foo></foo>"
+            "dependencies"     | "<project xmlns=\"http://maven.apache.org/POM/4.0.0\"></project>"
+    }
+
+    def "getNode finds existing node"() {
+        when:
+            def xmlTree = new XmlParser().parseText(text)
+            def actualNode = GroovyXmlUtil.getNode(xmlTree, innerName)
+
+        then:
+            actualNode.isPresent()
+
+        where:
+            innerName          | text
+            "bar"              | "<foo><bar>inner content to ensure correct</bar></foo>"
+            "dependencies"     | "<project xmlns=\"http://maven.apache.org/POM/4.0.0\"><dependencies>inner content to ensure correct</dependencies></project>"
+    }
+}


### PR DESCRIPTION
Nodes can also have `groovy.xml.QName`s, which need to be compared using their `matches(Object)` method.

This fixes a bug where `fabric-loom` added an extra `dependencies` node in `MavenPublication#processEntry`, causing Gradle to fail the build.