### PR TITLE
Add an option (enabled by default) to map synthetic field and method names from the official mojang mappings.

### DIFF
--- a/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/LayeredMappingSpecBuilder.java
+++ b/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/LayeredMappingSpecBuilder.java
@@ -24,7 +24,10 @@
 
 package net.fabricmc.loom.api.mappings.layered.spec;
 
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
+import org.gradle.util.ConfigureUtil;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
@@ -47,10 +50,23 @@ public interface LayeredMappingSpecBuilder {
 	/**
 	 * Configure and add a layer that uses the official mappings provided by Mojang.
 	 */
+	@SuppressWarnings("rawtypes")
+	default LayeredMappingSpecBuilder officialMojangMappings(@DelegatesTo(value = MojangMappingsSpecBuilder.class, strategy = Closure.DELEGATE_FIRST) Closure closure) {
+		return officialMojangMappings(mojangMappingsSpecBuilder -> ConfigureUtil.configure(closure, mojangMappingsSpecBuilder));
+	}
+
+	/**
+	 * Configure and add a layer that uses the official mappings provided by Mojang.
+	 */
 	LayeredMappingSpecBuilder officialMojangMappings(Action<MojangMappingsSpecBuilder> action);
 
 	default LayeredMappingSpecBuilder parchment(Object object) {
 		return parchment(object, parchmentMappingsSpecBuilder -> parchmentMappingsSpecBuilder.setRemovePrefix(true));
+	}
+
+	@SuppressWarnings("rawtypes")
+	default LayeredMappingSpecBuilder parchment(Object object, @DelegatesTo(value = ParchmentMappingsSpecBuilder.class, strategy = Closure.DELEGATE_FIRST) Closure closure) {
+		return parchment(object, parchmentMappingsSpecBuilder -> ConfigureUtil.configure(closure, parchmentMappingsSpecBuilder));
 	}
 
 	LayeredMappingSpecBuilder parchment(Object object, Action<ParchmentMappingsSpecBuilder> action);

--- a/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/MojangMappingsSpecBuilder.java
+++ b/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/MojangMappingsSpecBuilder.java
@@ -31,4 +31,6 @@ public interface MojangMappingsSpecBuilder {
 	 * <p>When disabled synthetic fields and methods will not be mapped leaving them with their intermediary name.
 	 */
 	MojangMappingsSpecBuilder setNameSyntheticMembers(boolean value);
+
+	boolean getNameSyntheticMembers();
 }

--- a/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/MojangMappingsSpecBuilder.java
+++ b/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/MojangMappingsSpecBuilder.java
@@ -24,40 +24,11 @@
 
 package net.fabricmc.loom.api.mappings.layered.spec;
 
-import org.gradle.api.Action;
-import org.jetbrains.annotations.ApiStatus;
-
-/**
- * Used to configure a layered mapping spec.
- */
-@ApiStatus.Experimental
-public interface LayeredMappingSpecBuilder {
+public interface MojangMappingsSpecBuilder {
 	/**
-	 * Add a MappingsSpec layer.
+	 * When enabled synthetic fields and methods will be mapped to name specified in the official mojang mappings.
+	 *
+	 * <p>When disabled synthetic fields and methods will not be mapped leaving them with their intermediary name.
 	 */
-	LayeredMappingSpecBuilder addLayer(MappingsSpec<?> mappingSpec);
-
-	/**
-	 * Add a layer that uses the official mappings provided by Mojang with the default options.
-	 */
-	default LayeredMappingSpecBuilder officialMojangMappings() {
-		return officialMojangMappings(builder -> { });
-	}
-
-	/**
-	 * Configure and add a layer that uses the official mappings provided by Mojang.
-	 */
-	LayeredMappingSpecBuilder officialMojangMappings(Action<MojangMappingsSpecBuilder> action);
-
-	default LayeredMappingSpecBuilder parchment(Object object) {
-		return parchment(object, parchmentMappingsSpecBuilder -> parchmentMappingsSpecBuilder.setRemovePrefix(true));
-	}
-
-	LayeredMappingSpecBuilder parchment(Object object, Action<ParchmentMappingsSpecBuilder> action);
-
-	/**
-	 * Add a signatureFix layer. Reads the @extras/record_signatures.json" file in a jar file such as yarn.
-	 */
-	@ApiStatus.Experimental
-	LayeredMappingSpecBuilder signatureFix(Object object);
+	MojangMappingsSpecBuilder setNameSyntheticMembers(boolean value);
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingSpecBuilderImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingSpecBuilderImpl.java
@@ -33,10 +33,11 @@ import org.gradle.api.Action;
 import net.fabricmc.loom.api.mappings.layered.spec.FileSpec;
 import net.fabricmc.loom.api.mappings.layered.spec.LayeredMappingSpecBuilder;
 import net.fabricmc.loom.api.mappings.layered.spec.MappingsSpec;
+import net.fabricmc.loom.api.mappings.layered.spec.MojangMappingsSpecBuilder;
 import net.fabricmc.loom.api.mappings.layered.spec.ParchmentMappingsSpecBuilder;
 import net.fabricmc.loom.configuration.providers.mappings.extras.signatures.SignatureFixesSpec;
 import net.fabricmc.loom.configuration.providers.mappings.intermediary.IntermediaryMappingsSpec;
-import net.fabricmc.loom.configuration.providers.mappings.mojmap.MojangMappingsSpec;
+import net.fabricmc.loom.configuration.providers.mappings.mojmap.MojangMappingsSpecBuilderImpl;
 import net.fabricmc.loom.configuration.providers.mappings.parchment.ParchmentMappingsSpecBuilderImpl;
 
 public class LayeredMappingSpecBuilderImpl implements LayeredMappingSpecBuilder {
@@ -49,8 +50,10 @@ public class LayeredMappingSpecBuilderImpl implements LayeredMappingSpecBuilder 
 	}
 
 	@Override
-	public LayeredMappingSpecBuilder officialMojangMappings() {
-		return addLayer(new MojangMappingsSpec());
+	public LayeredMappingSpecBuilder officialMojangMappings(Action<MojangMappingsSpecBuilder> action) {
+		MojangMappingsSpecBuilderImpl builder = MojangMappingsSpecBuilderImpl.builder();
+		action.execute(builder);
+		return addLayer(builder.build());
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/mojmap/MojangMappingsSpecBuilderImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/mojmap/MojangMappingsSpecBuilderImpl.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2016-2021 FabricMC
+ * Copyright (c) 2021 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,29 +24,26 @@
 
 package net.fabricmc.loom.configuration.providers.mappings.mojmap;
 
-import net.fabricmc.loom.api.mappings.layered.MappingContext;
-import net.fabricmc.loom.api.mappings.layered.spec.MappingsSpec;
-import net.fabricmc.loom.configuration.providers.minecraft.MinecraftVersionMeta;
+import net.fabricmc.loom.api.mappings.layered.spec.MojangMappingsSpecBuilder;
 
-public record MojangMappingsSpec(boolean nameSyntheticMembers) implements MappingsSpec<MojangMappingLayer> {
-	// Keys in dependency manifest
-	private static final String MANIFEST_CLIENT_MAPPINGS = "client_mappings";
-	private static final String MANIFEST_SERVER_MAPPINGS = "server_mappings";
+public class MojangMappingsSpecBuilderImpl implements MojangMappingsSpecBuilder {
+	// TODO 0.11 loom change default to false
+	private boolean nameSyntheticMembers = true;
+
+	private MojangMappingsSpecBuilderImpl() {
+	}
+
+	public static MojangMappingsSpecBuilderImpl builder() {
+		return new MojangMappingsSpecBuilderImpl();
+	}
 
 	@Override
-	public MojangMappingLayer createLayer(MappingContext context) {
-		MinecraftVersionMeta versionInfo = context.minecraftProvider().getVersionInfo();
+	public MojangMappingsSpecBuilder setNameSyntheticMembers(boolean value) {
+		nameSyntheticMembers = value;
+		return this;
+	}
 
-		if (versionInfo.download(MANIFEST_CLIENT_MAPPINGS) == null) {
-			throw new RuntimeException("Failed to find official mojang mappings for " + context.minecraftVersion());
-		}
-
-		return new MojangMappingLayer(
-				versionInfo.download(MANIFEST_CLIENT_MAPPINGS),
-				versionInfo.download(MANIFEST_SERVER_MAPPINGS),
-				context.workingDirectory("mojang"),
-				nameSyntheticMembers(),
-				context.getLogger()
-		);
+	public MojangMappingsSpec build() {
+		return new MojangMappingsSpec(nameSyntheticMembers);
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/mojmap/MojangMappingsSpecBuilderImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/mojmap/MojangMappingsSpecBuilderImpl.java
@@ -43,6 +43,11 @@ public class MojangMappingsSpecBuilderImpl implements MojangMappingsSpecBuilder 
 		return this;
 	}
 
+	@Override
+	public boolean getNameSyntheticMembers() {
+		return nameSyntheticMembers;
+	}
+
 	public MojangMappingsSpec build() {
 		return new MojangMappingsSpec(nameSyntheticMembers);
 	}

--- a/src/test/groovy/net/fabricmc/loom/test/integration/MojangMappingsProjectTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/MojangMappingsProjectTest.groovy
@@ -48,4 +48,30 @@ class MojangMappingsProjectTest extends Specification implements GradleProjectTe
 		where:
 			version << STANDARD_TEST_VERSIONS
 	}
+
+	@Unroll
+	def "mojang mappings without synthetic field names (gradle #version)"() {
+		setup:
+			def gradle = gradleProject(project: "minimalBase", version: version)
+
+			gradle.buildGradle << '''
+                dependencies {
+                    minecraft "com.mojang:minecraft:1.18-pre5"
+                    mappings loom.layered {
+						officialMojangMappings {
+							nameSyntheticMembers = false
+						}
+					}
+                }
+            '''
+
+		when:
+			def result = gradle.run(task: "build")
+
+		then:
+			result.task(":build").outcome == SUCCESS
+
+		where:
+			version << STANDARD_TEST_VERSIONS
+	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingSpecBuilderTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingSpecBuilderTest.groovy
@@ -42,7 +42,7 @@ class LayeredMappingSpecBuilderTest extends Specification {
             }
             def layers = spec.layers()
         then:
-            spec.version == "layered+hash.961"
+            spec.version == "layered+hash.2192"
             layers.size() == 2
             layers[0].class == IntermediaryMappingsSpec
             layers[1].class == MojangMappingsSpec
@@ -57,7 +57,7 @@ class LayeredMappingSpecBuilderTest extends Specification {
             def layers = spec.layers()
             def parchment = layers[2] as ParchmentMappingsSpec
         then:
-            spec.version == "layered+hash.863714404"
+            spec.version == "layered+hash.863752565"
             layers.size() == 3
             layers[0].class == IntermediaryMappingsSpec
             layers[1].class == MojangMappingsSpec
@@ -77,7 +77,7 @@ class LayeredMappingSpecBuilderTest extends Specification {
             def layers = spec.layers()
             def parchment = layers[2] as ParchmentMappingsSpec
         then:
-            spec.version == "layered+hash.863714410"
+            spec.version == "layered+hash.863752571"
             layers.size() == 3
             layers[0].class == IntermediaryMappingsSpec
             layers[1].class == MojangMappingsSpec
@@ -97,7 +97,7 @@ class LayeredMappingSpecBuilderTest extends Specification {
             def layers = spec.layers()
             def parchment = layers[2] as ParchmentMappingsSpec
         then:
-            spec.version == "layered+hash.1144465487"
+            spec.version == "layered+hash.1144427326"
             layers.size() == 3
             layers[0].class == IntermediaryMappingsSpec
             layers[1].class == MojangMappingsSpec

--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/ParchmentMappingLayerTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/ParchmentMappingLayerTest.groovy
@@ -38,7 +38,7 @@ class ParchmentMappingLayerTest extends LayeredMappingsSpecification {
             withMavenFile(PARCHMENT_NOTATION, downloadFile(PARCHMENT_URL, "parchment.zip"))
             def mappings = getLayeredMappings(
                     new IntermediaryMappingsSpec(),
-                    new MojangMappingsSpec(),
+                    new MojangMappingsSpec(true),
                     new ParchmentMappingsSpec(FileSpec.create(PARCHMENT_NOTATION), false)
             )
             def tiny = getTiny(mappings)
@@ -61,7 +61,7 @@ class ParchmentMappingLayerTest extends LayeredMappingsSpecification {
             withMavenFile(PARCHMENT_NOTATION, downloadFile(PARCHMENT_URL, "parchment.zip"))
             def mappings = getLayeredMappings(
                     new IntermediaryMappingsSpec(),
-                    new MojangMappingsSpec(),
+                    new MojangMappingsSpec(true),
                     new ParchmentMappingsSpec(FileSpec.create(PARCHMENT_NOTATION), true)
             )
             def tiny = getTiny(mappings)


### PR DESCRIPTION
This is enabled by default to match the existing behaviour. This default should be changed in 0.11.

This option can be changed like so:
```groovy
dependencies {
	minecraft "com.mojang:minecraft:1.16.5"
	mappings loom.layered {
		officialMojangMappings {
			nameSyntheticMembers = false
		}
	}
}
```