### PR TITLE
Only quote program arguments if they actually contain spaces

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
@@ -209,7 +209,12 @@ public class RunConfig {
 			}
 
 			first = false;
-			sb.append("\"").append(arg).append("\"");
+
+			if (arg.contains(" ")) {
+				sb.append("\"").append(arg).append("\"");
+			} else {
+				sb.append(arg);
+			}
 		}
 
 		return sb.toString();


### PR DESCRIPTION
Fixes arguments like "--username" not being recognized by MC due to unnecessary quoting.