### PR TITLE
Make mod* configurations match Gradle's defaults

### DIFF
--- a/src/main/java/net/fabricmc/loom/build/ModCompileRemapper.java
+++ b/src/main/java/net/fabricmc/loom/build/ModCompileRemapper.java
@@ -151,6 +151,11 @@ public class ModCompileRemapper {
 				for (ModDependencyInfo info : modDependencies) {
 					project.getDependencies().add(info.targetConfig.getName(), info.getRemappedNotation());
 				}
+
+				// Report deprecation warnings
+				if (entry.replacedWith() != null && !modDependencies.isEmpty()) {
+					extension.getDeprecationHelper().replaceWithInLoom0_11(entry.sourceConfiguration(), entry.replacedWith());
+				}
 			});
 		}
 	}

--- a/src/main/java/net/fabricmc/loom/configuration/RemappedConfigurationEntry.java
+++ b/src/main/java/net/fabricmc/loom/configuration/RemappedConfigurationEntry.java
@@ -26,8 +26,13 @@ package net.fabricmc.loom.configuration;
 
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.plugins.JavaPlugin;
+import org.jetbrains.annotations.Nullable;
 
-public record RemappedConfigurationEntry(String sourceConfiguration, String targetConfiguration, boolean isOnModCompileClasspath, String mavenScope) {
+public record RemappedConfigurationEntry(String sourceConfiguration, String targetConfiguration, boolean isOnModCompileClasspath, String mavenScope, @Nullable String replacedWith) {
+	public RemappedConfigurationEntry(String sourceConfiguration, String targetConfiguration, boolean isOnModCompileClasspath, String mavenScope) {
+		this(sourceConfiguration, targetConfiguration, isOnModCompileClasspath, mavenScope, null);
+	}
+
 	public boolean hasMavenScope() {
 		return mavenScope != null && !mavenScope.isEmpty();
 	}

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -45,8 +45,10 @@ public class Constants {
 	public static final List<RemappedConfigurationEntry> MOD_COMPILE_ENTRIES = ImmutableList.of(
 			new RemappedConfigurationEntry("modApi", JavaPlugin.API_CONFIGURATION_NAME, true, "compile"),
 			new RemappedConfigurationEntry("modImplementation", JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, true, "runtime"),
-			new RemappedConfigurationEntry("modRuntime", JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, false, ""),
-			new RemappedConfigurationEntry("modCompileOnly", JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME, true, "")
+			new RemappedConfigurationEntry("modRuntime", JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, false, "", "modRuntimeOnly"),
+			new RemappedConfigurationEntry("modCompileOnly", JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME, true, ""),
+			new RemappedConfigurationEntry("modCompileOnlyApi", JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME, true, "compile"),
+			new RemappedConfigurationEntry("modRuntimeOnly", JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, false, "runtime")
 	);
 
 	private Constants() {


### PR DESCRIPTION
First, see this diagram for how Gradle's configurations are organised:
![configuration diagram](https://docs.gradle.org/current/userguide/img/java-library-ignore-deprecated-main.png)

The configurations extending `apiElements` are exposed as `compile`, and the configurations extending `runtimeElements` (and not `apiElements`) are exposed as `runtime` in a POM.

This PR brings Loom to the same structure of configurations as Gradle itself, with the same POM behaviour.

- Added `modCompileOnlyApi`: a direct match to `compileOnlyApi`
- Deprecated `modRuntime`: its naming follows the deprecated `runtime` configuration, which was removed along with `compile` in Gradle 7
  - The deprecation warning is for 0.11 - I believe this is enough time to migrate, but I can change it.
- Added `modRuntimeOnly`: a direct match to `runtimeOnly`
  - Unlike the old `modRuntime`, **`modRuntimeOnly` follows `runtimeOnly`'s behaviour and is exposed as a runtime dep in POMs.** Modifying the existing `modRuntime` with this would be a breaking change, since libraries use it to depend on various mods as "dev runtime" dependencies from [Mod Menu](https://github.com/CottonMC/LibGui/blob/6851be1399c377d02f6fe52f667880578da9d7ef/build.gradle#L47) to [DataBreaker](https://github.com/Patbox/SidebarAPI/blob/568f65a2c791230e93031c82ff3ae6ba089cc43f/build.gradle#L57).
  - Should I add a `modDevRuntimeOnly` configuration that is not exposed at all?

I'm also planning a follow-up to this for fixing #200 properly, but this is a small and easy PR first. :wink: