### PR TITLE
Add support for mixins written in groovy

### DIFF
--- a/src/main/java/net/fabricmc/loom/build/mixin/AnnotationProcessorInvoker.java
+++ b/src/main/java/net/fabricmc/loom/build/mixin/AnnotationProcessorInvoker.java
@@ -53,6 +53,7 @@ import net.fabricmc.loom.util.Constants;
 public abstract class AnnotationProcessorInvoker<T extends Task> {
 	public static final String JAVA = "java";
 	public static final String SCALA = "scala";
+	public static final String GROOVY = "groovy";
 
 	protected final Project project;
 	protected final Map<SourceSet, T> invokerTasks;

--- a/src/main/java/net/fabricmc/loom/build/mixin/GroovyApInvoker.java
+++ b/src/main/java/net/fabricmc/loom/build/mixin/GroovyApInvoker.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2022 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.build.mixin;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.compile.GroovyCompile;
+
+import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.extension.MixinExtension;
+
+public class GroovyApInvoker extends AnnotationProcessorInvoker<GroovyCompile> {
+	public GroovyApInvoker(Project project) {
+		super(
+				project,
+				ImmutableList.of(),
+				getInvokerTasks(project));
+	}
+
+	private static Map<SourceSet, GroovyCompile> getInvokerTasks(Project project) {
+		MixinExtension mixin = LoomGradleExtension.get(project).getMixin();
+		return mixin.getInvokerTasksStream(AnnotationProcessorInvoker.GROOVY).collect(
+				Collectors.toMap(Map.Entry::getKey,
+						entry -> Objects.requireNonNull((GroovyCompile) entry.getValue())));
+	}
+
+	@Override
+	protected void passArgument(GroovyCompile compileTask, String key, String value) {
+		compileTask.getOptions().getCompilerArgs().add("-A" + key + "=" + value);
+	}
+
+	@Override
+	protected File getRefmapDestinationDir(GroovyCompile task) {
+		return task.getDestinationDirectory().getAsFile().get();
+	}
+}

--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -37,6 +37,7 @@ import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
 
 import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.build.mixin.GroovyApInvoker;
 import net.fabricmc.loom.build.mixin.JavaApInvoker;
 import net.fabricmc.loom.build.mixin.KaptApInvoker;
 import net.fabricmc.loom.build.mixin.ScalaApInvoker;
@@ -268,6 +269,11 @@ public final class CompileConfiguration {
 		if (project.getPluginManager().hasPlugin("org.jetbrains.kotlin.kapt")) {
 			project.getLogger().info("Configuring compiler arguments for Kapt plugin");
 			new KaptApInvoker(project).configureMixin();
+		}
+
+		if (project.getPluginManager().hasPlugin("groovy")) {
+			project.getLogger().info("Configuring compiler arguments for Groovy");
+			new GroovyApInvoker(project).configureMixin();
 		}
 	}
 


### PR DESCRIPTION
Mixins written in groovy or compiled by groovy tasks won't get their refmaps in correct places. This adds support for processing them.