### PR TITLE
Add a test for leaking runtime scope dependencies on compile classpath

### DIFF
--- a/src/test/resources/projects/maven/build.gradle
+++ b/src/test/resources/projects/maven/build.gradle
@@ -29,7 +29,7 @@ task verifyCompileClasspath {
 	doLast {
 		configurations.compileClasspath.resolve().each {
 			if (it.name.contains("fabric-api")) {
-				throw new IllegalStateException("Compile classpath contains implementation dependency $it.name")
+				throw new IllegalStateException("Compile classpath contains 'runtime' scope dependency $it.name")
 			}
 		}
 	}

--- a/src/test/resources/projects/maven/build.gradle
+++ b/src/test/resources/projects/maven/build.gradle
@@ -23,3 +23,16 @@ dependencies {
 
 	modImplementation System.getProperty("loom.test.resolve")
 }
+
+// Test that implementation deps don't leak into the compile classpath from maven deps
+task verifyCompileClasspath {
+	doLast {
+		configurations.compileClasspath.resolve().each {
+			if (it.name.contains("fabric-api")) {
+				throw new IllegalStateException("Compile classpath contains implementation dependency $it.name")
+			}
+		}
+	}
+}
+
+check.dependsOn verifyCompileClasspath

--- a/src/test/resources/projects/mavenLibrary/build.gradle
+++ b/src/test/resources/projects/mavenLibrary/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	minecraft "com.mojang:minecraft:1.16.5"
 	mappings "net.fabricmc:yarn:1.16.5+build.5:v2"
 	modImplementation "net.fabricmc:fabric-loader:0.11.2"
+	modImplementation "net.fabricmc.fabric-api:fabric-api:0.31.0+1.16"
 }
 
 processResources {


### PR DESCRIPTION
This makes MavenProjectTest fail because dependencies declared with a "runtime" scope are still put on the compile classpath when you use a `mod*` config on the compile classpath. I don't really know at the moment how to fix this, but this test is a good starting point IMO.