### PR TITLE
Configure ValidateAccessWidenerTask.targetJar lazily

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/ValidateAccessWidenerTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ValidateAccessWidenerTask.java
@@ -58,7 +58,7 @@ public abstract class ValidateAccessWidenerTask extends DefaultTask {
 		final LoomGradleExtension extension = LoomGradleExtension.get(getProject());
 
 		getAccessWidener().convention(extension.getAccessWidenerPath()).finalizeValueOnRead();
-		getTargetJar().convention(getProject().getObjects().fileProperty().fileValue(extension.getMinecraftMappedProvider().getMappedJar())).finalizeValueOnRead();
+		getTargetJar().convention(getProject().getLayout().file(getProject().provider(() -> extension.getMinecraftMappedProvider().getMappedJar()))).finalizeValueOnRead();
 	}
 
 	@TaskAction


### PR DESCRIPTION
This should prevent crashes if the `validateAccessWidener` task is initialised manually (by other plugins or scripts iterating all tasks, for example) before Loom's `afterEvaluate`s init the dep managers.

(The example I gave is an actual issue someone else ran into in the wild)