### PR TITLE
Bump jackson-databind to 2.13.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
 	// libraries
 	implementation ('commons-io:commons-io:2.8.0')
 	implementation ('com.google.code.gson:gson:2.8.8')
-	implementation ('com.fasterxml.jackson.core:jackson-databind:2.12.5')
+	implementation ('com.fasterxml.jackson.core:jackson-databind:2.13.0')
 	implementation ('com.google.guava:guava:30.1.1-jre')
 	implementation ('org.ow2.asm:asm:9.2')
 	implementation ('org.ow2.asm:asm-analysis:9.2')


### PR DESCRIPTION
Fixes issues when running alongside other gradle plugins using a newer version