### PR TITLE
Intermediate mapping handling improvements.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,7 @@ dependencies {
 		exclude group: 'org.jetbrains.kotlin'
 	}
 	testImplementation 'net.fabricmc:fabric-installer:0.9.0'
+	testImplementation 'org.mockito:mockito-core:4.3.1'
 
 	compileOnly 'org.jetbrains:annotations:23.0.0'
 }

--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -112,10 +112,6 @@ public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 
 	boolean isRootProject();
 
-	default String getIntermediaryUrl(String minecraftVersion) {
-		return String.format(this.getIntermediaryUrl().get(), minecraftVersion);
-	}
-
 	@Override
 	MixinExtension getMixin();
 

--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -35,9 +35,11 @@ import org.gradle.api.publish.maven.MavenPublication;
 import org.jetbrains.annotations.ApiStatus;
 
 import net.fabricmc.loom.api.decompilers.DecompilerOptions;
+import net.fabricmc.loom.api.mappings.intermediate.IntermediateMappingsProvider;
 import net.fabricmc.loom.api.mappings.layered.spec.LayeredMappingSpecBuilder;
 import net.fabricmc.loom.configuration.ide.RunConfigSettings;
 import net.fabricmc.loom.configuration.processors.JarProcessor;
+import net.fabricmc.loom.configuration.providers.mappings.NoOpIntermediateMappingsProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftJarConfiguration;
 import net.fabricmc.loom.util.DeprecationHelper;
 
