### PR TITLE
Allow developer set the site where to download game resource.

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
@@ -39,6 +39,7 @@ import net.fabricmc.loom.decompilers.DecompilerConfiguration;
 import net.fabricmc.loom.task.LoomTasks;
 
 public class LoomGradlePlugin implements Plugin<Project> {
+	public static Project project;
 	public static boolean refreshDeps;
 	public static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 
@@ -47,6 +48,7 @@ public class LoomGradlePlugin implements Plugin<Project> {
 		project.getLogger().lifecycle("Fabric Loom: " + LoomGradlePlugin.class.getPackage().getImplementationVersion());
 
 		refreshDeps = project.getGradle().getStartParameter().isRefreshDependencies();
+		LoomGradlePlugin.project = project;
 
 		if (refreshDeps) {
 			MappingsCache.INSTANCE.invalidate();

--- a/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
@@ -30,6 +30,7 @@ import com.google.gson.GsonBuilder;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
+import net.fabricmc.loom.configuration.MirrorConfiguration;
 import net.fabricmc.loom.configuration.CompileConfiguration;
 import net.fabricmc.loom.configuration.FabricApiExtension;
 import net.fabricmc.loom.configuration.MavenPublication;
@@ -39,7 +40,6 @@ import net.fabricmc.loom.decompilers.DecompilerConfiguration;
 import net.fabricmc.loom.task.LoomTasks;
 
 public class LoomGradlePlugin implements Plugin<Project> {
-	public static Project project;
 	public static boolean refreshDeps;
 	public static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 
@@ -48,7 +48,6 @@ public class LoomGradlePlugin implements Plugin<Project> {
 		project.getLogger().lifecycle("Fabric Loom: " + LoomGradlePlugin.class.getPackage().getImplementationVersion());
 
 		refreshDeps = project.getGradle().getStartParameter().isRefreshDependencies();
-		LoomGradlePlugin.project = project;
 
 		if (refreshDeps) {
 			MappingsCache.INSTANCE.invalidate();
@@ -65,6 +64,7 @@ public class LoomGradlePlugin implements Plugin<Project> {
 		project.getExtensions().add("loom", project.getExtensions().getByName("minecraft"));
 		project.getExtensions().create("fabricApi", FabricApiExtension.class, project);
 
+		MirrorConfiguration.setup(project);
 		CompileConfiguration.setupConfigurations(project);
 		IdeConfiguration.setup(project);
 		CompileConfiguration.configureCompile(project);

--- a/src/main/java/net/fabricmc/loom/configuration/MirrorConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/MirrorConfiguration.java
@@ -1,0 +1,27 @@
+package net.fabricmc.loom.configuration;
+
+import net.fabricmc.loom.util.Constants;
+import net.fabricmc.loom.util.Mirrors;
+
+import org.gradle.api.Project;
+
+public class MirrorConfiguration {
+	public static void setup(Project project){
+		if (!(project.hasProperty("loom_libraries_base")
+				|| project.hasProperty("loom_resources_base")
+		        || project.hasProperty("version_manifests"))){
+			return;
+		}
+
+		String LIBRARIES_BASE_MIRRORS = project.hasProperty("loom_libraries_base")
+				? String.valueOf(project.property("loom_libraries_base")) : Constants.LIBRARIES_BASE;
+		String RESOURCES_BASE_MIRRORS = project.hasProperty("loom_resources_base")
+				? String.valueOf(project.property("loom_resources_base")) : Constants.RESOURCES_BASE;
+		String VERSION_MANIFESTS = project.hasProperty("version_manifests")
+				? String.valueOf(project.property("version_manifests")) : Constants.VERSION_MANIFESTS;
+
+		Mirrors.changeMirror(LIBRARIES_BASE_MIRRORS
+				,RESOURCES_BASE_MIRRORS
+				,VERSION_MANIFESTS);
+	}
+}

--- a/src/main/java/net/fabricmc/loom/configuration/MirrorConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/MirrorConfiguration.java
@@ -33,7 +33,7 @@ public class MirrorConfiguration {
 	public static void setup(Project project){
 		if (!(project.hasProperty("loom_libraries_base")
 				|| project.hasProperty("loom_resources_base")
-		        || project.hasProperty("version_manifests"))){
+		        || project.hasProperty("loom_version_manifests"))){
 			return;
 		}
 
@@ -41,8 +41,8 @@ public class MirrorConfiguration {
 				? String.valueOf(project.property("loom_libraries_base")) : Constants.LIBRARIES_BASE;
 		String RESOURCES_BASE_MIRRORS = project.hasProperty("loom_resources_base")
 				? String.valueOf(project.property("loom_resources_base")) : Constants.RESOURCES_BASE;
-		String VERSION_MANIFESTS = project.hasProperty("version_manifests")
-				? String.valueOf(project.property("version_manifests")) : Constants.VERSION_MANIFESTS;
+		String VERSION_MANIFESTS = project.hasProperty("loom_version_manifests")
+				? String.valueOf(project.property("loom_version_manifests")) : Constants.VERSION_MANIFESTS;
 
 		Mirrors.changeMirror(LIBRARIES_BASE_MIRRORS
 				,RESOURCES_BASE_MIRRORS

--- a/src/main/java/net/fabricmc/loom/configuration/MirrorConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/MirrorConfiguration.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package net.fabricmc.loom.configuration;
 
 import net.fabricmc.loom.util.Constants;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/MinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/MinecraftProvider.java
@@ -44,6 +44,7 @@ import net.fabricmc.loom.configuration.providers.minecraft.ManifestVersion;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftLibraryProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftVersionMeta;
 import net.fabricmc.loom.util.Constants;
+import net.fabricmc.loom.util.Mirrors;
 import net.fabricmc.loom.util.DownloadUtil;
 import net.fabricmc.loom.util.HashedDownloadUtil;
 import net.fabricmc.stitch.merge.JarMerger;
@@ -136,7 +137,7 @@ public class MinecraftProvider extends DependencyProvider {
 			}
 		} else {
 			getProject().getLogger().debug("Downloading version manifests");
-			DownloadUtil.downloadIfChanged(new URL(Constants.VERSION_MANIFESTS), versionManifestJson, getProject().getLogger());
+			DownloadUtil.downloadIfChanged(new URL(Mirrors.hasMirror() ? Mirrors.VERSION_MANIFESTS : Constants.VERSION_MANIFESTS), versionManifestJson, getProject().getLogger());
 		}
 
 		String versionManifest = Files.asCharSource(versionManifestJson, StandardCharsets.UTF_8).read();

--- a/src/main/java/net/fabricmc/loom/configuration/providers/MinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/MinecraftProvider.java
@@ -137,7 +137,7 @@ public class MinecraftProvider extends DependencyProvider {
 			}
 		} else {
 			getProject().getLogger().debug("Downloading version manifests");
-			DownloadUtil.downloadIfChanged(new URL(Mirrors.hasMirror() ? Mirrors.VERSION_MANIFESTS : Constants.VERSION_MANIFESTS), versionManifestJson, getProject().getLogger());
+			DownloadUtil.downloadIfChanged(new URL(Mirrors.getVersionManifests()), versionManifestJson, getProject().getLogger());
 		}
 
 		String versionManifest = Files.asCharSource(versionManifestJson, StandardCharsets.UTF_8).read();

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftVersionMeta.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftVersionMeta.java
@@ -31,6 +31,7 @@ import java.util.Objects;
 
 import com.google.gson.JsonObject;
 
+import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.OperatingSystem;
 
 @SuppressWarnings("unused")
@@ -208,6 +209,10 @@ public final class MinecraftVersionMeta {
 	}
 
 	public final class Artifact extends Downloadable {
+		@Override
+		public String getUrl() {
+			return Constants.LIBRARIES_BASE + super.getPath();
+		}
 	}
 
 	public final class Classifier extends Downloadable {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftVersionMeta.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftVersionMeta.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 import com.google.gson.JsonObject;
 
 import net.fabricmc.loom.util.Constants;
+import net.fabricmc.loom.util.Mirrors;
 import net.fabricmc.loom.util.OperatingSystem;
 
 @SuppressWarnings("unused")
@@ -211,7 +212,7 @@ public final class MinecraftVersionMeta {
 	public final class Artifact extends Downloadable {
 		@Override
 		public String getUrl() {
-			return Constants.LIBRARIES_BASE + super.getPath();
+			return Mirrors.hasMirror() ? Mirrors.LIBRARIES_BASE_MIRRORS : Constants.LIBRARIES_BASE + super.getPath();
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftVersionMeta.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftVersionMeta.java
@@ -212,7 +212,7 @@ public final class MinecraftVersionMeta {
 	public final class Artifact extends Downloadable {
 		@Override
 		public String getUrl() {
-			return Mirrors.hasMirror() ? Mirrors.LIBRARIES_BASE_MIRRORS : Constants.LIBRARIES_BASE + super.getPath();
+			return Mirrors.getLibrariesBase() + super.getPath();
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/assets/MinecraftAssetsProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/assets/MinecraftAssetsProvider.java
@@ -118,7 +118,7 @@ public class MinecraftAssetsProvider {
 					final ProgressLogger[] progressLogger = new ProgressLogger[1];
 
 					try {
-						HashedDownloadUtil.downloadIfInvalid(new URL(Mirrors.hasMirror() ? Mirrors.RESOURCES_BASE_MIRRORS : Constants.RESOURCES_BASE + sha1.substring(0, 2) + "/" + sha1), file, sha1, project.getLogger(), true, () -> {
+						HashedDownloadUtil.downloadIfInvalid(new URL(Mirrors.getResourcesBase() + sha1.substring(0, 2) + "/" + sha1), file, sha1, project.getLogger(), true, () -> {
 							ProgressLogger logger = loggers.pollFirst();
 
 							if (logger == null) {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/assets/MinecraftAssetsProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/assets/MinecraftAssetsProvider.java
@@ -44,6 +44,7 @@ import net.fabricmc.loom.LoomGradlePlugin;
 import net.fabricmc.loom.configuration.providers.MinecraftProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftVersionMeta;
 import net.fabricmc.loom.util.Constants;
+import net.fabricmc.loom.util.Mirrors;
 import net.fabricmc.loom.util.HashedDownloadUtil;
 import net.fabricmc.loom.util.gradle.ProgressLogger;
 
@@ -117,7 +118,7 @@ public class MinecraftAssetsProvider {
 					final ProgressLogger[] progressLogger = new ProgressLogger[1];
 
 					try {
-						HashedDownloadUtil.downloadIfInvalid(new URL(Constants.RESOURCES_BASE + sha1.substring(0, 2) + "/" + sha1), file, sha1, project.getLogger(), true, () -> {
+						HashedDownloadUtil.downloadIfInvalid(new URL(Mirrors.hasMirror() ? Mirrors.RESOURCES_BASE_MIRRORS : Constants.RESOURCES_BASE + sha1.substring(0, 2) + "/" + sha1), file, sha1, project.getLogger(), true, () -> {
 							ProgressLogger logger = loggers.pollFirst();
 
 							if (logger == null) {

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -27,19 +27,17 @@ package net.fabricmc.loom.util;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
-
-import net.fabricmc.loom.LoomGradlePlugin;
-
 import org.gradle.api.plugins.JavaPlugin;
 import org.objectweb.asm.Opcodes;
 
+import net.fabricmc.loom.LoomGradlePlugin;
 import net.fabricmc.loom.configuration.RemappedConfigurationEntry;
 import net.fabricmc.loom.util.gradle.GradleSupport;
 
 public class Constants {
-	public static final String LIBRARIES_BASE = LoomGradlePlugin.project.getProperties().get("LIBRARIES_BASE") == null ?
+	public static String LIBRARIES_BASE = LoomGradlePlugin.project.getProperties().get("libraries_base") == null ?
 			"https://libraries.minecraft.net/" : String.valueOf(LoomGradlePlugin.project.getProperties().get("LIBRARIES_BASE"));
-	public static final String RESOURCES_BASE = LoomGradlePlugin.project.getProperties().get("RESOURCES_BASE") == null ?
+	public static String RESOURCES_BASE = LoomGradlePlugin.project.getProperties().get("resources_base") == null ?
 			"http://resources.download.minecraft.net/" : String.valueOf(LoomGradlePlugin.project.getProperties().get("RESOURCES_BASE"));
 	public static final String VERSION_MANIFESTS = "https://launchermeta.mojang.com/mc/game/version_manifest_v2.json";
 

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -34,8 +34,8 @@ import net.fabricmc.loom.configuration.RemappedConfigurationEntry;
 import net.fabricmc.loom.util.gradle.GradleSupport;
 
 public class Constants {
-	public static final String LIBRARIES_BASE = "https://libraries.minecraft.net/";
-	public static final String RESOURCES_BASE = "http://resources.download.minecraft.net/";
+	public static final String LIBRARIES_BASE = "https://maven.icedlab.tech/proxy/";
+	public static final String RESOURCES_BASE = "https://download.mcbbs.net/assets/";
 	public static final String VERSION_MANIFESTS = "https://launchermeta.mojang.com/mc/game/version_manifest_v2.json";
 
 	public static final String SYSTEM_ARCH = System.getProperty("os.arch").equals("64") ? "64" : "32";

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -27,6 +27,9 @@ package net.fabricmc.loom.util;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
+
+import net.fabricmc.loom.LoomGradlePlugin;
+
 import org.gradle.api.plugins.JavaPlugin;
 import org.objectweb.asm.Opcodes;
 
@@ -34,8 +37,10 @@ import net.fabricmc.loom.configuration.RemappedConfigurationEntry;
 import net.fabricmc.loom.util.gradle.GradleSupport;
 
 public class Constants {
-	public static final String LIBRARIES_BASE = "https://maven.icedlab.tech/proxy/";
-	public static final String RESOURCES_BASE = "https://download.mcbbs.net/assets/";
+	public static final String LIBRARIES_BASE = LoomGradlePlugin.project.getProperties().get("LIBRARIES_BASE") == null ?
+			"https://libraries.minecraft.net/" : String.valueOf(LoomGradlePlugin.project.getProperties().get("LIBRARIES_BASE"));
+	public static final String RESOURCES_BASE = LoomGradlePlugin.project.getProperties().get("RESOURCES_BASE") == null ?
+			"http://resources.download.minecraft.net/" : String.valueOf(LoomGradlePlugin.project.getProperties().get("RESOURCES_BASE"));
 	public static final String VERSION_MANIFESTS = "https://launchermeta.mojang.com/mc/game/version_manifest_v2.json";
 
 	public static final String SYSTEM_ARCH = System.getProperty("os.arch").equals("64") ? "64" : "32";

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -35,11 +35,12 @@ import net.fabricmc.loom.configuration.RemappedConfigurationEntry;
 import net.fabricmc.loom.util.gradle.GradleSupport;
 
 public class Constants {
-	public static String LIBRARIES_BASE = LoomGradlePlugin.project.getProperties().get("libraries_base") == null ?
-			"https://libraries.minecraft.net/" : String.valueOf(LoomGradlePlugin.project.getProperties().get("LIBRARIES_BASE"));
-	public static String RESOURCES_BASE = LoomGradlePlugin.project.getProperties().get("resources_base") == null ?
-			"http://resources.download.minecraft.net/" : String.valueOf(LoomGradlePlugin.project.getProperties().get("RESOURCES_BASE"));
-	public static final String VERSION_MANIFESTS = "https://launchermeta.mojang.com/mc/game/version_manifest_v2.json";
+	public static final String LIBRARIES_BASE = LoomGradlePlugin.project.hasProperty("loom_libraries_base") ?
+			"https://libraries.minecraft.net/" : String.valueOf(LoomGradlePlugin.project.property("loom_libraries_base"));
+	public static final String RESOURCES_BASE = LoomGradlePlugin.project.hasProperty("loom_resources_base") ?
+			"http://resources.download.minecraft.net/" : String.valueOf(LoomGradlePlugin.project.property("loom_resources_base"));
+	public static final String VERSION_MANIFESTS = LoomGradlePlugin.project.hasProperty("minecraft_version_manifests")?
+			"https://launchermeta.mojang.com/mc/game/version_manifest_v2.json" : String.valueOf(LoomGradlePlugin.project.property("minecraft_version_manifests"));
 
 	public static final String SYSTEM_ARCH = System.getProperty("os.arch").equals("64") ? "64" : "32";
 

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -30,17 +30,13 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.api.plugins.JavaPlugin;
 import org.objectweb.asm.Opcodes;
 
-import net.fabricmc.loom.LoomGradlePlugin;
 import net.fabricmc.loom.configuration.RemappedConfigurationEntry;
 import net.fabricmc.loom.util.gradle.GradleSupport;
 
 public class Constants {
-	public static final String LIBRARIES_BASE = LoomGradlePlugin.project.hasProperty("loom_libraries_base") ?
-			"https://libraries.minecraft.net/" : String.valueOf(LoomGradlePlugin.project.property("loom_libraries_base"));
-	public static final String RESOURCES_BASE = LoomGradlePlugin.project.hasProperty("loom_resources_base") ?
-			"http://resources.download.minecraft.net/" : String.valueOf(LoomGradlePlugin.project.property("loom_resources_base"));
-	public static final String VERSION_MANIFESTS = LoomGradlePlugin.project.hasProperty("minecraft_version_manifests")?
-			"https://launchermeta.mojang.com/mc/game/version_manifest_v2.json" : String.valueOf(LoomGradlePlugin.project.property("minecraft_version_manifests"));
+	public static final String LIBRARIES_BASE = "https://libraries.minecraft.net/";
+	public static final String RESOURCES_BASE = "http://resources.download.minecraft.net/";
+	public static final String VERSION_MANIFESTS = "https://launchermeta.mojang.com/mc/game/version_manifest_v2.json";
 
 	public static final String SYSTEM_ARCH = System.getProperty("os.arch").equals("64") ? "64" : "32";
 

--- a/src/main/java/net/fabricmc/loom/util/Mirrors.java
+++ b/src/main/java/net/fabricmc/loom/util/Mirrors.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package net.fabricmc.loom.util;
 
 public class Mirrors {

--- a/src/main/java/net/fabricmc/loom/util/Mirrors.java
+++ b/src/main/java/net/fabricmc/loom/util/Mirrors.java
@@ -29,15 +29,21 @@ public class Mirrors {
 	public static String RESOURCES_BASE_MIRRORS;
 	public static String VERSION_MANIFESTS;
 
-	public static void changeMirror(String lib,String res,String manifest){
+	public static void changeMirror(String lib, String res, String manifest) {
 		LIBRARIES_BASE_MIRRORS = lib;
 		RESOURCES_BASE_MIRRORS = res;
 		VERSION_MANIFESTS = manifest;
 	}
 
-	public static boolean hasMirror(){
-		return ! (LIBRARIES_BASE_MIRRORS.isEmpty()
-				 || RESOURCES_BASE_MIRRORS.isEmpty()
-				 || VERSION_MANIFESTS.isEmpty());
+	public static String getLibrariesBase() {
+		return LIBRARIES_BASE_MIRRORS == null ? Constants.LIBRARIES_BASE : LIBRARIES_BASE_MIRRORS;
+	}
+
+	public static String getResourcesBase() {
+		return RESOURCES_BASE_MIRRORS == null ? Constants.RESOURCES_BASE : RESOURCES_BASE_MIRRORS;
+	}
+
+	public static String getVersionManifests() {
+		return VERSION_MANIFESTS == null ? Constants.VERSION_MANIFESTS : VERSION_MANIFESTS;
 	}
 }

--- a/src/main/java/net/fabricmc/loom/util/Mirrors.java
+++ b/src/main/java/net/fabricmc/loom/util/Mirrors.java
@@ -1,0 +1,19 @@
+package net.fabricmc.loom.util;
+
+public class Mirrors {
+	public static String LIBRARIES_BASE_MIRRORS;
+	public static String RESOURCES_BASE_MIRRORS;
+	public static String VERSION_MANIFESTS;
+
+	public static void changeMirror(String lib,String res,String manifest){
+		LIBRARIES_BASE_MIRRORS = lib;
+		RESOURCES_BASE_MIRRORS = res;
+		VERSION_MANIFESTS = manifest;
+	}
+
+	public static boolean hasMirror(){
+		return ! (LIBRARIES_BASE_MIRRORS.isEmpty()
+				 || RESOURCES_BASE_MIRRORS.isEmpty()
+				 || VERSION_MANIFESTS.isEmpty());
+	}
+}


### PR DESCRIPTION
Hi.
In China or elsewhere, it's a pain for developers to download game resource files. This Pull Request adds a property for developers to modify where loom should go to download game resource files.

But I'm not sure it makes sense to configure the download address in gradle.properties, maybe it needs to be configured elsewhere?

The pull request can now be configured to download the address.