### PR TITLE
Fix removing of jar processors not marking the file as invalid.

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/processors/JarProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/JarProcessor.java
@@ -35,7 +35,8 @@ public interface JarProcessor {
 	void process(File file);
 
 	/**
-	 * Return true to make all jar processors run again, return false to use the existing results of jar processing.
+	 * Return a id/hash of the current state, when changed the jar will be re-processed.
+	 * Just return the classname or something unique if there is no state to your JarProcessor
 	 */
-	boolean isInvalid(File file);
+	String getId();
 }

--- a/src/main/java/net/fabricmc/loom/util/CloseableList.java
+++ b/src/main/java/net/fabricmc/loom/util/CloseableList.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2021 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+
+public class CloseableList<T extends Closeable> extends ArrayList<T> implements Closeable {
+	@Override
+	public void close() throws IOException {
+		IOException exception = null;
+
+		for (T t : this) {
+			try {
+				t.close();
+			} catch (IOException e) {
+				if (exception == null) {
+					exception = new IOException("Failed to close list");
+				}
+
+				exception.addSuppressed(e);
+			}
+		}
+
+		if (exception != null) {
+			throw exception;
+		}
+	}
+}


### PR DESCRIPTION
I might just store a list of the jar processors used instead of breaking the api. Feedback is welcome. 