### PR TITLE
Add localRuntime and modLocalRuntime configurations

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -64,6 +64,8 @@ public final class CompileConfiguration {
 		extension.createLazyConfiguration(Constants.Configurations.MAPPINGS_FINAL);
 		extension.createLazyConfiguration(Constants.Configurations.LOOM_DEVELOPMENT_DEPENDENCIES);
 		extension.createLazyConfiguration(Constants.Configurations.UNPICK_CLASSPATH);
+		extension.createLazyConfiguration(Constants.Configurations.LOCAL_RUNTIME);
+		extendsFrom(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME, Constants.Configurations.LOCAL_RUNTIME, project);
 
 		for (RemappedConfigurationEntry entry : Constants.MOD_COMPILE_ENTRIES) {
 			extension.createLazyConfiguration(entry.sourceConfiguration())

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -49,7 +49,8 @@ public class Constants {
 			new RemappedConfigurationEntry("modRuntime", JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, false, true, "", "modRuntimeOnly"),
 			new RemappedConfigurationEntry("modCompileOnly", JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME, true, false, ""),
 			new RemappedConfigurationEntry("modCompileOnlyApi", JavaPlugin.COMPILE_ONLY_API_CONFIGURATION_NAME, true, false, JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME),
-			new RemappedConfigurationEntry("modRuntimeOnly", JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, false, true, JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME)
+			new RemappedConfigurationEntry("modRuntimeOnly", JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, false, true, JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME),
+			new RemappedConfigurationEntry("modLocalRuntime", Configurations.LOCAL_RUNTIME, false, true, "")
 	);
 
 	private Constants() {
@@ -72,6 +73,12 @@ public class Constants {
 		public static final String LOOM_DEVELOPMENT_DEPENDENCIES = "loomDevelopmentDependencies";
 		public static final String MAPPING_CONSTANTS = "mappingsConstants";
 		public static final String UNPICK_CLASSPATH = "unpick";
+		/**
+		 * A configuration that behaves like {@code runtimeOnly} but is not
+		 * exposed in {@code runtimeElements} to dependents. A bit like
+		 * {@code testRuntimeOnly}, but for mods.
+		 */
+		public static final String LOCAL_RUNTIME = "localRuntime";
 
 		private Configurations() {
 		}

--- a/src/test/groovy/net/fabricmc/loom/test/integration/LocalRuntimeTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/LocalRuntimeTest.groovy
@@ -1,0 +1,53 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2018-2021 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.integration
+
+import net.fabricmc.loom.test.util.GradleProjectTestTrait
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static net.fabricmc.loom.test.LoomTestConstants.STANDARD_TEST_VERSIONS
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class LocalRuntimeTest extends Specification implements GradleProjectTestTrait {
+	@Unroll
+	def "build (gradle #version)"() {
+		setup:
+			def gradle = gradleProject(project: "localRuntime", version: version)
+
+		when:
+			def result = gradle.run(tasks: ["build", "publishToMavenLocal"])
+
+		then:
+			result.task(":build").outcome == SUCCESS
+			def pomFile = new File(gradle.getProjectDir(), "build/publications/mavenJava/pom-default.xml")
+			def pom = pomFile.text
+			!pom.contains("fabric-api")
+			!pom.contains("enigma")
+
+		where:
+			version << STANDARD_TEST_VERSIONS
+	}
+}

--- a/src/test/resources/projects/localRuntime/build.gradle
+++ b/src/test/resources/projects/localRuntime/build.gradle
@@ -1,0 +1,79 @@
+plugins {
+	id 'fabric-loom'
+	id 'maven-publish'
+}
+
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
+archivesBaseName = project.archives_base_name
+version = loom.modVersion
+group = project.maven_group
+
+repositories {
+    // Add repositories to retrieve artifacts from in here.
+    // You should only use this when depending on other mods because
+    // Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
+    // See https://docs.gradle.org/current/userguide/declaring_repositories.html
+    // for more information about repositories.
+}
+
+dependencies {
+	// To change the versions see the gradle.properties file
+	minecraft "com.mojang:minecraft:${project.minecraft_version}"
+	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+
+	// Fabric API. This is technically optional, but you probably want it anyway.
+	modLocalRuntime "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	localRuntime "cuchaz:enigma:1.4.7" // an example non-mod local dependency
+
+	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
+	// You may need to force-disable transitiveness on them.
+}
+
+tasks.withType(JavaCompile).configureEach {
+	// ensure that the encoding is set to UTF-8, no matter what the system default is
+	// this fixes some edge cases with special characters not displaying correctly
+	// see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
+	// If Javadoc is generated, this must be specified in that task too.
+	it.options.encoding = "UTF-8"
+
+	// The Minecraft launcher currently installs Java 8 for users, so your mod probably wants to target Java 8 too
+	// JDK 9 introduced a new way of specifying this that will make sure no newer classes or methods are used.
+	// We'll use that if it's available, but otherwise we'll use the older option.
+	def targetVersion = 8
+	if (JavaVersion.current().isJava9Compatible()) {
+		 it.options.release = targetVersion
+	}
+}
+
+java {
+	// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
+	// if it is present.
+	// If you remove this line, sources will not be generated.
+	withSourcesJar()
+}
+
+jar {
+	from("LICENSE") {
+		rename { "${it}_${project.archivesBaseName}"}
+	}
+}
+
+// configure the maven publication
+publishing {
+	publications {
+		mavenJava(MavenPublication) {
+			from components.java
+		}
+	}
+    
+    // See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
+    repositories {
+        // Add repositories to publish to here.
+        // Notice: This block does NOT have the same function as the block in the top level.
+        // The repositories here will be used for publishing your artifact, not for
+        // retrieving dependencies.
+    }
+}

--- a/src/test/resources/projects/localRuntime/gradle.properties
+++ b/src/test/resources/projects/localRuntime/gradle.properties
@@ -1,0 +1,16 @@
+# Done to increase the memory available to gradle.
+org.gradle.jvmargs=-Xmx1G
+
+# Fabric Properties
+	# check these on https://fabricmc.net/use
+	minecraft_version=1.16.5
+	yarn_mappings=1.16.5+build.5
+	loader_version=0.11.2
+
+# Mod Properties
+	maven_group = com.example
+	archives_base_name = fabric-example-mod
+
+# Dependencies
+	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
+	fabric_version=0.31.0+1.16

--- a/src/test/resources/projects/localRuntime/settings.gradle
+++ b/src/test/resources/projects/localRuntime/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "fabric-example-mod"
+

--- a/src/test/resources/projects/localRuntime/src/main/java/net/fabricmc/example/ExampleMod.java
+++ b/src/test/resources/projects/localRuntime/src/main/java/net/fabricmc/example/ExampleMod.java
@@ -1,0 +1,14 @@
+package net.fabricmc.example;
+
+import net.fabricmc.api.ModInitializer;
+
+public class ExampleMod implements ModInitializer {
+	@Override
+	public void onInitialize() {
+		// This code runs as soon as Minecraft is in a mod-load-ready state.
+		// However, some things (like resources) may still be uninitialized.
+		// Proceed with mild caution.
+
+		System.out.println("Hello simple Fabric mod");
+	}
+}

--- a/src/test/resources/projects/localRuntime/src/main/java/net/fabricmc/example/mixin/ExampleMixin.java
+++ b/src/test/resources/projects/localRuntime/src/main/java/net/fabricmc/example/mixin/ExampleMixin.java
@@ -1,0 +1,15 @@
+package net.fabricmc.example.mixin;
+
+import net.minecraft.client.gui.screen.TitleScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TitleScreen.class)
+public class ExampleMixin {
+	@Inject(at = @At("HEAD"), method = "init()V")
+	private void init(CallbackInfo info) {
+		System.out.println("This line is printed by an example mod mixin!");
+	}
+}

--- a/src/test/resources/projects/localRuntime/src/main/resources/fabric.mod.json
+++ b/src/test/resources/projects/localRuntime/src/main/resources/fabric.mod.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "id": "modid",
+  "version": "1.0.0",
+
+  "name": "Example Mod",
+  "description": "This is an example description! Tell everyone what your mod is about!",
+  "authors": [
+    "Me!"
+  ],
+  "contact": {
+    "homepage": "https://fabricmc.net/",
+    "sources": "https://github.com/FabricMC/fabric-example-mod"
+  },
+
+  "license": "CC0-1.0",
+
+  "environment": "*",
+  "entrypoints": {
+    "main": [
+      "net.fabricmc.example.ExampleMod"
+    ]
+  },
+  "mixins": [
+    "modid.mixins.json"
+  ],
+
+  "depends": {
+    "fabricloader": ">=0.7.4",
+    "minecraft": "1.16.x"
+  },
+  "suggests": {
+    "another-mod": "*"
+  }
+}

--- a/src/test/resources/projects/localRuntime/src/main/resources/modid.mixins.json
+++ b/src/test/resources/projects/localRuntime/src/main/resources/modid.mixins.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "net.fabricmc.example.mixin",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+  ],
+  "client": [
+    "ExampleMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/test/resources/projects/localRuntime/src/test/java/net/fabricmc/example/test/ExampleMod.java
+++ b/src/test/resources/projects/localRuntime/src/test/java/net/fabricmc/example/test/ExampleMod.java
@@ -1,0 +1,12 @@
+package net.fabricmc.example.test;
+
+import net.fabricmc.api.ModInitializer;
+import net.minecraft.client.gui.screen.TitleScreen;
+
+// Just a simple class to ensure the tests can compile against loader and minecraft
+public class ExampleMod implements ModInitializer {
+	@Override
+	public void onInitialize() {
+		TitleScreen screen = null;
+	}
+}


### PR DESCRIPTION
Closes #481.

- `localRuntime` is basically a non-exposed alternative of `runtimeOnly`. It's not added to `runtimeElements`, so dependents can't see it.
- `modLocalRuntime` is the mod version of the configuration, which behaves exactly the same as the deprecated `modRuntime`.

Possible questions you might have:
- "Why isn't this on the compile classpath?" You can use `(mod)CompileOnly` just fine.
- "Why not name it `localRuntime*Only*`?" I would, but it'd conflict with the `runtimeOnly` variant generated for a source set called `local`.