### PR TITLE
Make parchment layer test also test the parameter after being reordered

### DIFF
--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingsSpecification.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingsSpecification.groovy
@@ -30,8 +30,11 @@ import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingSpec
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsProcessor
 import net.fabricmc.loom.configuration.providers.mappings.MappingContext
 import net.fabricmc.loom.configuration.providers.mappings.MappingLayer
+import net.fabricmc.loom.configuration.providers.mappings.MappingNamespace
 import net.fabricmc.loom.configuration.providers.mappings.MappingsProvider
 import net.fabricmc.loom.configuration.providers.mappings.MappingsSpec
+import net.fabricmc.mappingio.adapter.MappingDstNsReorder
+import net.fabricmc.mappingio.adapter.MappingSourceNsSwitch
 import net.fabricmc.mappingio.format.Tiny2Writer
 import net.fabricmc.mappingio.tree.MemoryMappingTree
 import org.gradle.api.logging.Logger
@@ -87,6 +90,14 @@ abstract class LayeredMappingsSpecification extends Specification implements Lay
         def sw = new StringWriter()
         mappingTree.accept(new Tiny2Writer(sw, false))
         return sw.toString()
+    }
+
+    MemoryMappingTree reorder(MemoryMappingTree mappingTree) {
+        def reorderedMappings = new MemoryMappingTree()
+        def nsReorder = new MappingDstNsReorder(reorderedMappings, Collections.singletonList(MappingNamespace.NAMED.stringValue()))
+        def nsSwitch = new MappingSourceNsSwitch(nsReorder, MappingNamespace.INTERMEDIARY.stringValue(), true)
+        mappingTree.accept(nsSwitch)
+        return reorderedMappings
     }
 
     @CompileStatic

--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/ParchmentMappingLayerTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/ParchmentMappingLayerTest.groovy
@@ -48,7 +48,7 @@ class ParchmentMappingLayerTest extends LayeredMappingsSpecification {
             mappings.classes.size() == 5747
             mappings.classes[0].srcName.hashCode() == -1112444138 // MojMap name, just check the hash
             mappings.classes[0].getDstName(0) == "net/minecraft/class_2573"
-            mappings.classes[0].methods[0].args[0].srcName == "stack"
+            mappings.classes[0].methods[0].args[0].srcName.hashCode() == 109757064
             reorderedMappings.getClass("net/minecraft/class_2573").getMethod("method_10913", "(Lnet/minecraft/class_1799;Lnet/minecraft/class_1767;)V").args.size() > 0
     }
 

--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/ParchmentMappingLayerTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/ParchmentMappingLayerTest.groovy
@@ -38,16 +38,18 @@ class ParchmentMappingLayerTest extends LayeredMappingsSpecification {
             def mappings = getLayeredMappings(
                     new IntermediaryMappingsSpec(),
                     new MojangMappingsSpec(),
-                    new ParchmentMappingsSpec(PARCHMENT_NOTATION, false)
+                    new ParchmentMappingsSpec(PARCHMENT_NOTATION, true)
             )
             def tiny = getTiny(mappings)
+            def reorderedMappings = reorder(mappings)
         then:
             mappings.srcNamespace == "named"
             mappings.dstNamespaces == ["intermediary", "official"]
             mappings.classes.size() == 5747
             mappings.classes[0].srcName.hashCode() == -1112444138 // MojMap name, just check the hash
             mappings.classes[0].getDstName(0) == "net/minecraft/class_2573"
-            mappings.classes[0].methods[0].args[0].srcName == "pStack"
+            mappings.classes[0].methods[0].args[0].srcName == "stack"
+            reorderedMappings.getClass("net/minecraft/class_2573").getMethod("method_10913", "(Lnet/minecraft/class_1799;Lnet/minecraft/class_1767;)V").args.size() > 0
     }
 
     def "Read parchment mappings remove prefix" () {


### PR DESCRIPTION
The reorder method is taken straight from LayeredMappingsDependency: https://github.com/FabricMC/fabric-loom/blob/3ded0964c4282060ca9f50ef9db908d83b30e443/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsDependency.java#L78-L80

This PR should fail tests.