### PR TITLE
Fix regression in TinyJavadocProvider

### DIFF
--- a/src/main/java/net/fabricmc/loom/decompilers/fernflower/TinyJavadocProvider.java
+++ b/src/main/java/net/fabricmc/loom/decompilers/fernflower/TinyJavadocProvider.java
@@ -151,7 +151,7 @@ public class TinyJavadocProvider implements IFabricJavadocProvider {
 						addedParam = true;
 					}
 
-					parts.add(String.format("@param %s %s", methodMapping.getName(MappingsNamespace.NAMED.toString()), comment));
+					parts.add(String.format("@param %s %s", argMapping.getName(MappingsNamespace.NAMED.toString()), comment));
 				}
 			}
 


### PR DESCRIPTION
This was `param.getName` using tiny-mappings-parser before #495. ([See the relevant change here](https://github.com/FabricMC/fabric-loom/pull/495/files#diff-ad3bf7f6e6ab4508cba73a63853847481f7f5e61f1ff73f477efb3636ddaeae1R154)) It was writing the method name as the parameter name, which doesn't seem too correct...

Also... hacktoberfest maybe for this and FAPI? :tiny_potato: