### PR TITLE
Add field access widener to AW integration test

### DIFF
--- a/src/test/resources/accesswidener/expected.accesswidener
+++ b/src/test/resources/accesswidener/expected.accesswidener
@@ -1,7 +1,9 @@
 accessWidener	v1	intermediary
 accessible	class	net/minecraft/class_1928$class_5199
+accessible	class	net/minecraft/class_1735
 accessible	class	net/minecraft/class_1928$class_4314
 extendable	class	net/minecraft/class_1928$class_4314
 accessible	class	net/minecraft/class_5235$class_5238
 accessible	method	net/minecraft/class_1928$class_4314	<init>	(Ljava/util/function/Supplier;Ljava/util/function/Function;Ljava/util/function/BiConsumer;Lnet/minecraft/class_1928$class_5199;)V
 extendable	method	net/minecraft/class_1928$class_4314	<init>	(Ljava/util/function/Supplier;Ljava/util/function/Function;Ljava/util/function/BiConsumer;Lnet/minecraft/class_1928$class_5199;)V
+accessible	field	net/minecraft/class_1735	field_7873	I

--- a/src/test/resources/projects/accesswidener/src/main/resources/modid.accesswidener
+++ b/src/test/resources/projects/accesswidener/src/main/resources/modid.accesswidener
@@ -5,3 +5,5 @@ extendable  method  net/minecraft/world/GameRules$Type <init>  (Ljava/util/funct
 
 accessible  class   net/minecraft/world/GameRules$Acceptor
 accessible  class   net/minecraft/client/gui/screen/world/EditGameRulesScreen$RuleWidgetFactory
+
+accessible  field  net/minecraft/screen/slot/Slot  x  I


### PR DESCRIPTION
The build fails currently, seemingly due to a regression in tiny remapper. The error is from [a recently modified `assert`](https://github.com/FabricMC/tiny-remapper/blob/cc8e27ead7a2c50877dff5b2f6393ea94b0e4760/src/main/java/net/fabricmc/tinyremapper/AsmRemapper.java#L57). On 0.8, [this same test succeeds](https://github.com/Juuxel/fabric-loom/runs/3041213429).