### PR TITLE
Fix #473

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ dependencies {
 	implementation ('net.fabricmc:tiny-mappings-parser:0.3.0+build.17')
 
 	implementation 'net.fabricmc:access-widener:1.1.0'
-	implementation 'net.fabricmc:mapping-io:0.1.3'
+	implementation 'net.fabricmc:mapping-io:0.2.0'
 
 	implementation ('net.fabricmc:lorenz-tiny:3.0.0') {
 		transitive = false

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsDependency.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsDependency.java
@@ -76,7 +76,7 @@ public class LayeredMappingsDependency implements SelfResolvingDependency {
 					Tiny2Writer tiny2Writer = new Tiny2Writer(writer, false);
 
 					MappingDstNsReorder nsReorder = new MappingDstNsReorder(tiny2Writer, Collections.singletonList(MappingNamespace.NAMED.stringValue()));
-					MappingSourceNsSwitch nsSwitch = new MappingSourceNsSwitch(nsReorder, MappingNamespace.INTERMEDIARY.stringValue());
+					MappingSourceNsSwitch nsSwitch = new MappingSourceNsSwitch(nsReorder, MappingNamespace.INTERMEDIARY.stringValue(), true);
 					mappings.accept(nsSwitch);
 
 					Files.deleteIfExists(mappingsFile);

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/parchment/ParchmentPrefixStripingMappingVisitor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/parchment/ParchmentPrefixStripingMappingVisitor.java
@@ -24,6 +24,7 @@
 
 package net.fabricmc.loom.configuration.providers.mappings.parchment;
 
+import java.io.IOException;
 import java.util.Locale;
 
 import net.fabricmc.mappingio.MappingVisitor;
@@ -35,7 +36,7 @@ public final class ParchmentPrefixStripingMappingVisitor extends ForwardingMappi
 	}
 
 	@Override
-	public boolean visitMethodArg(int argPosition, int lvIndex, String srcName) {
+	public boolean visitMethodArg(int argPosition, int lvIndex, String srcName) throws IOException {
 		return super.visitMethodArg(argPosition, lvIndex, stripMethodArg(srcName));
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/parchment/ParchmentTreeV1.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/parchment/ParchmentTreeV1.java
@@ -24,6 +24,7 @@
 
 package net.fabricmc.loom.configuration.providers.mappings.parchment;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -39,7 +40,7 @@ public record ParchmentTreeV1(
 		@Nullable
 		List<Package> packages
 ) {
-	public void visit(MappingVisitor visitor, String srcNamespace) {
+	public void visit(MappingVisitor visitor, String srcNamespace) throws IOException {
 		while (true) {
 			if (visitor.visitHeader()) {
 				visitor.visitNamespaces(srcNamespace, Collections.emptyList());
@@ -68,7 +69,7 @@ public record ParchmentTreeV1(
 			@Nullable
 			List<String> javadoc
 	) {
-		public void visit(MappingVisitor visitor) {
+		public void visit(MappingVisitor visitor) throws IOException {
 			if (visitor.visitClass(name())) {
 				if (!visitor.visitElementContent(MappedElementKind.CLASS)) {
 					return;
@@ -99,7 +100,7 @@ public record ParchmentTreeV1(
 			@Nullable
 			List<String> javadoc
 	) {
-		public void visit(MappingVisitor visitor) {
+		public void visit(MappingVisitor visitor) throws IOException {
 			if (visitor.visitField(name, descriptor)) {
 				if (!visitor.visitElementContent(MappedElementKind.FIELD)) {
 					return;
@@ -120,7 +121,7 @@ public record ParchmentTreeV1(
 			@Nullable
 			List<String> javadoc
 	) {
-		public void visit(MappingVisitor visitor) {
+		public void visit(MappingVisitor visitor) throws IOException {
 			if (visitor.visitMethod(name, descriptor)) {
 				if (!visitor.visitElementContent(MappedElementKind.METHOD)) {
 					return;
@@ -145,7 +146,7 @@ public record ParchmentTreeV1(
 			@Nullable
 			String javadoc
 	) {
-		public void visit(MappingVisitor visitor) {
+		public void visit(MappingVisitor visitor) throws IOException {
 			if (visitor.visitMethodArg(index, index, name)) {
 				if (!visitor.visitElementContent(MappedElementKind.METHOD_ARG)) {
 					return;


### PR DESCRIPTION
fixes #473 .

It fixes the issue that layer mapping generates mojang mapping incorrectly, which causes MCE to generate incorrect refmap.

This needs to backport to 0.9 (not sure about 0.8 & 0.7).