### PR TITLE
Fix loom.accessWidener being a read-only property in Kotlin

### DIFF
--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -45,9 +45,6 @@ jobs:
       matrix:
         java: [jdk16]
         test: ${{ fromJson(needs.prepare_test_matrix.outputs.matrix) }}
-        exclude:
-          - java: jdk16
-            test: net.fabricmc.loom.test.integration.KotlinTest
 
     runs-on: ubuntu-20.04
     container:
@@ -74,9 +71,6 @@ jobs:
       matrix:
         java: [16]
         test: ${{ fromJson(needs.prepare_test_matrix.outputs.matrix) }}
-        exclude:
-          - java: 16
-            test: net.fabricmc.loom.test.integration.KotlinTest
 
     runs-on: windows-2019
 

--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -44,7 +44,7 @@ import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingSpecBuil
 public interface LoomGradleExtensionAPI {
 	File getAccessWidener();
 
-	void setAccessWidener(Object file);
+	void setAccessWidener(File file);
 
 	void setShareCaches(boolean shareCaches);
 

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -74,9 +74,9 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	}
 
 	@Override
-	public void setAccessWidener(Object file) {
+	public void setAccessWidener(File file) {
 		Objects.requireNonNull(file, "Access widener file cannot be null");
-		this.accessWidener = getProject().file(file);
+		this.accessWidener = file;
 	}
 
 	@Override

--- a/src/test/groovy/net/fabricmc/loom/test/integration/KotlinTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/KotlinTest.groovy
@@ -31,7 +31,6 @@ import spock.lang.Unroll
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
-@IgnoreIf({ jvm.java16Compatible }) // Fails on J16 > due to https://youtrack.jetbrains.com/issue/KT-45566
 class KotlinTest extends Specification implements ProjectTestTrait {
 	@Override
 	String name() {

--- a/src/test/resources/projects/kotlin/build.gradle.kts
+++ b/src/test/resources/projects/kotlin/build.gradle.kts
@@ -1,7 +1,7 @@
 import java.util.Properties
 
 plugins {
-	kotlin("jvm") version "1.4.31"
+	kotlin("jvm") version "1.5.21"
 	id("fabric-loom")
 }
 
@@ -16,5 +16,5 @@ dependencies {
 	minecraft(group = "com.mojang", name = "minecraft", version = "1.16.5")
 	mappings(group = "net.fabricmc", name = "yarn", version = "1.16.5+build.5", classifier = "v2")
 	modImplementation("net.fabricmc:fabric-loader:0.11.2")
-	modImplementation(group = "net.fabricmc", name = "fabric-language-kotlin", version = "1.5.0+kotlin.1.4.31")
+	modImplementation(group = "net.fabricmc", name = "fabric-language-kotlin", version = "1.6.3+kotlin.1.5.21")
 }


### PR DESCRIPTION
The setter with an `Object` parameter isn't considered the setter of the `accessWidener` property in Kotlin (understandably), so this PR changes the parameter type to `File`.