@@ -129,6 +131,20 @@ public interface LoomGradleExtensionAPI {
 	 * @return the property controlling the transitive access wideners
 	 */
 	Property<Boolean> getEnableTransitiveAccessWideners();
+
+	@ApiStatus.Experimental
+	IntermediateMappingsProvider getIntermediateMappingsProvider();
+
+	@ApiStatus.Experimental
+	<T extends IntermediateMappingsProvider> void setIntermediateMappingsProvider(Class<T> clazz, Action<T> action);
+
+	/**
+	 * An Experimental option to provide empty intermediate mappings, to be used for game versions without any intermediate mappings.
+	 */
+	@ApiStatus.Experimental
+	default void noIntermediateMappings() {
+		setIntermediateMappingsProvider(NoOpIntermediateMappingsProvider.class, p -> { });
+	}
 
 	/**
 	 * Use "%1$s" as a placeholder for the minecraft version.

--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -136,6 +136,9 @@ public interface LoomGradleExtensionAPI {
 	IntermediateMappingsProvider getIntermediateMappingsProvider();
 
 	@ApiStatus.Experimental
+	void setIntermediateMappingsProvider(IntermediateMappingsProvider intermediateMappingsProvider);
+
+	@ApiStatus.Experimental
 	<T extends IntermediateMappingsProvider> void setIntermediateMappingsProvider(Class<T> clazz, Action<T> action);
 
 	/**

--- a/src/main/java/net/fabricmc/loom/api/mappings/intermediate/IntermediateMappingsProvider.java
+++ b/src/main/java/net/fabricmc/loom/api/mappings/intermediate/IntermediateMappingsProvider.java
@@ -27,10 +27,7 @@ package net.fabricmc.loom.api.mappings.intermediate;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import javax.inject.Inject;
-
 import org.gradle.api.Named;
-import org.gradle.api.Project;
 import org.gradle.api.provider.Property;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -41,9 +38,6 @@ import org.jetbrains.annotations.ApiStatus;
 @ApiStatus.Experimental
 public abstract class IntermediateMappingsProvider implements Named {
 	public abstract Property<String> getMinecraftVersion();
-
-	@Inject
-	public abstract Project getProject();
 
 	/**
 	 * Generate or download a tinyv2 mapping file with intermediary and named namespaces.

--- a/src/main/java/net/fabricmc/loom/api/mappings/intermediate/IntermediateMappingsProvider.java
+++ b/src/main/java/net/fabricmc/loom/api/mappings/intermediate/IntermediateMappingsProvider.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2022 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.api.mappings.intermediate;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import javax.inject.Inject;
+
+import org.gradle.api.Named;
+import org.gradle.api.Project;
+import org.gradle.api.provider.Property;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * A simple API to allow 3rd party plugins.
+ * Implement by creating an abstract class overriding provide and getName
+ */
+@ApiStatus.Experimental
+public abstract class IntermediateMappingsProvider implements Named {
+	public abstract Property<String> getMinecraftVersion();
+
+	@Inject
+	public abstract Project getProject();
+
+	/**
+	 * Generate or download a tinyv2 mapping file with intermediary and named namespaces.
+	 * @throws IOException
+	 */
+	public abstract void provide(Path tinyMappings) throws IOException;
+}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/GradleMappingContext.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/GradleMappingContext.java
@@ -82,4 +82,12 @@ public class GradleMappingContext implements MappingContext {
 	public Logger getLogger() {
 		return project.getLogger();
 	}
+
+	public Project getProject() {
+		return project;
+	}
+
+	public LoomGradleExtension getExtension() {
+		return extension;
+	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/GradleMappingContext.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/GradleMappingContext.java
@@ -65,7 +65,7 @@ public class GradleMappingContext implements MappingContext {
 
 	@Override
 	public Supplier<MemoryMappingTree> intermediaryTree() {
-		return () -> IntermediaryService.getInstance(project, minecraftProvider()).getMemoryMappingTree();
+		return () -> IntermediateMappingsService.getInstance(project, minecraftProvider()).getMemoryMappingTree();
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/IntermediaryMappingsProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/IntermediaryMappingsProvider.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2022 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.configuration.providers.mappings;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.google.common.net.UrlEscapers;
+import org.gradle.api.provider.Property;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.fabricmc.loom.LoomGradlePlugin;
+import net.fabricmc.loom.api.mappings.intermediate.IntermediateMappingsProvider;
+import net.fabricmc.loom.util.DownloadUtil;
+
+public abstract class IntermediaryMappingsProvider extends IntermediateMappingsProvider {
+	private static final Logger LOGGER = LoggerFactory.getLogger(IntermediateMappingsProvider.class);
+
+	public abstract Property<String> getIntermediaryUrl();
+
+	@Override
+	public void provide(Path tinyMappings) throws IOException {
+		if (Files.exists(tinyMappings) && !LoomGradlePlugin.refreshDeps) {
+			return;
+		}
+
+		// Download and extract intermediary
+		final Path intermediaryJarPath = Files.createTempFile(getName(), ".jar");
+		final String encodedMcVersion = UrlEscapers.urlFragmentEscaper().escape(getMinecraftVersion().get());
+		final URL url = new URL(getIntermediaryUrl().get().formatted(encodedMcVersion));
+
+		LOGGER.info("Downloading intermediary from {}", url);
+
+		Files.deleteIfExists(tinyMappings);
+		Files.deleteIfExists(intermediaryJarPath);
+
+		DownloadUtil.downloadIfChanged(url, intermediaryJarPath.toFile(), LOGGER);
+		MappingsProviderImpl.extractMappings(intermediaryJarPath, tinyMappings);
+	}
+
+	@Override
+	public @NotNull String getName() {
+		return "intermediary-v2";
+	}
+}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingsProviderImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingsProviderImpl.java
@@ -83,9 +83,9 @@ public class MappingsProviderImpl implements MappingsProvider, SharedService {
 	private UnpickMetadata unpickMetadata;
 	private Map<String, String> signatureFixes;
 
-	private final Supplier<IntermediaryService> intermediaryService;
+	private final Supplier<IntermediateMappingsService> intermediaryService;
 
-	private MappingsProviderImpl(String mappingsIdentifier, Path mappingsWorkingDir, Supplier<IntermediaryService> intermediaryService) {
+	private MappingsProviderImpl(String mappingsIdentifier, Path mappingsWorkingDir, Supplier<IntermediateMappingsService> intermediaryService) {
 		this.mappingsIdentifier = mappingsIdentifier;
 
 		this.mappingsWorkingDir = mappingsWorkingDir;
@@ -99,7 +99,7 @@ public class MappingsProviderImpl implements MappingsProvider, SharedService {
 
 	public static synchronized MappingsProviderImpl getInstance(Project project, DependencyInfo dependency, MinecraftProvider minecraftProvider) {
 		return SharedServiceManager.get(project).getOrCreateService("MappingsProvider:%s:%s".formatted(dependency.getDepString(), minecraftProvider.minecraftVersion()), () -> {
-			Supplier<IntermediaryService> intermediaryService = Suppliers.memoize(() -> IntermediaryService.getInstance(project, minecraftProvider));
+			Supplier<IntermediateMappingsService> intermediaryService = Suppliers.memoize(() -> IntermediateMappingsService.getInstance(project, minecraftProvider));
 			return create(dependency, minecraftProvider, intermediaryService);
 		});
 	}
@@ -108,7 +108,7 @@ public class MappingsProviderImpl implements MappingsProvider, SharedService {
 		return Objects.requireNonNull(mappingTree, "Cannot get mappings before they have been read").get();
 	}
 
-	private static MappingsProviderImpl create(DependencyInfo dependency, MinecraftProvider minecraftProvider, Supplier<IntermediaryService> intermediaryService) {
+	private static MappingsProviderImpl create(DependencyInfo dependency, MinecraftProvider minecraftProvider, Supplier<IntermediateMappingsService> intermediaryService) {
 		final String version = dependency.getResolvedVersion();
 		final Path inputJar = dependency.resolveFile().orElseThrow(() -> new RuntimeException("Could not resolve mappings: " + dependency)).toPath();
 		final String mappingsName = StringUtils.removeSuffix(dependency.getDependency().getGroup() + "." + dependency.getDependency().getName(), "-unmerged");

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/NoOpIntermediateMappingsProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/NoOpIntermediateMappingsProvider.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2022 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.configuration.providers.mappings;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.fabricmc.loom.api.mappings.intermediate.IntermediateMappingsProvider;
+
+/**
+ * A bit of a hack, creates an empty intermediary mapping file to be used for mc versions without any intermediate mappings.
+ */
+public abstract class NoOpIntermediateMappingsProvider extends IntermediateMappingsProvider {
+	private static final String HEADER = "tiny\t2\t0\tofficial\tintermediary";
+
+	@Override
+	public void provide(Path tinyMappings) throws IOException {
+		Files.writeString(tinyMappings, HEADER, StandardCharsets.UTF_8);
+	}
+
+	@Override
+	public @NotNull String getName() {
+		return "empty-intermediate";
+	}
+}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/tiny/MappingsMerger.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/tiny/MappingsMerger.java
@@ -38,7 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
-import net.fabricmc.loom.configuration.providers.mappings.IntermediaryService;
+import net.fabricmc.loom.configuration.providers.mappings.IntermediateMappingsService;
 import net.fabricmc.mappingio.adapter.MappingNsCompleter;
 import net.fabricmc.mappingio.adapter.MappingSourceNsSwitch;
 import net.fabricmc.mappingio.format.Tiny2Reader;
@@ -49,12 +49,12 @@ import net.fabricmc.mappingio.tree.MemoryMappingTree;
 public final class MappingsMerger {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MappingsMerger.class);
 
-	public static void mergeAndSaveMappings(Path from, Path out, IntermediaryService intermediaryService) throws IOException {
+	public static void mergeAndSaveMappings(Path from, Path out, IntermediateMappingsService intermediateMappingsService) throws IOException {
 		Stopwatch stopwatch = Stopwatch.createStarted();
 		LOGGER.info(":merging mappings");
 
 		MemoryMappingTree intermediaryTree = new MemoryMappingTree();
-		intermediaryService.getMemoryMappingTree().accept(new MappingSourceNsSwitch(intermediaryTree, MappingsNamespace.INTERMEDIARY.toString()));
+		intermediateMappingsService.getMemoryMappingTree().accept(new MappingSourceNsSwitch(intermediaryTree, MappingsNamespace.INTERMEDIARY.toString()));
 
 		try (BufferedReader reader = Files.newBufferedReader(from, StandardCharsets.UTF_8)) {
 			Tiny2Reader.read(reader, intermediaryTree);

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftLibraryProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftLibraryProvider.java
@@ -62,6 +62,9 @@ public class MinecraftLibraryProvider {
 				// 1.4.7 contains an LWJGL version with an invalid maven pom, set the metadata sources to not use the pom for this version.
 				if ("org.lwjgl.lwjgl:lwjgl:2.9.1-nightly-20130708-debug3".equals(library.name())) {
 					LoomRepositoryPlugin.setupForLegacyVersions(project);
+				} else if (library.name().startsWith("org.ow2.asm:asm-all")) {
+					// Don't want asm-all, use the modern split version.
+					continue;
 				}
 
 				if (runtimeOnlyLog4j && library.name().startsWith("org.apache.logging.log4j")) {

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -225,6 +225,11 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	}
 
 	@Override
+	public void setIntermediateMappingsProvider(IntermediateMappingsProvider intermediateMappingsProvider) {
+		this.intermediateMappingsProvider.set(intermediateMappingsProvider);
+	}
+
+	@Override
 	public <T extends IntermediateMappingsProvider> void setIntermediateMappingsProvider(Class<T> clazz, Action<T> action) {
 		T provider = getProject().getObjects().newInstance(clazz);
 		configureIntermediateMappingsProviderInternal(provider);

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -40,6 +40,7 @@ import net.fabricmc.loom.api.InterfaceInjectionExtensionAPI;
 import net.fabricmc.loom.api.LoomGradleExtensionAPI;
 import net.fabricmc.loom.api.MixinExtensionAPI;
 import net.fabricmc.loom.api.decompilers.DecompilerOptions;
+import net.fabricmc.loom.api.mappings.intermediate.IntermediateMappingsProvider;
 import net.fabricmc.loom.api.mappings.layered.spec.LayeredMappingSpecBuilder;
 import net.fabricmc.loom.configuration.ide.RunConfigSettings;
 import net.fabricmc.loom.configuration.mods.ModVersionParser;
@@ -65,6 +66,7 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	protected final Property<Boolean> setupRemappedVariants;
 	protected final Property<Boolean> transitiveAccessWideners;
 	protected final Property<String> intermediary;
+	protected final Property<IntermediateMappingsProvider> intermediateMappingsProvider;
 	private final Property<Boolean> runtimeOnlyLog4j;
 	private final Property<MinecraftJarConfiguration> minecraftJarConfiguration;
 	private final InterfaceInjectionExtensionAPI interfaceInjectionExtension;
@@ -91,6 +93,9 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 		this.transitiveAccessWideners.finalizeValueOnRead();
 		this.intermediary = project.getObjects().property(String.class)
 				.convention("https://maven.fabricmc.net/net/fabricmc/intermediary/%1$s/intermediary-%1$s-v2.jar");
+
+		this.intermediateMappingsProvider = project.getObjects().property(IntermediateMappingsProvider.class);
+		this.intermediateMappingsProvider.finalizeValueOnRead();
 
 		this.versionParser = new ModVersionParser(project);
 
@@ -215,6 +220,21 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	}
 
 	@Override
+	public IntermediateMappingsProvider getIntermediateMappingsProvider() {
+		return intermediateMappingsProvider.get();
+	}
+
+	@Override
+	public <T extends IntermediateMappingsProvider> void setIntermediateMappingsProvider(Class<T> clazz, Action<T> action) {
+		T provider = getProject().getObjects().newInstance(clazz);
+		configureIntermediateMappingsProviderInternal(provider);
+		action.execute(provider);
+		intermediateMappingsProvider.set(provider);
+	}
+
+	protected abstract <T extends IntermediateMappingsProvider> void configureIntermediateMappingsProviderInternal(T provider);
+
+	@Override
 	public void disableDeprecatedPomGeneration(MavenPublication publication) {
 		net.fabricmc.loom.configuration.MavenPublication.excludePublication(publication);
 	}
@@ -253,6 +273,11 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 
 		@Override
 		protected LoomFiles getFiles() {
+			throw new RuntimeException("Yeah... something is really wrong");
+		}
+
+		@Override
+		protected <T extends IntermediateMappingsProvider> void configureIntermediateMappingsProviderInternal(T provider) {
 			throw new RuntimeException("Yeah... something is really wrong");
 		}
 

--- a/src/test/groovy/net/fabricmc/loom/test/integration/LegacyProjectTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/LegacyProjectTest.groovy
@@ -32,7 +32,6 @@ import static net.fabricmc.loom.test.LoomTestConstants.PRE_RELEASE_GRADLE
 import static net.fabricmc.loom.test.LoomTestConstants.STANDARD_TEST_VERSIONS
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
-// This test uses gradle 4.9 and 1.14.4 v1 mappings
 class LegacyProjectTest extends Specification implements GradleProjectTestTrait {
 	@Unroll
 	def "legacy build (gradle #version)"() {
@@ -55,7 +54,7 @@ class LegacyProjectTest extends Specification implements GradleProjectTestTrait 
 			def gradle = gradleProject(project: "minimalBase", version: PRE_RELEASE_GRADLE)
 			gradle.buildGradle << """
 				loom {
-                    intermediaryUrl = 'https://s.modm.us/intermediary-empty-v2.jar'
+                    noIntermediateMappings()
                 }
 
                 dependencies {
@@ -91,7 +90,7 @@ class LegacyProjectTest extends Specification implements GradleProjectTestTrait 
 			def gradle = gradleProject(project: "minimalBase", version: PRE_RELEASE_GRADLE)
 			gradle.buildGradle << """
 				loom {
-                    intermediaryUrl = 'https://s.modm.us/intermediary-empty-v2.jar'
+                    noIntermediateMappings()
 					clientOnlyMinecraftJar()
                 }
 

--- a/src/test/groovy/net/fabricmc/loom/test/unit/LoomMocks.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/LoomMocks.groovy
@@ -1,0 +1,45 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2022 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit
+
+import net.fabricmc.loom.configuration.providers.mappings.IntermediaryMappingsProvider
+import net.fabricmc.loom.test.util.GradleTestUtil
+
+import static org.mockito.Mockito.spy
+import static org.mockito.Mockito.when
+
+class LoomMocks {
+    static IntermediaryMappingsProvider intermediaryMappingsProviderMock(String minecraftVersion, String intermediaryUrl) {
+        def minecraftVersionProperty = GradleTestUtil.mockProperty(minecraftVersion)
+        def intermediaryUrlProperty = GradleTestUtil.mockProperty(intermediaryUrl)
+
+        Objects.requireNonNull(minecraftVersionProperty.get())
+
+        def mock = spy(IntermediaryMappingsProvider.class)
+        when(mock.getMinecraftVersion()).thenReturn(minecraftVersionProperty)
+        when(mock.getIntermediaryUrl()).thenReturn(intermediaryUrlProperty)
+        return mock
+    }
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingsSpecification.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingsSpecification.groovy
@@ -32,6 +32,7 @@ import net.fabricmc.loom.configuration.providers.mappings.IntermediateMappingsSe
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingSpec
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsProcessor
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider
+import net.fabricmc.loom.test.unit.LoomMocks
 import net.fabricmc.mappingio.adapter.MappingDstNsReorder
 import net.fabricmc.mappingio.adapter.MappingSourceNsSwitch
 import net.fabricmc.mappingio.format.Tiny2Writer
@@ -122,7 +123,7 @@ abstract class LayeredMappingsSpecification extends Specification implements Lay
         @Override
         Supplier<MemoryMappingTree> intermediaryTree() {
             return {
-                IntermediateMappingsService.create(intermediaryUrl, minecraftProvider()).memoryMappingTree
+                IntermediateMappingsService.create(LoomMocks.intermediaryMappingsProviderMock("test", intermediaryUrl), minecraftProvider()).memoryMappingTree
             }
         }
 

--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingsSpecification.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingsSpecification.groovy
@@ -28,7 +28,7 @@ import net.fabricmc.loom.api.mappings.layered.MappingContext
 import net.fabricmc.loom.api.mappings.layered.MappingLayer
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace
 import net.fabricmc.loom.api.mappings.layered.spec.MappingsSpec
-import net.fabricmc.loom.configuration.providers.mappings.IntermediaryService
+import net.fabricmc.loom.configuration.providers.mappings.IntermediateMappingsService
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingSpec
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsProcessor
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider
@@ -122,7 +122,7 @@ abstract class LayeredMappingsSpecification extends Specification implements Lay
         @Override
         Supplier<MemoryMappingTree> intermediaryTree() {
             return {
-                IntermediaryService.create(intermediaryUrl, minecraftProvider()).memoryMappingTree
+                IntermediateMappingsService.create(intermediaryUrl, minecraftProvider()).memoryMappingTree
             }
         }
 

--- a/src/test/groovy/net/fabricmc/loom/test/util/GradleTestUtil.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/util/GradleTestUtil.groovy
@@ -1,0 +1,38 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2022 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.util
+
+import org.gradle.api.provider.Property
+
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.when
+
+class GradleTestUtil {
+    static <T> Property<T> mockProperty(T value) {
+        def mock = mock(Property.class)
+        when(mock.get()).thenReturn(Objects.requireNonNull(value))
+        return mock
+    }
+}


### PR DESCRIPTION
- Add API to allow other plugins to supply their own intermediate mappings.
- Add hacky option to run with no intermediate mappings.

This is far from perfect as loom still refrences `intermediary` throughout, however its should be good enough for most use cases without another massive refactor.