### PR TITLE
Fix a bug during genSources

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
@@ -94,7 +94,7 @@ public class GenerateSourcesTask extends AbstractLoomTask {
 
 		try (StitchUtil.FileSystemDelegate inFs = StitchUtil.getJarFileSystem(oldCompiledJar.toFile(), true);
 			StitchUtil.FileSystemDelegate outFs = StitchUtil.getJarFileSystem(linemappedJarDestination.toFile(), true)) {
-			remapper.process(progressLogger, inFs.get().getPath("/"), outFs.get().getPath("/"));
+			remapper.process(progressLogger, inFs.get().getPath(File.separator), outFs.get().getPath(File.separator));
 		}
 
 		progressLogger.completed();


### PR DESCRIPTION
Fixes #369 

Basically, it would break on Windows systems because '/' is a Unix thing, so this field should work on both Windows and Unix. 