### PR TITLE
Support a wider range of parameters in FileSpec

### DIFF
--- a/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/FileSpec.java
+++ b/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/FileSpec.java
@@ -73,9 +73,9 @@ public interface FileSpec {
 		} else if (o instanceof File f) {
 			return createFromFile(f);
 		} else if (o instanceof Path p) {
-			return createFromFile(p.toFile());
+			return createFromFile(p);
 		} else if (o instanceof FileSystemLocation l) {
-			return createFromFile(l.getAsFile());
+			return createFromFile(l);
 		}
 
 		throw new UnsupportedOperationException("Cannot create FileSpec from object of type:" + o.getClass().getCanonicalName());

--- a/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/FileSpec.java
+++ b/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/FileSpec.java
@@ -49,7 +49,7 @@ public interface FileSpec {
 	 *
 	 * <p>The parameter will be evaluated like this:
 	 * <ul>
-	 * <li>{@link File}, {@link Path} and {@link org.gradle.api.file.FileSystemLocation} will be resolved as local files</li>
+	 * <li>{@link File}, {@link Path} and {@link FileSystemLocation} will be resolved as local files</li>
 	 * <li>{@link Provider} (including {@link org.gradle.api.provider.Property} will recursively be resolved as its current value</li>
 	 * <li>{@link CharSequence} (including {@link String} and {@link groovy.lang.GString}) will be resolved as Maven dependencies</li>
 	 * <li>{@link Dependency} will be resolved as any dependency</li>

--- a/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/FileSpec.java
+++ b/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/FileSpec.java
@@ -28,7 +28,6 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Objects;
 
-import groovy.lang.GString;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.file.RegularFileProperty;
@@ -52,7 +51,7 @@ public interface FileSpec {
 	 * <ul>
 	 * <li>{@link File}, {@link Path} and {@link org.gradle.api.file.FileSystemLocation} will be resolved as local files</li>
 	 * <li>{@link Provider} (including {@link org.gradle.api.provider.Property} will recursively be resolved as its current value</li>
-	 * <li>{@link String} and {@link GString} will be resolved as Maven dependencies</li>
+	 * <li>{@link CharSequence} (including {@link String} and {@link groovy.lang.GString}) will be resolved as Maven dependencies</li>
 	 * <li>{@link Dependency} will be resolved as any dependency</li>
 	 * </ul>
 	 *
@@ -62,9 +61,7 @@ public interface FileSpec {
 	static FileSpec create(Object o) {
 		Objects.requireNonNull(o, "Object cannot be null");
 
-		if (o instanceof String s) {
-			return createFromMavenDependency(s);
-		} else if (o instanceof GString s) {
+		if (o instanceof CharSequence s) {
 			return createFromMavenDependency(s.toString());
 		} else if (o instanceof Dependency d) {
 			return createFromDependency(d);

--- a/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/FileSpec.java
+++ b/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/FileSpec.java
@@ -28,8 +28,11 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Objects;
 
+import groovy.lang.GString;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Provider;
 import org.jetbrains.annotations.ApiStatus;
 
 import net.fabricmc.loom.api.mappings.layered.MappingContext;
@@ -42,17 +45,37 @@ import net.fabricmc.loom.configuration.providers.mappings.utils.MavenFileSpec;
  */
 @ApiStatus.Experimental
 public interface FileSpec {
+	/**
+	 * Creates a file spec.
+	 *
+	 * <p>The parameter will be evaluated like this:
+	 * <ul>
+	 * <li>{@link File}, {@link Path} and {@link org.gradle.api.file.FileSystemLocation} will be resolved as local files</li>
+	 * <li>{@link Provider} (including {@link org.gradle.api.provider.Property} will recursively be resolved as its current value</li>
+	 * <li>{@link String} and {@link GString} will be resolved as Maven dependencies</li>
+	 * <li>{@link Dependency} will be resolved as any dependency</li>
+	 * </ul>
+	 *
+	 * @param o the file notation
+	 * @return the created file spec
+	 */
 	static FileSpec create(Object o) {
 		Objects.requireNonNull(o, "Object cannot be null");
 
 		if (o instanceof String s) {
 			return createFromMavenDependency(s);
+		} else if (o instanceof GString s) {
+			return createFromMavenDependency(s.toString());
 		} else if (o instanceof Dependency d) {
 			return createFromDependency(d);
+		} else if (o instanceof Provider<?> p) {
+			return create(p.get());
 		} else if (o instanceof File f) {
 			return createFromFile(f);
-		} else if (o instanceof RegularFileProperty rfp) {
-			return createFromFile(rfp);
+		} else if (o instanceof Path p) {
+			return createFromFile(p.toFile());
+		} else if (o instanceof FileSystemLocation l) {
+			return createFromFile(l.getAsFile());
 		}
 
 		throw new UnsupportedOperationException("Cannot create FileSpec from object of type:" + o.getClass().getCanonicalName());
@@ -70,9 +93,17 @@ public interface FileSpec {
 		return new LocalFileSpec(file);
 	}
 
+	static FileSpec createFromFile(FileSystemLocation location) {
+		return createFromFile(location.getAsFile());
+	}
+
+	static FileSpec createFromFile(Path path) {
+		return createFromFile(path.toFile());
+	}
+
 	// Note resolved instantly, this is not lazy
 	static FileSpec createFromFile(RegularFileProperty regularFileProperty) {
-		return createFromFile(regularFileProperty.getAsFile().get());
+		return createFromFile(regularFileProperty.get());
 	}
 
 	Path get(MappingContext context);


### PR DESCRIPTION
Now supports
- all `Provider`s recursively (incl. `Property`)
- groovy template string literal `GString` and other `CharSequence`s (this crashed before if you had sth like `parchment("group:name:$parchmentVersion")`)
- `Path` and gradle `FileSystemLocation` (the values of `RegularFileProperty`)