### PR TITLE
Make --refresh-dependencies work 

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingsProviderImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingsProviderImpl.java
@@ -355,6 +355,8 @@ public class MappingsProviderImpl extends DependencyProvider implements Mappings
 			if (Files.exists(mappingsWorkingDir)) {
 				Files.walkFileTree(mappingsWorkingDir, new DeletingFileVisitor());
 			}
+
+			Files.createDirectories(mappingsWorkingDir);
 		} catch (IOException e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
Make --refresh-dependencies work by creating the directory after clearing it