### PR TITLE
Use Property in LoomGradleExtension & Move task groups to constants

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -93,8 +93,6 @@ public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 
 	boolean isRootProject();
 
-	boolean isShareCaches();
-
 	default boolean ideSync() {
 		return Boolean.parseBoolean(System.getProperty("idea.sync.active", "false"));
 	}

--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -102,5 +102,6 @@ public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 		return String.format("https://maven.fabricmc.net/net/fabricmc/intermediary/%1$s/intermediary-%1$s-v2.jar", minecraftVersion);
 	}
 
-	MixinApExtension getMixinApExtension();
+	@Override
+	MixinApExtension getMixin();
 }

--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -107,8 +107,6 @@ public interface LoomGradleExtensionAPI {
 		return getGameJarProcessors().get();
 	}
 
-	@Deprecated(forRemoval = true)
-	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default void addJarProcessor(JarProcessor processor) {
 		getDeprecationHelper().replaceWithInLoom0_11("jarProcessors", "gameJarProcessors");
 		getGameJarProcessors().add(processor);

--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -32,7 +32,6 @@ import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.model.ReplacedBy;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.jetbrains.annotations.ApiStatus;
@@ -41,68 +40,79 @@ import net.fabricmc.loom.api.decompilers.LoomDecompiler;
 import net.fabricmc.loom.configuration.ide.RunConfigSettings;
 import net.fabricmc.loom.configuration.processors.JarProcessor;
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingSpecBuilder;
+import net.fabricmc.loom.util.DeprecationHelper;
 
 /**
  * This is the public api available exposed to build scripts.
  */
 public interface LoomGradleExtensionAPI {
+	@ApiStatus.Internal
+	DeprecationHelper getDeprecationHelper();
+
 	RegularFileProperty getAccessWidenerPath();
 
-	@Deprecated
-	@ReplacedBy("accessWidenerPath")
+	@Deprecated(forRemoval = true)
+	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default File getAccessWidener() {
+		getDeprecationHelper().replaceWithInLoom0_11("accessWidener", "accessWidenerPath");
 		return getAccessWidenerPath().getAsFile().getOrNull();
 	}
 
-	@Deprecated
-	@ReplacedBy("accessWidenerPath")
+	@Deprecated(forRemoval = true)
+	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	void setAccessWidener(Object file);
 
-	Property<Boolean> getShareCaches();
+	Property<Boolean> getShareRemapCaches();
 
-	@Deprecated
-	@ReplacedBy("shareCaches")
+	@Deprecated(forRemoval = true)
+	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default void setShareCaches(boolean shareCaches) {
-		getShareCaches().set(shareCaches);
+		getDeprecationHelper().replaceWithInLoom0_11("shareCaches", "shareRemapCaches");
+		getShareRemapCaches().set(shareCaches);
 	}
 
-	@Deprecated
-	@ReplacedBy("shareCaches")
+	@Deprecated(forRemoval = true)
+	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default boolean isShareCaches() {
-		return getShareCaches().get();
+		getDeprecationHelper().replaceWithInLoom0_11("shareCaches", "shareRemapCaches");
+		return getShareRemapCaches().get();
 	}
 
-	@Deprecated
-	@ReplacedBy("shareCaches")
+	@Deprecated(forRemoval = true)
+	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default void shareCaches() {
 		setShareCaches(true);
 	}
 
 	ListProperty<LoomDecompiler> getLoomDecompilers();
 
-	@Deprecated
-	@ReplacedBy("loomDecompilers")
+	@Deprecated(forRemoval = true)
+	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default List<LoomDecompiler> getDecompilers() {
+		getDeprecationHelper().replaceWithInLoom0_11("decompilers", "loomDecompilers");
 		return getLoomDecompilers().get();
 	}
 
-	@Deprecated
-	@ReplacedBy("loomDecompilers")
+	@Deprecated(forRemoval = true)
+	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default void addDecompiler(LoomDecompiler decompiler) {
+		getDeprecationHelper().replaceWithInLoom0_11("decompilers", "loomDecompilers");
 		getLoomDecompilers().add(decompiler);
 	}
 
 	ListProperty<JarProcessor> getMinecraftJarProcessors();
 
-	@Deprecated
-	@ReplacedBy("minecraftJarProcessors")
+	@Deprecated(forRemoval = true)
+	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default List<JarProcessor> getJarProcessors() {
+		getDeprecationHelper().replaceWithInLoom0_11("jarProcessors", "minecraftJarProcessors");
 		return getMinecraftJarProcessors().get();
 	}
 
-	@Deprecated
-	@ReplacedBy("minecraftJarProcessors")
+	@Deprecated(forRemoval = true)
+	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default void addJarProcessor(JarProcessor processor) {
+		getDeprecationHelper().replaceWithInLoom0_11("jarProcessors", "minecraftJarProcessors");
 		getMinecraftJarProcessors().add(processor);
 	}
 
@@ -116,29 +126,33 @@ public interface LoomGradleExtensionAPI {
 
 	Property<String> getMixinRefmapName();
 
-	@Deprecated
-	@ReplacedBy("mixinRefmapName")
+	@Deprecated(forRemoval = true)
+	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default String getRefmapName() {
+		getDeprecationHelper().replaceWithInLoom0_11("refmapName", "mixinRefmapName");
 		return getMixinRefmapName().get();
 	}
 
-	@Deprecated
-	@ReplacedBy("mixinRefmapName")
+	@Deprecated(forRemoval = true)
+	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default void setRefmapName(String refmapName) {
+		getDeprecationHelper().replaceWithInLoom0_11("refmapName", "mixinRefmapName");
 		getMixinRefmapName().set(refmapName);
 	}
 
 	Property<Boolean> getRemapArchives();
 
-	@Deprecated
-	@ReplacedBy("remapArchives")
+	@Deprecated(forRemoval = true)
+	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default boolean isRemapMod() {
+		getDeprecationHelper().replaceWithInLoom0_11("remapMod", "remapArchives");
 		return getRemapArchives().get();
 	}
 
-	@Deprecated
-	@ReplacedBy("remapArchives")
+	@Deprecated(forRemoval = true)
+	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default void setRemapMod(boolean remapMod) {
+		getDeprecationHelper().replaceWithInLoom0_11("remapMod", "remapArchives");
 		getRemapArchives().set(remapMod);
 	}
 
@@ -151,15 +165,17 @@ public interface LoomGradleExtensionAPI {
 
 	Property<String> getCustomMinecraftManifest();
 
-	@Deprecated
-	@ReplacedBy("customMinecraftManifest")
+	@Deprecated(forRemoval = true)
+	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default void setCustomManifest(String customManifest) {
+		getDeprecationHelper().replaceWithInLoom0_11("customManifest", "customMinecraftManifest");
 		getCustomMinecraftManifest().set(customManifest);
 	}
 
-	@Deprecated
-	@ReplacedBy("customMinecraftManifest")
+	@Deprecated(forRemoval = true)
+	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default String getCustomManifest() {
+		getDeprecationHelper().replaceWithInLoom0_11("customManifest", "customMinecraftManifest");
 		return getCustomMinecraftManifest().getOrNull();
 	}
 }

--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -31,6 +31,10 @@ import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ReplacedBy;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
 import org.jetbrains.annotations.ApiStatus;
 
 import net.fabricmc.loom.api.decompilers.LoomDecompiler;
@@ -42,25 +46,65 @@ import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingSpecBuil
  * This is the public api available exposed to build scripts.
  */
 public interface LoomGradleExtensionAPI {
-	File getAccessWidener();
+	RegularFileProperty getAccessWidenerPath();
 
+	@Deprecated
+	@ReplacedBy("accessWidenerPath")
+	default File getAccessWidener() {
+		return getAccessWidenerPath().getAsFile().get();
+	}
+
+	@Deprecated
+	@ReplacedBy("accessWidenerPath")
 	void setAccessWidener(Object file);
 
-	void setShareCaches(boolean shareCaches);
+	Property<Boolean> getShareCaches();
 
-	boolean isShareCaches();
+	@Deprecated
+	@ReplacedBy("shareCaches")
+	default void setShareCaches(boolean shareCaches) {
+		getShareCaches().set(shareCaches);
+	}
 
+	@Deprecated
+	@ReplacedBy("shareCaches")
+	default boolean isShareCaches() {
+		return getShareCaches().get();
+	}
+
+	@Deprecated
+	@ReplacedBy("shareCaches")
 	default void shareCaches() {
 		setShareCaches(true);
 	}
 
-	List<LoomDecompiler> getDecompilers();
+	ListProperty<LoomDecompiler> getLoomDecompilers();
 
-	void addDecompiler(LoomDecompiler decompiler);
+	@Deprecated
+	@ReplacedBy("loomDecompilers")
+	default List<LoomDecompiler> getDecompilers() {
+		return getLoomDecompilers().get();
+	}
 
-	List<JarProcessor> getJarProcessors();
+	@Deprecated
+	@ReplacedBy("loomDecompilers")
+	default void addDecompiler(LoomDecompiler decompiler) {
+		getLoomDecompilers().add(decompiler);
+	}
 
-	void addJarProcessor(JarProcessor processor);
+	ListProperty<JarProcessor> getMinecraftJarProcessors();
+
+	@Deprecated
+	@ReplacedBy("minecraftJarProcessors")
+	default List<JarProcessor> getJarProcessors() {
+		return getMinecraftJarProcessors().get();
+	}
+
+	@Deprecated
+	@ReplacedBy("minecraftJarProcessors")
+	default void addJarProcessor(JarProcessor processor) {
+		getMinecraftJarProcessors().add(processor);
+	}
 
 	ConfigurableFileCollection getLog4jConfigs();
 
@@ -70,13 +114,33 @@ public interface LoomGradleExtensionAPI {
 
 	Dependency layered(Action<LayeredMappingSpecBuilder> action);
 
-	String getRefmapName();
+	Property<String> getMixinRefmapName();
 
-	void setRefmapName(String refmapName);
+	@Deprecated
+	@ReplacedBy("mixinRefmapName")
+	default String getRefmapName() {
+		return getMixinRefmapName().get();
+	}
 
-	boolean isRemapMod();
+	@Deprecated
+	@ReplacedBy("mixinRefmapName")
+	default void setRefmapName(String refmapName) {
+		getMixinRefmapName().set(refmapName);
+	}
 
-	void setRemapMod(boolean remapMod);
+	Property<Boolean> getRemapArchives();
+
+	@Deprecated
+	@ReplacedBy("remapArchives")
+	default boolean isRemapMod() {
+		return getRemapArchives().get();
+	}
+
+	@Deprecated
+	@ReplacedBy("remapArchives")
+	default void setRemapMod(boolean remapMod) {
+		getRemapArchives().set(remapMod);
+	}
 
 	void runs(Action<NamedDomainObjectContainer<RunConfigSettings>> action);
 
@@ -85,7 +149,17 @@ public interface LoomGradleExtensionAPI {
 	@ApiStatus.Experimental
 	void mixin(Action<MixinApExtensionAPI> action);
 
-	void setCustomManifest(String customManifest);
+	Property<String> getCustomMinecraftManifest();
 
-	String getCustomManifest();
+	@Deprecated
+	@ReplacedBy("customMinecraftManifest")
+	default void setCustomManifest(String customManifest) {
+		getCustomMinecraftManifest().set(customManifest);
+	}
+
+	@Deprecated
+	@ReplacedBy("customMinecraftManifest")
+	default String getCustomManifest() {
+		return getCustomMinecraftManifest().get();
+	}
 }

--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -82,7 +82,7 @@ public interface LoomGradleExtensionAPI {
 	}
 
 	default void shareCaches() {
-		setShareCaches(true);
+		getShareRemapCaches().set(true);
 	}
 
 	ListProperty<LoomDecompiler> getGameDecompilers();

--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -60,7 +60,10 @@ public interface LoomGradleExtensionAPI {
 
 	@Deprecated(forRemoval = true)
 	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
-	void setAccessWidener(File file);
+	default void setAccessWidener(File file) {
+		getDeprecationHelper().replaceWithInLoom0_11("accessWidener", "accessWidenerPath");
+		getAccessWidenerPath().set(file);
+	}
 
 	Property<Boolean> getShareRemapCaches();
 

--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -78,42 +78,37 @@ public interface LoomGradleExtensionAPI {
 		return getShareRemapCaches().get();
 	}
 
-	@Deprecated(forRemoval = true)
-	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default void shareCaches() {
 		setShareCaches(true);
 	}
 
-	ListProperty<LoomDecompiler> getLoomDecompilers();
+	ListProperty<LoomDecompiler> getGameDecompilers();
 
 	@Deprecated(forRemoval = true)
 	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default List<LoomDecompiler> getDecompilers() {
-		getDeprecationHelper().replaceWithInLoom0_11("decompilers", "loomDecompilers");
-		return getLoomDecompilers().get();
+		getDeprecationHelper().replaceWithInLoom0_11("decompilers", "gameDecompilers");
+		return getGameDecompilers().get();
 	}
 
-	@Deprecated(forRemoval = true)
-	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default void addDecompiler(LoomDecompiler decompiler) {
-		getDeprecationHelper().replaceWithInLoom0_11("decompilers", "loomDecompilers");
-		getLoomDecompilers().add(decompiler);
+		getGameDecompilers().add(decompiler);
 	}
 
-	ListProperty<JarProcessor> getMinecraftJarProcessors();
+	ListProperty<JarProcessor> getGameJarProcessors();
 
 	@Deprecated(forRemoval = true)
 	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default List<JarProcessor> getJarProcessors() {
-		getDeprecationHelper().replaceWithInLoom0_11("jarProcessors", "minecraftJarProcessors");
-		return getMinecraftJarProcessors().get();
+		getDeprecationHelper().replaceWithInLoom0_11("jarProcessors", "gameJarProcessors");
+		return getGameJarProcessors().get();
 	}
 
 	@Deprecated(forRemoval = true)
 	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default void addJarProcessor(JarProcessor processor) {
-		getDeprecationHelper().replaceWithInLoom0_11("jarProcessors", "minecraftJarProcessors");
-		getMinecraftJarProcessors().add(processor);
+		getDeprecationHelper().replaceWithInLoom0_11("jarProcessors", "gameJarProcessors");
+		getGameJarProcessors().add(processor);
 	}
 
 	ConfigurableFileCollection getLog4jConfigs();
@@ -124,20 +119,18 @@ public interface LoomGradleExtensionAPI {
 
 	Dependency layered(Action<LayeredMappingSpecBuilder> action);
 
-	Property<String> getMixinRefmapName();
-
 	@Deprecated(forRemoval = true)
 	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default String getRefmapName() {
-		getDeprecationHelper().replaceWithInLoom0_11("refmapName", "mixinRefmapName");
-		return getMixinRefmapName().get();
+		getDeprecationHelper().replaceWithInLoom0_11("refmapName", "mixin.defaultRefmapName");
+		return getMixin().getDefaultRefmapName().get();
 	}
 
 	@Deprecated(forRemoval = true)
 	@ApiStatus.ScheduledForRemoval(inVersion = "0.11")
 	default void setRefmapName(String refmapName) {
-		getDeprecationHelper().replaceWithInLoom0_11("refmapName", "mixinRefmapName");
-		getMixinRefmapName().set(refmapName);
+		getDeprecationHelper().replaceWithInLoom0_11("refmapName", "mixin.defaultRefmapName");
+		getMixin().getDefaultRefmapName().set(refmapName);
 	}
 
 	Property<Boolean> getRemapArchives();
@@ -162,6 +155,9 @@ public interface LoomGradleExtensionAPI {
 
 	@ApiStatus.Experimental
 	void mixin(Action<MixinApExtensionAPI> action);
+
+	@ApiStatus.Experimental
+	MixinApExtensionAPI getMixin();
 
 	Property<String> getCustomMinecraftManifest();
 

--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -108,7 +108,6 @@ public interface LoomGradleExtensionAPI {
 	}
 
 	default void addJarProcessor(JarProcessor processor) {
-		getDeprecationHelper().replaceWithInLoom0_11("jarProcessors", "gameJarProcessors");
 		getGameJarProcessors().add(processor);
 	}
 

--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -51,7 +51,7 @@ public interface LoomGradleExtensionAPI {
 	@Deprecated
 	@ReplacedBy("accessWidenerPath")
 	default File getAccessWidener() {
-		return getAccessWidenerPath().getAsFile().get();
+		return getAccessWidenerPath().getAsFile().getOrNull();
 	}
 
 	@Deprecated
@@ -160,6 +160,6 @@ public interface LoomGradleExtensionAPI {
 	@Deprecated
 	@ReplacedBy("customMinecraftManifest")
 	default String getCustomManifest() {
-		return getCustomMinecraftManifest().get();
+		return getCustomMinecraftManifest().getOrNull();
 	}
 }

--- a/src/main/java/net/fabricmc/loom/api/MixinApExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/MixinApExtensionAPI.java
@@ -35,7 +35,7 @@ public interface MixinApExtensionAPI {
 	 * Apply Mixin AP to sourceSet.
 	 * @param sourceSet the sourceSet that applies Mixin AP.
 	 * @param refmapName the output ref-map name. By default this will
-	 *                      be {@link net.fabricmc.loom.LoomGradleExtension#getRefmapName()}
+	 *                      be {@link net.fabricmc.loom.LoomGradleExtension#getMixinRefmapName()}
 	 * @param action used for filter the mixin json files. By default this will be all files
 	 *                  with name {@code *.mixins.json} that is inside the {@code resources} folder
 	 *                  of {@code sourceSet}.

--- a/src/main/java/net/fabricmc/loom/api/MixinApExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/MixinApExtensionAPI.java
@@ -25,17 +25,19 @@
 package net.fabricmc.loom.api;
 
 import org.gradle.api.Action;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.util.PatternSet;
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Experimental
 public interface MixinApExtensionAPI {
+	Property<String> getDefaultRefmapName();
+
 	/**
 	 * Apply Mixin AP to sourceSet.
 	 * @param sourceSet the sourceSet that applies Mixin AP.
-	 * @param refmapName the output ref-map name. By default this will
-	 *                      be {@link net.fabricmc.loom.LoomGradleExtension#getMixinRefmapName()}
+	 * @param refmapName the output ref-map name. By default this will be {@link #getDefaultRefmapName()}
 	 * @param action used for filter the mixin json files. By default this will be all files
 	 *                  with name {@code *.mixins.json} that is inside the {@code resources} folder
 	 *                  of {@code sourceSet}.

--- a/src/main/java/net/fabricmc/loom/build/MixinRefmapHelper.java
+++ b/src/main/java/net/fabricmc/loom/build/MixinRefmapHelper.java
@@ -44,7 +44,7 @@ public final class MixinRefmapHelper {
 	private MixinRefmapHelper() { }
 
 	public static boolean addRefmapName(Project project, Path outputPath) {
-		MixinApExtension mixin = LoomGradleExtension.get(project).getMixinApExtension();
+		MixinApExtension mixin = LoomGradleExtension.get(project).getMixin();
 		File output = outputPath.toFile();
 
 		return mixin.getMixinSourceSetsStream().map(sourceSet -> {

--- a/src/main/java/net/fabricmc/loom/build/mixin/AnnotationProcessorInvoker.java
+++ b/src/main/java/net/fabricmc/loom/build/mixin/AnnotationProcessorInvoker.java
@@ -65,7 +65,7 @@ public abstract class AnnotationProcessorInvoker<T extends Task> {
 	}
 
 	protected static Collection<Configuration> getApConfigurations(Project project, Function<String, String> getApConfigNameFunc) {
-		MixinApExtension mixin = LoomGradleExtension.get(project).getMixinApExtension();
+		MixinApExtension mixin = LoomGradleExtension.get(project).getMixin();
 		return mixin.getApConfigurationsStream(getApConfigNameFunc).collect(Collectors.toList());
 	}
 

--- a/src/main/java/net/fabricmc/loom/build/mixin/JavaApInvoker.java
+++ b/src/main/java/net/fabricmc/loom/build/mixin/JavaApInvoker.java
@@ -46,7 +46,7 @@ public class JavaApInvoker extends AnnotationProcessorInvoker<JavaCompile> {
 	}
 
 	private static Map<SourceSet, JavaCompile> getInvokerTasks(Project project) {
-		MixinApExtension mixin = LoomGradleExtension.get(project).getMixinApExtension();
+		MixinApExtension mixin = LoomGradleExtension.get(project).getMixin();
 		return mixin.getInvokerTasksStream(AnnotationProcessorInvoker.JAVA)
 				.collect(Collectors.toMap(Map.Entry::getKey, entry -> Objects.requireNonNull((JavaCompile) entry.getValue())));
 	}

--- a/src/main/java/net/fabricmc/loom/build/mixin/KaptApInvoker.java
+++ b/src/main/java/net/fabricmc/loom/build/mixin/KaptApInvoker.java
@@ -66,7 +66,7 @@ public class KaptApInvoker extends AnnotationProcessorInvoker<JavaCompile> {
 	}
 
 	private static Map<SourceSet, JavaCompile> getInvokerTasks(Project project) {
-		MixinApExtension mixin = LoomGradleExtension.get(project).getMixinApExtension();
+		MixinApExtension mixin = LoomGradleExtension.get(project).getMixin();
 		return mixin.getInvokerTasksStream(AnnotationProcessorInvoker.JAVA)
 				.collect(Collectors.toMap(Map.Entry::getKey, entry -> Objects.requireNonNull((JavaCompile) entry.getValue())));
 	}

--- a/src/main/java/net/fabricmc/loom/build/mixin/ScalaApInvoker.java
+++ b/src/main/java/net/fabricmc/loom/build/mixin/ScalaApInvoker.java
@@ -47,7 +47,7 @@ public class ScalaApInvoker extends AnnotationProcessorInvoker<ScalaCompile> {
 	}
 
 	private static Map<SourceSet, ScalaCompile> getInvokerTasks(Project project) {
-		MixinApExtension mixin = LoomGradleExtension.get(project).getMixinApExtension();
+		MixinApExtension mixin = LoomGradleExtension.get(project).getMixin();
 		return mixin.getInvokerTasksStream(AnnotationProcessorInvoker.SCALA)
 				.collect(Collectors.toMap(Map.Entry::getKey, entry -> Objects.requireNonNull((ScalaCompile) entry.getValue())));
 	}

--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -145,7 +145,7 @@ public final class CompileConfiguration {
 			System.setProperty("log4j.skipJansi", "true");
 
 			project.getLogger().info("Configuring compiler arguments for Java");
-			MixinApExtension mixinApExtension = LoomGradleExtension.get(project).getMixinApExtension();
+			MixinApExtension mixinApExtension = LoomGradleExtension.get(project).getMixin();
 			mixinApExtension.init();
 
 			new JavaApInvoker(project).configureMixin();

--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -129,9 +129,10 @@ public final class CompileConfiguration {
 			project.getTasks().getByName("cleanEclipse").finalizedBy(project.getTasks().getByName("cleanEclipseRuns"));
 
 			SetupIntelijRunConfigs.setup(project);
+			extension.getRemapArchives().finalizeValue();
 
 			// Enables the default mod remapper
-			if (extension.isRemapMod()) {
+			if (extension.getRemapArchives().get()) {
 				RemapConfiguration.setupDefaultRemap(project);
 			} else {
 				Jar jarTask = (Jar) project.getTasks().getByName("jar");

--- a/src/main/java/net/fabricmc/loom/configuration/RemapConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/RemapConfiguration.java
@@ -97,7 +97,7 @@ public class RemapConfiguration {
 		// TODO what is this for?
 		Task parentTask = project.getTasks().getByName("build");
 
-		if (extension.getShareCaches().get()) {
+		if (extension.getShareRemapCaches().get()) {
 			Project rootProject = project.getRootProject();
 
 			if (extension.isRootProject()) {
@@ -155,7 +155,7 @@ public class RemapConfiguration {
 				});
 			}
 
-			if (extension.getShareCaches().get()) {
+			if (extension.getShareRemapCaches().get()) {
 				remapSourcesJarTask.setSourceRemapper(remapper);
 			}
 

--- a/src/main/java/net/fabricmc/loom/configuration/RemapConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/RemapConfiguration.java
@@ -97,7 +97,7 @@ public class RemapConfiguration {
 		// TODO what is this for?
 		Task parentTask = project.getTasks().getByName("build");
 
-		if (extension.isShareCaches()) {
+		if (extension.getShareCaches().get()) {
 			Project rootProject = project.getRootProject();
 
 			if (extension.isRootProject()) {
@@ -155,7 +155,7 @@ public class RemapConfiguration {
 				});
 			}
 
-			if (extension.isShareCaches()) {
+			if (extension.getShareCaches().get()) {
 				remapSourcesJarTask.setSourceRemapper(remapper);
 			}
 

--- a/src/main/java/net/fabricmc/loom/configuration/accesswidener/AccessWidenerJarProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/accesswidener/AccessWidenerJarProcessor.java
@@ -77,14 +77,15 @@ public class AccessWidenerJarProcessor implements JarProcessor {
 	@Override
 	public void setup() {
 		LoomGradleExtension loomGradleExtension = LoomGradleExtension.get(project);
+		File awPath = loomGradleExtension.getAccessWidenerPath().getAsFile().get();
 
-		if (!loomGradleExtension.getAccessWidener().exists()) {
-			throw new RuntimeException("Could not find access widener file @ " + loomGradleExtension.getAccessWidener().getAbsolutePath());
+		if (!awPath.exists()) {
+			throw new RuntimeException("Could not find access widener file @ " + awPath.getAbsolutePath());
 		}
 
-		inputHash = Checksum.sha256(loomGradleExtension.getAccessWidener());
+		inputHash = Checksum.sha256(awPath);
 
-		try (BufferedReader reader = new BufferedReader(new FileReader(loomGradleExtension.getAccessWidener()))) {
+		try (BufferedReader reader = new BufferedReader(new FileReader(awPath))) {
 			accessWidenerReader.read(reader);
 		} catch (IOException e) {
 			throw new RuntimeException("Failed to read project access widener file");

--- a/src/main/java/net/fabricmc/loom/configuration/accesswidener/AccessWidenerJarProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/accesswidener/AccessWidenerJarProcessor.java
@@ -77,7 +77,7 @@ public class AccessWidenerJarProcessor implements JarProcessor {
 	@Override
 	public void setup() {
 		LoomGradleExtension loomGradleExtension = LoomGradleExtension.get(project);
-		File awPath = loomGradleExtension.getAccessWidenerPath().getAsFile().get();
+		File awPath = loomGradleExtension.getAccessWidenerPath().get().getAsFile();
 
 		if (!awPath.exists()) {
 			throw new RuntimeException("Could not find access widener file @ " + awPath.getAbsolutePath());

--- a/src/main/java/net/fabricmc/loom/configuration/providers/MinecraftProviderImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/MinecraftProviderImpl.java
@@ -212,7 +212,7 @@ public class MinecraftProviderImpl extends DependencyProvider implements Minecra
 	}
 
 	private boolean hasRecentValidManifest() throws IOException {
-		if (getExtension().getCustomManifest() != null) {
+		if (getExtension().getCustomMinecraftManifest().isPresent()) {
 			return false;
 		}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/MinecraftProviderImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/MinecraftProviderImpl.java
@@ -121,7 +121,7 @@ public class MinecraftProviderImpl extends DependencyProvider implements Minecra
 	}
 
 	private void downloadMcJson(boolean offline) throws IOException {
-		if (getExtension().getShareCaches().get() && !getExtension().isRootProject() && versionManifestJson.exists() && !isRefreshDeps()) {
+		if (getExtension().getShareRemapCaches().get() && !getExtension().isRootProject() && versionManifestJson.exists() && !isRefreshDeps()) {
 			return;
 		}
 
@@ -233,7 +233,7 @@ public class MinecraftProviderImpl extends DependencyProvider implements Minecra
 	}
 
 	private void downloadJars(Logger logger) throws IOException {
-		if (getExtension().getShareCaches().get() && !getExtension().isRootProject() && minecraftClientJar.exists() && minecraftServerJar.exists() && !isRefreshDeps()) {
+		if (getExtension().getShareRemapCaches().get() && !getExtension().isRootProject() && minecraftClientJar.exists() && minecraftServerJar.exists() && !isRefreshDeps()) {
 			return;
 		}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/MinecraftProviderImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/MinecraftProviderImpl.java
@@ -121,7 +121,7 @@ public class MinecraftProviderImpl extends DependencyProvider implements Minecra
 	}
 
 	private void downloadMcJson(boolean offline) throws IOException {
-		if (getExtension().isShareCaches() && !getExtension().isRootProject() && versionManifestJson.exists() && !isRefreshDeps()) {
+		if (getExtension().getShareCaches().get() && !getExtension().isRootProject() && versionManifestJson.exists() && !isRefreshDeps()) {
 			return;
 		}
 
@@ -145,10 +145,10 @@ public class MinecraftProviderImpl extends DependencyProvider implements Minecra
 
 		Optional<ManifestVersion.Versions> optionalVersion = Optional.empty();
 
-		if (getExtension().getCustomManifest() != null) {
+		if (getExtension().getCustomMinecraftManifest().isPresent()) {
 			ManifestVersion.Versions customVersion = new ManifestVersion.Versions();
 			customVersion.id = minecraftVersion;
-			customVersion.url = getExtension().getCustomManifest();
+			customVersion.url = getExtension().getCustomMinecraftManifest().get();
 			optionalVersion = Optional.of(customVersion);
 			getProject().getLogger().lifecycle("Using custom minecraft manifest");
 		}
@@ -233,7 +233,7 @@ public class MinecraftProviderImpl extends DependencyProvider implements Minecra
 	}
 
 	private void downloadJars(Logger logger) throws IOException {
-		if (getExtension().isShareCaches() && !getExtension().isRootProject() && minecraftClientJar.exists() && minecraftServerJar.exists() && !isRefreshDeps()) {
+		if (getExtension().getShareCaches().get() && !getExtension().isRootProject() && minecraftClientJar.exists() && minecraftServerJar.exists() && !isRefreshDeps()) {
 			return;
 		}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingsProviderImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingsProviderImpl.java
@@ -177,11 +177,13 @@ public class MappingsProviderImpl extends DependencyProvider implements Mappings
 
 		LoomGradleExtension extension = getExtension();
 
-		if (extension.getAccessWidener() != null) {
-			extension.addJarProcessor(new AccessWidenerJarProcessor(getProject()));
+		if (extension.getAccessWidenerPath().isPresent()) {
+			extension.getMinecraftJarProcessors().add(new AccessWidenerJarProcessor(getProject()));
 		}
 
-		JarProcessorManager processorManager = new JarProcessorManager(extension.getJarProcessors());
+		extension.getAccessWidenerPath().finalizeValue();
+		extension.getMinecraftJarProcessors().finalizeValue();
+		JarProcessorManager processorManager = new JarProcessorManager(extension.getMinecraftJarProcessors().get());
 		extension.setJarProcessorManager(processorManager);
 		processorManager.setupProcessors();
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingsProviderImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingsProviderImpl.java
@@ -178,12 +178,12 @@ public class MappingsProviderImpl extends DependencyProvider implements Mappings
 		LoomGradleExtension extension = getExtension();
 
 		if (extension.getAccessWidenerPath().isPresent()) {
-			extension.getMinecraftJarProcessors().add(new AccessWidenerJarProcessor(getProject()));
+			extension.getGameJarProcessors().add(new AccessWidenerJarProcessor(getProject()));
 		}
 
 		extension.getAccessWidenerPath().finalizeValue();
-		extension.getMinecraftJarProcessors().finalizeValue();
-		JarProcessorManager processorManager = new JarProcessorManager(extension.getMinecraftJarProcessors().get());
+		extension.getGameJarProcessors().finalizeValue();
+		JarProcessorManager processorManager = new JarProcessorManager(extension.getGameJarProcessors().get());
 		extension.setJarProcessorManager(processorManager);
 		processorManager.setupProcessors();
 

--- a/src/main/java/net/fabricmc/loom/decompilers/DecompilerConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/decompilers/DecompilerConfiguration.java
@@ -36,7 +36,7 @@ public final class DecompilerConfiguration {
 
 	public static void setup(Project project) {
 		LoomGradleExtension extension = LoomGradleExtension.get(project);
-		extension.getLoomDecompilers().add(new FabricFernFlowerDecompiler(project));
-		extension.getLoomDecompilers().add(new FabricCFRDecompiler(project));
+		extension.getGameDecompilers().add(new FabricFernFlowerDecompiler(project));
+		extension.getGameDecompilers().add(new FabricCFRDecompiler(project));
 	}
 }

--- a/src/main/java/net/fabricmc/loom/decompilers/DecompilerConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/decompilers/DecompilerConfiguration.java
@@ -36,7 +36,7 @@ public final class DecompilerConfiguration {
 
 	public static void setup(Project project) {
 		LoomGradleExtension extension = LoomGradleExtension.get(project);
-		extension.addDecompiler(new FabricFernFlowerDecompiler(project));
-		extension.addDecompiler(new FabricCFRDecompiler(project));
+		extension.getLoomDecompilers().add(new FabricFernFlowerDecompiler(project));
+		extension.getLoomDecompilers().add(new FabricCFRDecompiler(project));
 	}
 }

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -43,11 +43,13 @@ import net.fabricmc.loom.configuration.providers.mappings.GradleMappingContext;
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingSpec;
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingSpecBuilder;
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsDependency;
+import net.fabricmc.loom.util.DeprecationHelper;
 
 /**
  * This class implements the public extension api.
  */
 public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionAPI {
+	protected final DeprecationHelper deprecationHelper;
 	protected final ListProperty<LoomDecompiler> decompilers;
 	protected final ListProperty<JarProcessor> jarProcessors;
 	protected final ConfigurableFileCollection log4jConfigs;
@@ -75,6 +77,13 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 		this.remapArchives = project.getObjects().property(Boolean.class)
 				.convention(true);
 		this.customManifest = project.getObjects().property(String.class);
+
+		this.deprecationHelper = new DeprecationHelper.ProjectBased(project);
+	}
+
+	@Override
+	public DeprecationHelper getDeprecationHelper() {
+		return deprecationHelper;
 	}
 
 	@Override
@@ -84,11 +93,12 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 
 	@Override
 	public void setAccessWidener(Object file) {
+		getDeprecationHelper().replaceWithInLoom0_11("accessWidener", "accessWidenerPath");
 		getAccessWidenerPath().set(getProject().file(file));
 	}
 
 	@Override
-	public Property<Boolean> getShareCaches() {
+	public Property<Boolean> getShareRemapCaches() {
 		return shareCaches;
 	}
 
@@ -162,6 +172,11 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 		private EnsureCompile() {
 			super(null, null);
 			throw new RuntimeException();
+		}
+
+		@Override
+		public DeprecationHelper getDeprecationHelper() {
+			throw new RuntimeException("Yeah... something is really wrong");
 		}
 
 		@Override

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -24,17 +24,15 @@
 
 package net.fabricmc.loom.extension;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
 import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.plugins.BasePluginConvention;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
 
 import net.fabricmc.loom.api.MixinApExtensionAPI;
 import net.fabricmc.loom.api.decompilers.LoomDecompiler;
@@ -50,65 +48,58 @@ import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsDepende
  * This class implements the public extension api.
  */
 public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionAPI {
-	protected final List<LoomDecompiler> decompilers = new ArrayList<>();
-	protected final List<JarProcessor> jarProcessors = new ArrayList<>();
+	protected final ListProperty<LoomDecompiler> decompilers;
+	protected final ListProperty<JarProcessor> jarProcessors;
 	protected final ConfigurableFileCollection log4jConfigs;
-
-	protected File accessWidener = null;
-	protected boolean shareCaches = false;
-	protected String refmapName = null;
-	protected boolean remapMod = true;
-	protected String customManifest;
+	protected final RegularFileProperty accessWidener;
+	protected final Property<Boolean> shareCaches;
+	protected final Property<String> refmapName;
+	protected final Property<Boolean> remapArchives;
+	protected final Property<String> customManifest;
 
 	private NamedDomainObjectContainer<RunConfigSettings> runConfigs;
 
 	protected LoomGradleExtensionApiImpl(Project project, LoomFiles directories) {
 		this.runConfigs = project.container(RunConfigSettings.class,
 				baseName -> new RunConfigSettings(project, baseName));
+		this.decompilers = project.getObjects().listProperty(LoomDecompiler.class)
+				.empty();
+		this.jarProcessors = project.getObjects().listProperty(JarProcessor.class)
+				.empty();
 		this.log4jConfigs = project.files(directories.getDefaultLog4jConfigFile());
+		this.accessWidener = project.getObjects().fileProperty();
+		this.shareCaches = project.getObjects().property(Boolean.class)
+				.convention(false);
+		this.refmapName = project.getObjects().property(String.class)
+				.convention(project.provider(this::getDefaultMixinRefmapName));
+		this.remapArchives = project.getObjects().property(Boolean.class)
+				.convention(true);
+		this.customManifest = project.getObjects().property(String.class);
 	}
 
 	@Override
-	public File getAccessWidener() {
+	public RegularFileProperty getAccessWidenerPath() {
 		return accessWidener;
 	}
 
 	@Override
 	public void setAccessWidener(Object file) {
-		Objects.requireNonNull(file, "Access widener file cannot be null");
-		this.accessWidener = getProject().file(file);
+		getAccessWidenerPath().set(getProject().file(file));
 	}
 
 	@Override
-	public void setShareCaches(boolean shareCaches) {
-		this.shareCaches = shareCaches;
-	}
-
-	@Override
-	public boolean isShareCaches() {
+	public Property<Boolean> getShareCaches() {
 		return shareCaches;
 	}
 
 	@Override
-	public List<LoomDecompiler> getDecompilers() {
+	public ListProperty<LoomDecompiler> getLoomDecompilers() {
 		return decompilers;
 	}
 
 	@Override
-	public void addDecompiler(LoomDecompiler decompiler) {
-		Objects.requireNonNull(decompiler, "Decompiler cannot be null");
-		decompilers.add(decompiler);
-	}
-
-	@Override
-	public List<JarProcessor> getJarProcessors() {
+	public ListProperty<JarProcessor> getMinecraftJarProcessors() {
 		return jarProcessors;
-	}
-
-	@Override
-	public void addJarProcessor(JarProcessor processor) {
-		Objects.requireNonNull(processor, "Jar processor cannot be null");
-		jarProcessors.add(processor);
 	}
 
 	@Override
@@ -120,24 +111,19 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	}
 
 	@Override
-	public String getRefmapName() {
-		if (refmapName == null || refmapName.isEmpty()) {
-			String defaultRefmapName = getProject().getConvention().getPlugin(BasePluginConvention.class).getArchivesBaseName() + "-refmap.json";
-			getProject().getLogger().info("Could not find refmap definition, will be using default name: " + defaultRefmapName);
-			refmapName = defaultRefmapName;
-		}
-
+	public Property<String> getMixinRefmapName() {
 		return refmapName;
 	}
 
-	@Override
-	public void setRefmapName(String refmapName) {
-		this.refmapName = refmapName;
+	public String getDefaultMixinRefmapName() {
+		String defaultRefmapName = getProject().getConvention().getPlugin(BasePluginConvention.class).getArchivesBaseName() + "-refmap.json";
+		getProject().getLogger().info("Could not find refmap definition, will be using default name: " + defaultRefmapName);
+		return defaultRefmapName;
 	}
 
 	@Override
-	public void setRemapMod(boolean remapMod) {
-		this.remapMod = remapMod;
+	public Property<Boolean> getRemapArchives() {
+		return remapArchives;
 	}
 
 	@Override
@@ -156,23 +142,12 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	}
 
 	@Override
-	public boolean isRemapMod() {
-		return remapMod;
-	}
-
-	@Override
 	public void mixin(Action<MixinApExtensionAPI> action) {
 		action.execute(getMixinApExtension());
 	}
 
 	@Override
-	public void setCustomManifest(String customManifest) {
-		Objects.requireNonNull(customManifest, "Custom manifest cannot be null");
-		this.customManifest = customManifest;
-	}
-
-	@Override
-	public String getCustomManifest() {
+	public Property<String> getCustomMinecraftManifest() {
 		return customManifest;
 	}
 

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -24,15 +24,12 @@
 
 package net.fabricmc.loom.extension;
 
-import java.io.File;
-
 import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.plugins.BasePluginConvention;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 
@@ -88,12 +85,6 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	@Override
 	public RegularFileProperty getAccessWidenerPath() {
 		return accessWidener;
-	}
-
-	@Override
-	public void setAccessWidener(File file) {
-		getDeprecationHelper().replaceWithInLoom0_11("accessWidener", "accessWidenerPath");
-		getAccessWidenerPath().set(getProject().file(file));
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -55,7 +55,6 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	protected final ConfigurableFileCollection log4jConfigs;
 	protected final RegularFileProperty accessWidener;
 	protected final Property<Boolean> shareCaches;
-	protected final Property<String> refmapName;
 	protected final Property<Boolean> remapArchives;
 	protected final Property<String> customManifest;
 
@@ -72,8 +71,6 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 		this.accessWidener = project.getObjects().fileProperty();
 		this.shareCaches = project.getObjects().property(Boolean.class)
 				.convention(false);
-		this.refmapName = project.getObjects().property(String.class)
-				.convention(project.provider(this::getDefaultMixinRefmapName));
 		this.remapArchives = project.getObjects().property(Boolean.class)
 				.convention(true);
 		this.customManifest = project.getObjects().property(String.class);
@@ -103,12 +100,12 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	}
 
 	@Override
-	public ListProperty<LoomDecompiler> getLoomDecompilers() {
+	public ListProperty<LoomDecompiler> getGameDecompilers() {
 		return decompilers;
 	}
 
 	@Override
-	public ListProperty<JarProcessor> getMinecraftJarProcessors() {
+	public ListProperty<JarProcessor> getGameJarProcessors() {
 		return jarProcessors;
 	}
 
@@ -118,17 +115,6 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 		action.execute(builder);
 		LayeredMappingSpec builtSpec = builder.build();
 		return new LayeredMappingsDependency(new GradleMappingContext(getProject(), "layers_" + builtSpec.getVersion().replace("+", "_").replace(".", "_")), builtSpec, builtSpec.getVersion());
-	}
-
-	@Override
-	public Property<String> getMixinRefmapName() {
-		return refmapName;
-	}
-
-	public String getDefaultMixinRefmapName() {
-		String defaultRefmapName = getProject().getConvention().getPlugin(BasePluginConvention.class).getArchivesBaseName() + "-refmap.json";
-		getProject().getLogger().info("Could not find refmap definition, will be using default name: " + defaultRefmapName);
-		return defaultRefmapName;
 	}
 
 	@Override
@@ -153,7 +139,7 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 
 	@Override
 	public void mixin(Action<MixinApExtensionAPI> action) {
-		action.execute(getMixinApExtension());
+		action.execute(getMixin());
 	}
 
 	@Override
@@ -164,8 +150,6 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	protected abstract Project getProject();
 
 	protected abstract LoomFiles getFiles();
-
-	protected abstract MixinApExtension getMixinApExtension();
 
 	// This is here to ensure that LoomGradleExtensionApiImpl compiles without any unimplemented methods
 	private final class EnsureCompile extends LoomGradleExtensionApiImpl {
@@ -190,7 +174,7 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 		}
 
 		@Override
-		protected MixinApExtension getMixinApExtension() {
+		public MixinApExtension getMixin() {
 			throw new RuntimeException("Yeah... something is really wrong");
 		}
 	}

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
@@ -164,7 +164,7 @@ public class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl implemen
 	}
 
 	@Override
-	public MixinApExtension getMixinApExtension() {
+	public MixinApExtension getMixin() {
 		return this.mixinApExtension;
 	}
 }

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
@@ -63,7 +63,8 @@ public class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl implemen
 	public LoomGradleExtensionImpl(Project project, LoomFiles files) {
 		super(project, files);
 		this.project = project;
-		this.mixinApExtension = new MixinApExtensionImpl(project);
+		// Initiate with newInstance to allow gradle to decorate our extension
+		this.mixinApExtension = project.getObjects().newInstance(MixinApExtensionImpl.class, project);
 		this.loomFiles = files;
 		this.unmappedMods = project.files();
 	}

--- a/src/main/java/net/fabricmc/loom/extension/MixinApExtension.java
+++ b/src/main/java/net/fabricmc/loom/extension/MixinApExtension.java
@@ -34,6 +34,7 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.util.PatternSet;
@@ -57,13 +58,13 @@ public interface MixinApExtension extends MixinApExtensionAPI {
 	 */
 	final class MixinInformationContainer {
 		private final SourceSet sourceSet;
-		private final String refmapName;
+		private final Provider<String> refmapName;
 		private Stream<String> mixinJsonNames;
 
 		final PatternSet mixinJsonPattern;
 
 		public MixinInformationContainer(@NotNull SourceSet sourceSet,
-										@NotNull String refmapName,
+										@NotNull Provider<String> refmapName,
 										@NotNull PatternSet mixinJsonPattern) {
 			this.sourceSet = sourceSet;
 			this.refmapName = refmapName;
@@ -88,7 +89,7 @@ public interface MixinApExtension extends MixinApExtensionAPI {
 
 		@NotNull
 		public String getRefmapName() {
-			return refmapName;
+			return refmapName.get();
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loom/extension/MixinApExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/MixinApExtensionApiImpl.java
@@ -28,11 +28,11 @@ import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.util.PatternSet;
 
-import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.MixinApExtensionAPI;
 
 public abstract class MixinApExtensionApiImpl implements MixinApExtensionAPI {
@@ -76,8 +76,7 @@ public abstract class MixinApExtensionApiImpl implements MixinApExtensionAPI {
 
 	@Override
 	public void add(SourceSet sourceSet, Action<PatternSet> action) {
-		LoomGradleExtension extension = LoomGradleExtension.get(getProject());
-		add(sourceSet, extension.getMixinRefmapName(), action);
+		add(sourceSet, getDefaultRefmapName(), action);
 	}
 
 	@Override
@@ -87,8 +86,7 @@ public abstract class MixinApExtensionApiImpl implements MixinApExtensionAPI {
 
 	@Override
 	public void add(String sourceSetName, Action<PatternSet> action) {
-		LoomGradleExtension extension = LoomGradleExtension.get(getProject());
-		add(sourceSetName, extension.getMixinRefmapName(), action);
+		add(sourceSetName, getDefaultRefmapName(), action);
 	}
 
 	@Override
@@ -117,6 +115,11 @@ public abstract class MixinApExtensionApiImpl implements MixinApExtensionAPI {
 
 		@Override
 		protected Project getProject() {
+			throw new RuntimeException("Yeah... something is really wrong");
+		}
+
+		@Override
+		public Property<String> getDefaultRefmapName() {
 			throw new RuntimeException("Yeah... something is really wrong");
 		}
 

--- a/src/main/java/net/fabricmc/loom/extension/MixinApExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/MixinApExtensionImpl.java
@@ -33,6 +33,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.inject.Inject;
+
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
@@ -51,6 +53,7 @@ public class MixinApExtensionImpl extends MixinApExtensionApiImpl implements Mix
 	private final Project project;
 	private final Property<String> defaultRefmapName;
 
+	@Inject
 	public MixinApExtensionImpl(Project project) {
 		this.isDefault = true;
 		this.project = project;

--- a/src/main/java/net/fabricmc/loom/extension/MixinApExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/MixinApExtensionImpl.java
@@ -37,7 +37,9 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.plugins.BasePluginConvention;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.SourceSet;
@@ -47,15 +49,29 @@ import org.jetbrains.annotations.NotNull;
 public class MixinApExtensionImpl extends MixinApExtensionApiImpl implements MixinApExtension {
 	private boolean isDefault;
 	private final Project project;
+	private final Property<String> defaultRefmapName;
 
 	public MixinApExtensionImpl(Project project) {
 		this.isDefault = true;
 		this.project = project;
+		this.defaultRefmapName = project.getObjects().property(String.class)
+				.convention(project.provider(this::getDefaultMixinRefmapName));
 	}
 
 	@Override
 	public Project getProject() {
 		return this.project;
+	}
+
+	@Override
+	public Property<String> getDefaultRefmapName() {
+		return defaultRefmapName;
+	}
+
+	private String getDefaultMixinRefmapName() {
+		String defaultRefmapName = getProject().getConvention().getPlugin(BasePluginConvention.class).getArchivesBaseName() + "-refmap.json";
+		getProject().getLogger().info("Could not find refmap definition, will be using default name: " + defaultRefmapName);
+		return defaultRefmapName;
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/extension/MixinApExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/MixinApExtensionImpl.java
@@ -38,6 +38,7 @@ import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.util.PatternSet;
@@ -58,7 +59,7 @@ public class MixinApExtensionImpl extends MixinApExtensionApiImpl implements Mix
 	}
 
 	@Override
-	protected PatternSet add0(SourceSet sourceSet, String refmapName) {
+	protected PatternSet add0(SourceSet sourceSet, Provider<String> refmapName) {
 		PatternSet pattern = new PatternSet().setIncludes(Collections.singletonList("*.mixins.json"));
 		MixinApExtension.setMixinInformationContainer(sourceSet, new MixinApExtension.MixinInformationContainer(sourceSet, refmapName, pattern));
 

--- a/src/main/java/net/fabricmc/loom/task/AbstractLoomTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractLoomTask.java
@@ -28,10 +28,11 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Internal;
 
 import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.util.Constants;
 
 public abstract class AbstractLoomTask extends DefaultTask {
 	public AbstractLoomTask() {
-		setGroup("fabric");
+		setGroup(Constants.TaskGroup.FABRIC);
 	}
 
 	@Internal

--- a/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
@@ -35,13 +35,14 @@ import org.gradle.api.Project;
 import org.gradle.api.tasks.JavaExec;
 
 import net.fabricmc.loom.configuration.ide.RunConfig;
+import net.fabricmc.loom.util.Constants;
 
 public abstract class AbstractRunTask extends JavaExec {
 	private final RunConfig config;
 
 	public AbstractRunTask(Function<Project, RunConfig> configProvider) {
 		super();
-		setGroup("fabric");
+		setGroup(Constants.TaskGroup.FABRIC);
 		this.config = configProvider.apply(getProject());
 
 		setClasspath(config.sourceSet.getRuntimeClasspath());

--- a/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
@@ -56,7 +56,6 @@ public class GenerateSourcesTask extends AbstractLoomTask {
 	public GenerateSourcesTask(LoomDecompiler decompiler) {
 		this.decompiler = decompiler;
 
-		setGroup("fabric");
 		getOutputs().upToDateWhen((o) -> false);
 	}
 

--- a/src/main/java/net/fabricmc/loom/task/LoomTasks.java
+++ b/src/main/java/net/fabricmc/loom/task/LoomTasks.java
@@ -136,9 +136,9 @@ public final class LoomTasks {
 				inputJar = outputJar;
 			}
 
-			extension.getLoomDecompilers().finalizeValue();
+			extension.getGameDecompilers().finalizeValue();
 
-			for (LoomDecompiler decompiler : extension.getLoomDecompilers().get()) {
+			for (LoomDecompiler decompiler : extension.getGameDecompilers().get()) {
 				String taskName = decompiler instanceof FabricFernFlowerDecompiler ? "genSources" : "genSourcesWith" + decompiler.name();
 				// decompiler will be passed to the constructor of GenerateSourcesTask
 				GenerateSourcesTask generateSourcesTask = tasks.register(taskName, GenerateSourcesTask.class, decompiler).get();

--- a/src/main/java/net/fabricmc/loom/task/LoomTasks.java
+++ b/src/main/java/net/fabricmc/loom/task/LoomTasks.java
@@ -35,6 +35,7 @@ import net.fabricmc.loom.api.decompilers.LoomDecompiler;
 import net.fabricmc.loom.configuration.ide.RunConfigSettings;
 import net.fabricmc.loom.configuration.providers.mappings.MappingsProviderImpl;
 import net.fabricmc.loom.decompilers.fernflower.FabricFernFlowerDecompiler;
+import net.fabricmc.loom.util.Constants;
 
 public final class LoomTasks {
 	private LoomTasks() {
@@ -50,7 +51,7 @@ public final class LoomTasks {
 
 		tasks.register("remapJar", RemapJarTask.class, t -> {
 			t.setDescription("Remaps the built project jar to intermediary mappings.");
-			t.setGroup("fabric");
+			t.setGroup(Constants.TaskGroup.FABRIC);
 		});
 
 		tasks.register("downloadAssets", DownloadAssetsTask.class, t -> t.setDescription("Downloads required assets for Fabric."));
@@ -65,24 +66,24 @@ public final class LoomTasks {
 		tasks.register("genIdeaWorkspace", GenIdeaProjectTask.class, t -> {
 			t.setDescription("Generates an IntelliJ IDEA workspace from this project.");
 			t.dependsOn("idea", "downloadAssets");
-			t.setGroup("ide");
+			t.setGroup(Constants.TaskGroup.IDE);
 		});
 
 		tasks.register("genEclipseRuns", GenEclipseRunsTask.class, t -> {
 			t.setDescription("Generates Eclipse run configurations for this project.");
 			t.dependsOn("downloadAssets");
-			t.setGroup("ide");
+			t.setGroup(Constants.TaskGroup.IDE);
 		});
 
 		tasks.register("cleanEclipseRuns", CleanEclipseRunsTask.class, t -> {
 			t.setDescription("Removes Eclipse run configurations for this project.");
-			t.setGroup("ide");
+			t.setGroup(Constants.TaskGroup.IDE);
 		});
 
 		tasks.register("vscode", GenVsCodeProjectTask.class, t -> {
 			t.setDescription("Generates VSCode launch configurations.");
 			t.dependsOn("downloadAssets");
-			t.setGroup("ide");
+			t.setGroup(Constants.TaskGroup.IDE);
 		});
 	}
 
@@ -97,7 +98,6 @@ public final class LoomTasks {
 
 			tasks.register(taskName, RunGameTask.class, config).configure(t -> {
 				t.setDescription("Starts the '" + config.getConfigName() + "' run configuration");
-				t.setGroup("fabric");
 
 				if (config.getEnvironment().equals("client")) {
 					t.dependsOn("downloadAssets");
@@ -136,7 +136,9 @@ public final class LoomTasks {
 				inputJar = outputJar;
 			}
 
-			for (LoomDecompiler decompiler : extension.getDecompilers()) {
+			extension.getLoomDecompilers().finalizeValue();
+
+			for (LoomDecompiler decompiler : extension.getLoomDecompilers().get()) {
 				String taskName = decompiler instanceof FabricFernFlowerDecompiler ? "genSources" : "genSourcesWith" + decompiler.name();
 				// decompiler will be passed to the constructor of GenerateSourcesTask
 				GenerateSourcesTask generateSourcesTask = tasks.register(taskName, GenerateSourcesTask.class, decompiler).get();

--- a/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
@@ -147,7 +147,7 @@ public class RemapJarTask extends Jar {
 
 		jarRemapper.scheduleRemap(input, output)
 				.supplyAccessWidener((remapData, remapper) -> {
-					if (getRemapAccessWidener().getOrElse(false) && extension.getAccessWidener() != null) {
+					if (getRemapAccessWidener().getOrElse(false) && extension.getAccessWidenerPath().isPresent()) {
 						AccessWidenerJarProcessor accessWidenerJarProcessor = extension.getJarProcessorManager().getByType(AccessWidenerJarProcessor.class);
 						byte[] data;
 

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -117,4 +117,12 @@ public class Constants {
 		private Knot() {
 		}
 	}
+
+	public static final class TaskGroup {
+		public static final String FABRIC = "fabric";
+		public static final String IDE = "ide";
+
+		private TaskGroup() {
+		}
+	}
 }

--- a/src/main/java/net/fabricmc/loom/util/DeprecationHelper.java
+++ b/src/main/java/net/fabricmc/loom/util/DeprecationHelper.java
@@ -60,7 +60,7 @@ public interface DeprecationHelper {
 
 			project.getGradle().buildFinished(buildResult -> {
 				if (usingDeprecatedApi.get()) {
-					project.getLogger().lifecycle("Deprecated Loom APIs were used in this build, making it incompatible with future versions of loom. "
+					project.getLogger().lifecycle("Deprecated Loom APIs were used in this build, making it incompatible with future versions of Loom. "
 											+ "Use Gradle warning modes to control the verbosity of the warnings.");
 				}
 			});

--- a/src/main/java/net/fabricmc/loom/util/DeprecationHelper.java
+++ b/src/main/java/net/fabricmc/loom/util/DeprecationHelper.java
@@ -1,0 +1,62 @@
+package net.fabricmc.loom.util;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.gradle.api.Project;
+import org.gradle.api.logging.LogLevel;
+import org.gradle.api.logging.configuration.WarningMode;
+
+public interface DeprecationHelper {
+	default void replaceWithInLoom0_10(String currentName, String newName) {
+		toBeRemovedIn(currentName, newName, "Loom 0.10");
+	}
+
+	default void replaceWithInLoom0_11(String currentName, String newName) {
+		toBeRemovedIn(currentName, newName, "Loom 0.11");
+	}
+
+	default void replaceWithInLoom0_12(String currentName, String newName) {
+		toBeRemovedIn(currentName, newName, "Loom 0.12");
+	}
+
+	default void toBeRemovedIn(String currentName, String newName, String removalVersion) {
+		warn("The '%s' property has been deprecated, and has been replaced with '%s'. This is scheduled to be removed in %s.".formatted(currentName, newName, removalVersion));
+	}
+
+	Project getProject();
+
+	void warn(String warning);
+
+	class ProjectBased implements DeprecationHelper {
+		private final Project project;
+		private final AtomicBoolean usingDeprecatedApi = new AtomicBoolean(false);
+
+		public ProjectBased(Project project) {
+			this.project = project;
+
+			project.getGradle().buildFinished(buildResult -> {
+				if (usingDeprecatedApi.get()) {
+					project.getLogger().lifecycle("Deprecated Loom APIs were used in this build, making it incompatible with future versions of loom. "
+											+ "Use Gradle warning modes to control the verbosity of the warnings.");
+				}
+			});
+		}
+
+		@Override
+		public Project getProject() {
+			return project;
+		}
+
+		@Override
+		public void warn(String warning) {
+			WarningMode warningMode = getProject().getGradle().getStartParameter().getWarningMode();
+			getProject().getLogger().log(warningMode == WarningMode.None ? LogLevel.INFO : LogLevel.WARN, warning);
+
+			if (warningMode == WarningMode.Fail) {
+				throw new UnsupportedOperationException(warning);
+			}
+
+			usingDeprecatedApi.set(true);
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/DeprecationHelper.java
+++ b/src/main/java/net/fabricmc/loom/util/DeprecationHelper.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2021 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package net.fabricmc.loom.util;
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/src/test/groovy/net/fabricmc/loom/test/integration/CustomManifestTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/CustomManifestTest.groovy
@@ -40,7 +40,7 @@ class CustomManifestTest extends Specification implements ProjectTestTrait {
     def filesReady() {
         buildGradle() << '''
             loom {
-                customManifest = "https://maven.fabricmc.net/net/minecraft/1_18_experimental-snapshot-1.json"
+                customMinecraftManifest = "https://maven.fabricmc.net/net/minecraft/1_18_experimental-snapshot-1.json"
             }
 
             dependencies {

--- a/src/test/resources/projects/accesswidener/build.gradle
+++ b/src/test/resources/projects/accesswidener/build.gradle
@@ -19,7 +19,7 @@ repositories {
 }
 
 loom {
-	accessWidener = file("src/main/resources/modid.accesswidener")
+	accessWidenerPath = file("src/main/resources/modid.accesswidener")
 }
 
 dependencies {

--- a/src/test/resources/projects/dependencyResolutionManagement/projmap/build.gradle
+++ b/src/test/resources/projects/dependencyResolutionManagement/projmap/build.gradle
@@ -69,7 +69,7 @@ jar {
 }
 
 minecraft {
-	accessWidener = file("src/main/resources/modid.accesswidener")
+	accessWidener.set file("src/main/resources/modid.accesswidener")
 }
 
 // configure the maven publication

--- a/src/test/resources/projects/dependencyResolutionManagement/projmap/build.gradle
+++ b/src/test/resources/projects/dependencyResolutionManagement/projmap/build.gradle
@@ -69,7 +69,7 @@ jar {
 }
 
 minecraft {
-	accessWidener.set file("src/main/resources/modid.accesswidener")
+	accessWidenerPath = file("src/main/resources/modid.accesswidener")
 }
 
 // configure the maven publication

--- a/src/test/resources/projects/mixinApAutoRefmap/build.gradle
+++ b/src/test/resources/projects/mixinApAutoRefmap/build.gradle
@@ -68,7 +68,7 @@ java {
 }
 
 loom {
-	refmapName = "refmap0000.json"
+	mixin.defaultRefmapName = "refmap0000.json"
 
 	mixin {
 		add(sourceSets["main"], "refmap0001.json")

--- a/src/test/resources/projects/mixinApAutoRefmap/build.gradle
+++ b/src/test/resources/projects/mixinApAutoRefmap/build.gradle
@@ -68,9 +68,8 @@ java {
 }
 
 loom {
-	mixin.defaultRefmapName = "refmap0000.json"
-
 	mixin {
+		defaultRefmapName = "refmap0000.json"
 		add(sourceSets["main"], "refmap0001.json")
 		add(sourceSets["mixin"], "refmap0002.json")
 		add(sourceSets["mixin1"], "refmap0003.json") {

--- a/src/test/resources/projects/mixinApSimple/build.gradle
+++ b/src/test/resources/projects/mixinApSimple/build.gradle
@@ -67,8 +67,8 @@ java {
 }
 
 loom {
-	refmapName = "default-refmap0000.json"
 	mixin {
+		defaultRefmapName = "default-refmap0000.json"
 		add(sourceSets["main"], "main-refmap0000.json")
 		add(sourceSets["mixin"])
 	}

--- a/src/test/resources/projects/multiproject/build.gradle
+++ b/src/test/resources/projects/multiproject/build.gradle
@@ -40,7 +40,7 @@ allprojects {
 	}
 
 	loom {
-		shareCaches = true
+		shareCaches()
 	}
 
 	java {


### PR DESCRIPTION
Replacing the getters and setters is quite annoying since we have to choose a different name for the methods.

Using properties allow us to finalize and freeze values that should not be changed after evaluation (see finalizeValue)