### PR TITLE
Expose `loom` extension as the API, deprecate `minecraft` extension

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -43,12 +43,11 @@ import net.fabricmc.loom.configuration.providers.MinecraftProviderImpl;
 import net.fabricmc.loom.configuration.providers.mappings.MappingsProviderImpl;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftMappedProvider;
 import net.fabricmc.loom.extension.LoomFiles;
-import net.fabricmc.loom.extension.LoomGradleExtensionImpl;
 import net.fabricmc.loom.extension.MixinApExtension;
 
 public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 	static LoomGradleExtension get(Project project) {
-		return project.getExtensions().getByType(LoomGradleExtensionImpl.class);
+		return (LoomGradleExtension) project.getExtensions().getByName("loom");
 	}
 
 	LoomFiles getFiles();

--- a/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
@@ -34,6 +34,7 @@ import com.google.gson.GsonBuilder;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.PluginAware;
 
+import net.fabricmc.loom.api.LoomGradleExtensionAPI;
 import net.fabricmc.loom.bootstrap.BootstrappedPlugin;
 import net.fabricmc.loom.configuration.CompileConfiguration;
 import net.fabricmc.loom.configuration.FabricApiExtension;
@@ -43,6 +44,7 @@ import net.fabricmc.loom.configuration.providers.mappings.MappingsCache;
 import net.fabricmc.loom.decompilers.DecompilerConfiguration;
 import net.fabricmc.loom.extension.LoomGradleExtensionImpl;
 import net.fabricmc.loom.extension.LoomFilesImpl;
+import net.fabricmc.loom.extension.MinecraftGradleExtension;
 import net.fabricmc.loom.task.LoomTasks;
 
 public class LoomGradlePlugin implements BootstrappedPlugin {
@@ -75,9 +77,9 @@ public class LoomGradlePlugin implements BootstrappedPlugin {
 		project.apply(ImmutableMap.of("plugin", "eclipse"));
 		project.apply(ImmutableMap.of("plugin", "idea"));
 
-		// Setup extensions, loom shadows minecraft
-		project.getExtensions().create(LoomGradleExtension.class, "minecraft", LoomGradleExtensionImpl.class, project, new LoomFilesImpl(project));
-		project.getExtensions().add("loom", project.getExtensions().getByName("minecraft"));
+		// Setup extensions, minecraft wraps loom
+		var extension = project.getExtensions().create(LoomGradleExtensionAPI.class, "loom", LoomGradleExtensionImpl.class, project, new LoomFilesImpl(project));
+		project.getExtensions().create(LoomGradleExtensionAPI.class, "minecraft", MinecraftGradleExtension.class, extension);
 		project.getExtensions().create("fabricApi", FabricApiExtension.class, project);
 
 		CompileConfiguration.setupConfigurations(project);

--- a/src/main/java/net/fabricmc/loom/extension/MinecraftGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/extension/MinecraftGradleExtension.java
@@ -1,0 +1,134 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2021 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.extension;
+
+import org.gradle.api.Action;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+
+import net.fabricmc.loom.api.LoomGradleExtensionAPI;
+import net.fabricmc.loom.api.MixinApExtensionAPI;
+import net.fabricmc.loom.api.decompilers.LoomDecompiler;
+import net.fabricmc.loom.configuration.ide.RunConfigSettings;
+import net.fabricmc.loom.configuration.processors.JarProcessor;
+import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingSpecBuilder;
+import net.fabricmc.loom.util.DeprecationHelper;
+
+public class MinecraftGradleExtension implements LoomGradleExtensionAPI {
+	private final LoomGradleExtensionAPI parent;
+	private boolean deprecationReported = false;
+
+	public MinecraftGradleExtension(LoomGradleExtensionAPI parent) {
+		this.parent = parent;
+	}
+
+	private void reportDeprecation() {
+		if (!deprecationReported) {
+			getDeprecationHelper().replaceWithInLoom0_11("minecraft", "loom");
+			deprecationReported = true;
+		}
+	}
+
+	@Override
+	public DeprecationHelper getDeprecationHelper() {
+		return parent.getDeprecationHelper();
+	}
+
+	@Override
+	public RegularFileProperty getAccessWidenerPath() {
+		reportDeprecation();
+		return parent.getAccessWidenerPath();
+	}
+
+	@Override
+	public Property<Boolean> getShareRemapCaches() {
+		reportDeprecation();
+		return parent.getShareRemapCaches();
+	}
+
+	@Override
+	public ListProperty<LoomDecompiler> getGameDecompilers() {
+		reportDeprecation();
+		return parent.getGameDecompilers();
+	}
+
+	@Override
+	public ListProperty<JarProcessor> getGameJarProcessors() {
+		reportDeprecation();
+		return parent.getGameJarProcessors();
+	}
+
+	@Override
+	public ConfigurableFileCollection getLog4jConfigs() {
+		reportDeprecation();
+		return parent.getLog4jConfigs();
+	}
+
+	@Override
+	public Dependency layered(Action<LayeredMappingSpecBuilder> action) {
+		reportDeprecation();
+		return parent.layered(action);
+	}
+
+	@Override
+	public Property<Boolean> getRemapArchives() {
+		reportDeprecation();
+		return parent.getRemapArchives();
+	}
+
+	@Override
+	public void runs(Action<NamedDomainObjectContainer<RunConfigSettings>> action) {
+		reportDeprecation();
+		parent.runs(action);
+	}
+
+	@Override
+	public NamedDomainObjectContainer<RunConfigSettings> getRunConfigs() {
+		reportDeprecation();
+		return parent.getRunConfigs();
+	}
+
+	@Override
+	public void mixin(Action<MixinApExtensionAPI> action) {
+		reportDeprecation();
+		parent.mixin(action);
+	}
+
+	@Override
+	public MixinApExtensionAPI getMixin() {
+		reportDeprecation();
+		return parent.getMixin();
+	}
+
+	@Override
+	public Property<String> getCustomMinecraftManifest() {
+		reportDeprecation();
+		return parent.getCustomMinecraftManifest();
+	}
+}

--- a/src/test/resources/projects/dependencyResolutionManagement/projmap/build.gradle
+++ b/src/test/resources/projects/dependencyResolutionManagement/projmap/build.gradle
@@ -68,7 +68,7 @@ jar {
 	}
 }
 
-minecraft {
+loom {
 	accessWidenerPath = file("src/main/resources/modid.accesswidener")
 }
 


### PR DESCRIPTION
Types of extensions (from a buildscript's POV):

| Extension | Type |
| - | - |
| `loom` | before: `LoomGradleExtensionImpl`<br>after: `LoomGradleExtensionAPI` |
| `minecraft` | before: `LoomGradleExtension` (the impl interface)<br>after: `LoomGradleExtensionAPI` |