### PR TITLE
Support Groovy 3's QName in GroovyXmlUtil

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ repositories {
 dependencies {
 	implementation gradleApi()
 
+	// Compile against groovy 3 to aid with gradle 7 support. Remove when updating to gradle 7
+	compileOnly 'org.codehaus.groovy:groovy-all:3.0.7'
+
 	// libraries
 	implementation ('commons-io:commons-io:2.8.0')
 	implementation ('org.zeroturnaround:zt-zip:1.14')

--- a/src/main/java/net/fabricmc/loom/util/GroovyXmlUtil.java
+++ b/src/main/java/net/fabricmc/loom/util/GroovyXmlUtil.java
@@ -31,6 +31,8 @@ import java.util.stream.Stream;
 import groovy.util.Node;
 import groovy.xml.QName;
 
+import net.fabricmc.loom.util.gradle.GradleSupport;
+
 public final class GroovyXmlUtil {
 	private GroovyXmlUtil() { }
 
@@ -63,7 +65,17 @@ public final class GroovyXmlUtil {
 			return ((QName) nodeName).matches(givenName);
 		}
 
+		// New groovy 3 (gradle 7) class
+		if (GradleSupport.IS_GRADLE_7_OR_NEWER && nodeName.getClass().getName().equals("groovy.namespace.QName")) {
+			return isSameNameGroovy3(nodeName, givenName);
+		}
+
 		throw new UnsupportedOperationException("Cannot determine if " + nodeName.getClass() + " is the same as a String");
+	}
+
+	// TODO Move out of its own method when requiring gradle 7
+	private static boolean isSameNameGroovy3(Object nodeName, String givenName) {
+		return ((groovy.namespace.QName) nodeName).matches(givenName);
 	}
 
 	public static Stream<Node> childrenNodesStream(Node node) {

--- a/src/test/groovy/net/fabricmc/loom/test/intergration/MavenProjectTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/intergration/MavenProjectTest.groovy
@@ -41,49 +41,51 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 class MavenProjectTest extends Specification implements MockMavenServerTrait, ArchiveAssertionsTrait {
 	@RestoreSystemProperties
 	@Unroll
-	def "publish lib #version"() {
+	def "publish lib #version #gradle"() {
 		given:
 			setProperty('loom.test.version', version)
 			library = true
 		when:
-			def result = create("publish")
+			def result = create("publish", gradle)
 		then:
 			result.task(":publish").outcome == SUCCESS
 			hasArchiveEntry("fabric-example-lib-${version}.jar", "net/fabricmc/example/ExampleLib.class")
 		where:
-			version           | _
-			'1.0.0'           | _
-			'1.1.0'           | _
-			'1.1.1'           | _
-			'1.2.0+meta'      | _
-			'2.0.0-SNAPSHOT'  | _
-			'2.0.0-SNAPSHOT'  | _ // Publish this twice to give ourselves a bit of a challenge
-			'master-SNAPSHOT' | _
+			version           | gradle
+			'1.0.0'           | DEFAULT_GRADLE
+			'1.0.0'           | PRE_RELEASE_GRADLE
+			'1.1.0'           | DEFAULT_GRADLE
+			'1.1.1'           | DEFAULT_GRADLE
+			'1.2.0+meta'      | DEFAULT_GRADLE
+			'2.0.0-SNAPSHOT'  | DEFAULT_GRADLE
+			'2.0.0-SNAPSHOT'  | DEFAULT_GRADLE // Publish this twice to give ourselves a bit of a challenge
+			'master-SNAPSHOT' | DEFAULT_GRADLE
 	}
 
 	@RestoreSystemProperties
 	@Unroll
-	def "resolve #version"() {
+	def "resolve #version #gradle"() {
 		given:
 			setProperty('loom.test.resolve', "com.example:fabric-example-lib:${version}")
 			library = false
 		when:
-			def result = create("build")
+			def result = create("build", gradle)
 		then:
 			result.task(":build").outcome == SUCCESS
 			hasArchiveEntry("fabric-example-mod-1.0.0.jar", "net/fabricmc/examplemod/ExampleMod.class")
 		where:
-			version                      | _
-			'1.0.0'                      | _
-			'1.1.+'                      | _
-			'1.2.0+meta'                 | _
-			'2.0.0-SNAPSHOT'             | _
-			'master-SNAPSHOT'            | _
-			'1.0.0:classifier'           | _
-			'1.1.+:classifier'           | _
-			'1.2.0+meta:classifier'      | _
-			'2.0.0-SNAPSHOT:classifier'  | _
-			'master-SNAPSHOT:classifier' | _
+			version                      | gradle
+			'1.0.0'                      | DEFAULT_GRADLE
+			'1.0.0'                      | PRE_RELEASE_GRADLE
+			'1.1.+'                      | DEFAULT_GRADLE
+			'1.2.0+meta'                 | DEFAULT_GRADLE
+			'2.0.0-SNAPSHOT'             | DEFAULT_GRADLE
+			'master-SNAPSHOT'            | DEFAULT_GRADLE
+			'1.0.0:classifier'           | DEFAULT_GRADLE
+			'1.1.+:classifier'           | DEFAULT_GRADLE
+			'1.2.0+meta:classifier'      | DEFAULT_GRADLE
+			'2.0.0-SNAPSHOT:classifier'  | DEFAULT_GRADLE
+			'master-SNAPSHOT:classifier' | DEFAULT_GRADLE
 	}
 
 	// Set to true when to build and publish the mavenLibrary


### PR DESCRIPTION
Fixes a crash in gradle 7, also updated the tests to cover this.