### PR TITLE
Fix ParchmentMappingLayerTest test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ dependencies {
 
 	implementation 'net.fabricmc:access-widener:1.1.0'
 	// wait for player to publish a version
-	implementation 'net.fabricmc:mapping-io:0.2.9999'
+	implementation 'net.fabricmc:mapping-io:0.2.1'
 
 	implementation ('net.fabricmc:lorenz-tiny:3.0.0') {
 		transitive = false

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,8 @@ dependencies {
 	implementation ('net.fabricmc:tiny-mappings-parser:0.3.0+build.17')
 
 	implementation 'net.fabricmc:access-widener:1.1.0'
-	implementation 'net.fabricmc:mapping-io:0.2.0'
+	// wait for player to publish a version
+	implementation 'net.fabricmc:mapping-io:0.2.9999'
 
 	implementation ('net.fabricmc:lorenz-tiny:3.0.0') {
 		transitive = false

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,6 @@ dependencies {
 	implementation ('net.fabricmc:tiny-mappings-parser:0.3.0+build.17')
 
 	implementation 'net.fabricmc:access-widener:1.1.0'
-	// wait for player to publish a version
 	implementation 'net.fabricmc:mapping-io:0.2.1'
 
 	implementation ('net.fabricmc:lorenz-tiny:3.0.0') {

--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/ParchmentMappingLayerTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/ParchmentMappingLayerTest.groovy
@@ -38,7 +38,7 @@ class ParchmentMappingLayerTest extends LayeredMappingsSpecification {
             def mappings = getLayeredMappings(
                     new IntermediaryMappingsSpec(),
                     new MojangMappingsSpec(),
-                    new ParchmentMappingsSpec(PARCHMENT_NOTATION, true)
+                    new ParchmentMappingsSpec(PARCHMENT_NOTATION, false)
             )
             def tiny = getTiny(mappings)
             def reorderedMappings = reorder(mappings)
@@ -48,7 +48,7 @@ class ParchmentMappingLayerTest extends LayeredMappingsSpecification {
             mappings.classes.size() == 5747
             mappings.classes[0].srcName.hashCode() == -1112444138 // MojMap name, just check the hash
             mappings.classes[0].getDstName(0) == "net/minecraft/class_2573"
-            mappings.classes[0].methods[0].args[0].srcName.hashCode() == 109757064
+            mappings.classes[0].methods[0].args[0].srcName.hashCode() == -1008297992
             reorderedMappings.getClass("net/minecraft/class_2573").getMethod("method_10913", "(Lnet/minecraft/class_1799;Lnet/minecraft/class_1767;)V").args.size() > 0
     }
 
@@ -64,12 +64,14 @@ class ParchmentMappingLayerTest extends LayeredMappingsSpecification {
                     new ParchmentMappingsSpec(PARCHMENT_NOTATION, true)
             )
             def tiny = getTiny(mappings)
+            def reorderedMappings = reorder(mappings)
         then:
             mappings.srcNamespace == "named"
             mappings.dstNamespaces == ["intermediary", "official"]
             mappings.classes.size() == 5747
             mappings.classes[0].srcName.hashCode() == -1112444138 // MojMap name, just check the hash
             mappings.classes[0].getDstName(0) == "net/minecraft/class_2573"
-            mappings.classes[0].methods[0].args[0].srcName == "stack"
+            mappings.classes[0].methods[0].args[0].srcName.hashCode() == 109757064
+            reorderedMappings.getClass("net/minecraft/class_2573").getMethod("method_10913", "(Lnet/minecraft/class_1799;Lnet/minecraft/class_1767;)V").args.size() > 0
     }
 }


### PR DESCRIPTION
Read more about this issue in #483 

This should fix tests.

Parameter names were dropped due to their missing source names, this is considered a bug in mapping-io and was fixed.

This PR updates mapping-io, and reverted a mess up by me in #483 with the removing prefix option.