### PR TITLE
Inline compatibility declaration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,7 @@ plugins {
 	id "org.cadixdev.licenser" version "0.5.0"
 }
 
-sourceCompatibility = 16
-targetCompatibility = 16
+sourceCompatibility = targetCompatibility = JavaVersion.VERSION_16
 
 tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"


### PR DESCRIPTION
There is absolutely no need of writing two lines to declare the source and target Java compatibility.
Also, it is better to use the JavaVersion class to get the final constants of Java versions.