### PR TITLE
Fix gradle module metadatas not including api deps in runtimeElements

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -96,8 +96,8 @@ public final class CompileConfiguration {
 				extendsFrom(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME, entry.getRemappedConfiguration(), project);
 			}
 
-			if (entry.hasConsumerConfiguration()) {
-				extendsFrom(entry.consumerConfiguration(), entry.sourceConfiguration(), project);
+			for (String outgoingConfiguration : entry.publishingMode().outgoingConfigurations()) {
+				extendsFrom(outgoingConfiguration, entry.sourceConfiguration(), project);
 			}
 		}
 

--- a/src/main/java/net/fabricmc/loom/configuration/MavenPublication.java
+++ b/src/main/java/net/fabricmc/loom/configuration/MavenPublication.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.google.common.collect.ImmutableMap;
 import groovy.util.Node;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -48,7 +49,9 @@ import net.fabricmc.loom.util.DeprecationHelper;
 import net.fabricmc.loom.util.GroovyXmlUtil;
 
 public final class MavenPublication {
-	private static final Map<String, String> CONFIGURATION_TO_SCOPE = Map.of(
+	// ImmutableMap is needed since it guarantees ordering
+	// (compile must go before runtime, or otherwise dependencies might get the "weaker" runtime scope).
+	private static final Map<String, String> CONFIGURATION_TO_SCOPE = ImmutableMap.of(
 			JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME, "compile",
 			JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME, "runtime"
 	);

--- a/src/main/java/net/fabricmc/loom/configuration/RemappedConfigurationEntry.java
+++ b/src/main/java/net/fabricmc/loom/configuration/RemappedConfigurationEntry.java
@@ -24,17 +24,15 @@
 
 package net.fabricmc.loom.configuration;
 
+import java.util.Set;
+
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.plugins.JavaPlugin;
 import org.jetbrains.annotations.Nullable;
 
-public record RemappedConfigurationEntry(String sourceConfiguration, String targetConfiguration, boolean compileClasspath, boolean runtimeClasspath, String consumerConfiguration, @Nullable String replacedWith) {
-	public RemappedConfigurationEntry(String sourceConfiguration, String targetConfiguration, boolean compileClasspath, boolean runtimeClasspath, String consumerConfiguration) {
-		this(sourceConfiguration, targetConfiguration, compileClasspath, runtimeClasspath, consumerConfiguration, null);
-	}
-
-	public boolean hasConsumerConfiguration() {
-		return consumerConfiguration != null && !consumerConfiguration.isEmpty();
+public record RemappedConfigurationEntry(String sourceConfiguration, String targetConfiguration, boolean compileClasspath, boolean runtimeClasspath, PublishingMode publishingMode, @Nullable String replacedWith) {
+	public RemappedConfigurationEntry(String sourceConfiguration, String targetConfiguration, boolean compileClasspath, boolean runtimeClasspath, PublishingMode publishingMode) {
+		this(sourceConfiguration, targetConfiguration, compileClasspath, runtimeClasspath, publishingMode, null);
 	}
 
 	public String getRemappedConfiguration() {
@@ -47,5 +45,22 @@ public record RemappedConfigurationEntry(String sourceConfiguration, String targ
 		}
 
 		return targetConfiguration;
+	}
+
+	public enum PublishingMode {
+		NONE,
+		COMPILE_ONLY(JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME),
+		RUNTIME_ONLY(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME),
+		COMPILE_AND_RUNTIME(JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME, JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME);
+
+		private final Set<String> outgoingConfigurations;
+
+		PublishingMode(String... outgoingConfigurations) {
+			this.outgoingConfigurations = Set.of(outgoingConfigurations);
+		}
+
+		public Set<String> outgoingConfigurations() {
+			return outgoingConfigurations;
+		}
 	}
 }

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -31,6 +31,7 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.objectweb.asm.Opcodes;
 
 import net.fabricmc.loom.configuration.RemappedConfigurationEntry;
+import net.fabricmc.loom.configuration.RemappedConfigurationEntry.PublishingMode;
 
 public class Constants {
 	public static final String LIBRARIES_BASE = "https://libraries.minecraft.net/";
@@ -44,13 +45,13 @@ public class Constants {
 	public static final int ASM_VERSION = Opcodes.ASM9;
 
 	public static final List<RemappedConfigurationEntry> MOD_COMPILE_ENTRIES = ImmutableList.of(
-			new RemappedConfigurationEntry("modApi", JavaPlugin.API_CONFIGURATION_NAME, true, true, JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME),
-			new RemappedConfigurationEntry("modImplementation", JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, true, true, JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME),
-			new RemappedConfigurationEntry("modRuntime", JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, false, true, "", "modRuntimeOnly"),
-			new RemappedConfigurationEntry("modCompileOnly", JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME, true, false, ""),
-			new RemappedConfigurationEntry("modCompileOnlyApi", JavaPlugin.COMPILE_ONLY_API_CONFIGURATION_NAME, true, false, JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME),
-			new RemappedConfigurationEntry("modRuntimeOnly", JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, false, true, JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME),
-			new RemappedConfigurationEntry("modLocalRuntime", Configurations.LOCAL_RUNTIME, false, true, "")
+			new RemappedConfigurationEntry("modApi", JavaPlugin.API_CONFIGURATION_NAME, true, true, PublishingMode.COMPILE_AND_RUNTIME),
+			new RemappedConfigurationEntry("modImplementation", JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, true, true, PublishingMode.RUNTIME_ONLY),
+			new RemappedConfigurationEntry("modRuntime", JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, false, true, PublishingMode.NONE, "modRuntimeOnly"),
+			new RemappedConfigurationEntry("modCompileOnly", JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME, true, false, PublishingMode.NONE),
+			new RemappedConfigurationEntry("modCompileOnlyApi", JavaPlugin.COMPILE_ONLY_API_CONFIGURATION_NAME, true, false, PublishingMode.COMPILE_ONLY),
+			new RemappedConfigurationEntry("modRuntimeOnly", JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, false, true, PublishingMode.RUNTIME_ONLY),
+			new RemappedConfigurationEntry("modLocalRuntime", Configurations.LOCAL_RUNTIME, false, true, PublishingMode.NONE)
 	);
 
 	private Constants() {


### PR DESCRIPTION
(yes, the branch is incorrectly named)

I forgot to add `modApi` to `runtimeElements` so that configuration was accidentally published as compile-only in Gradle module metadatas (when using `from components.java`) - here's a cleaner and more descriptive solution for that.