### PR TITLE
Fix issues resolving libraries and natives for old mc versions down to 1.3.2.

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
@@ -28,6 +28,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.plugins.ExtensionAware;
@@ -90,6 +91,17 @@ public class LoomRepositoryPlugin implements Plugin<PluginAware> {
 			repo.setUrl(files.getRootProjectPersistentCache());
 			repo.patternLayout(layout -> layout.artifact("[revision]/[artifact](-[classifier])(.[ext])"));
 			repo.metadataSources(IvyArtifactRepository.MetadataSources::artifact);
+		});
+	}
+
+	public static void setupForLegacyVersions(Project project) {
+		// 1.4.7 contains an LWJGL version with an invalid maven pom, set the metadata sources to not use the pom for this version.
+		project.getRepositories().named("Mojang", MavenArtifactRepository.class, repo -> {
+			repo.metadataSources(sources -> {
+				// Only use the maven artifact and not the pom or gradle metadata.
+				sources.artifact();
+				sources.ignoreGradleMetadataRedirection();
+			});
 		});
 	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/LoomTestConstants.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/LoomTestConstants.groovy
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2021 FabricMC
+ * Copyright (c) 2021-2022 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +28,7 @@ import org.gradle.util.GradleVersion
 
 class LoomTestConstants {
     public final static String DEFAULT_GRADLE = GradleVersion.current().getVersion()
-    public final static String PRE_RELEASE_GRADLE = "7.5-20220122232041+0000"
+    public final static String PRE_RELEASE_GRADLE = "7.5-20220124231322+0000"
 
     public final static String[] STANDARD_TEST_VERSIONS = [DEFAULT_GRADLE, PRE_RELEASE_GRADLE]
 }

--- a/src/test/groovy/net/fabricmc/loom/test/integration/DecompileTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/DecompileTest.groovy
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2016-2021 FabricMC
+ * Copyright (c) 2016-2022 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -45,9 +45,7 @@ class DecompileTest extends Specification implements GradleProjectTestTrait {
 
 		where:
 			decompiler 		| task								| version
-			'fernflower'	| "genSourcesWithFernFlower"		| DEFAULT_GRADLE
 			'fernflower'	| "genSourcesWithFernFlower"		| PRE_RELEASE_GRADLE
-			'cfr' 			| "genSourcesWithCfr"				| DEFAULT_GRADLE
 			'cfr' 			| "genSourcesWithCfr"				| PRE_RELEASE_GRADLE
 	}
 

--- a/src/test/groovy/net/fabricmc/loom/test/integration/LegacyProjectTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/LegacyProjectTest.groovy
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2018-2021 FabricMC
+ * Copyright (c) 2018-2022 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +28,8 @@ import net.fabricmc.loom.test.util.GradleProjectTestTrait
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import static net.fabricmc.loom.test.LoomTestConstants.*
+import static net.fabricmc.loom.test.LoomTestConstants.PRE_RELEASE_GRADLE
+import static net.fabricmc.loom.test.LoomTestConstants.STANDARD_TEST_VERSIONS
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 // This test uses gradle 4.9 and 1.14.4 v1 mappings
@@ -46,5 +47,39 @@ class LegacyProjectTest extends Specification implements GradleProjectTestTrait 
 
 		where:
 			version << STANDARD_TEST_VERSIONS
+	}
+
+	@Unroll
+	def "Unsupported minecraft (minecraft #version)"() {
+		setup:
+			def gradle = gradleProject(project: "minimalBase", version: PRE_RELEASE_GRADLE)
+			gradle.buildGradle << """
+				loom {
+                    intermediaryUrl = 'https://s.modm.us/intermediary-empty-v2.jar'
+                }
+
+                dependencies {
+                    minecraft "com.mojang:minecraft:${version}"
+                    mappings loom.layered() {
+						// No names
+					}
+
+                    modImplementation "net.fabricmc:fabric-loader:0.12.12"
+                }
+			"""
+
+		when:
+			def result = gradle.run(task: "configureClientLaunch")
+
+		then:
+			result.task(":configureClientLaunch").outcome == SUCCESS
+
+		where:
+			version 		| _
+			'1.13.2'		| _
+			'1.12.2'		| _
+			'1.8.9'			| _
+			'1.7.10'		| _
+			'1.4.7'			| _
 	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/integration/LegacyProjectTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/LegacyProjectTest.groovy
@@ -80,6 +80,8 @@ class LegacyProjectTest extends Specification implements GradleProjectTestTrait 
 			'1.12.2'		| _
 			'1.8.9'			| _
 			'1.7.10'		| _
+			'1.6.4'			| _
 			'1.4.7'			| _
+			'1.3.2'			| _
 	}
 }


### PR DESCRIPTION
Add a simple integration tests. Fixes #583 and fixes #582.

Tests are ran for:
- 1.13.2
- 1.12.2
- 1.8.9
- 1.7.10
- 1.6.4
- 1.4.7
- 1.3.2

Please let me know if there are any other versions you would like support for and a test can be added. 1.4.7 required some special casing due to an invalid pom on Mojang's maven.