### PR TITLE
Add unpick support to layered file mappings, add direct url support to FileSpec.

### DIFF
--- a/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/FileMappingsSpecBuilder.java
+++ b/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/FileMappingsSpecBuilder.java
@@ -76,7 +76,7 @@ public interface FileMappingsSpecBuilder {
 	 *
 	 * @return this builder
 	 */
-	FileMappingsSpecBuilder disableUnpick();
+	FileMappingsSpecBuilder containsUnpick();
 
 	/**
 	 * Sets the merge namespace of this mappings spec.

--- a/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/FileMappingsSpecBuilder.java
+++ b/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/FileMappingsSpecBuilder.java
@@ -72,6 +72,13 @@ public interface FileMappingsSpecBuilder {
 	FileMappingsSpecBuilder enigmaMappings();
 
 	/**
+	 * Any unpick data in a zip file will be ignored.
+	 *
+	 * @return this builder
+	 */
+	FileMappingsSpecBuilder disableUnpick();
+
+	/**
 	 * Sets the merge namespace of this mappings spec.
 	 *
 	 * <p>The merge namespace is the namespace that is used to match up this layer's

--- a/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/FileMappingsSpecBuilder.java
+++ b/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/FileMappingsSpecBuilder.java
@@ -72,7 +72,7 @@ public interface FileMappingsSpecBuilder {
 	FileMappingsSpecBuilder enigmaMappings();
 
 	/**
-	 * Any unpick data in a zip file will be ignored.
+	 * Marks that the zip file contains unpick data.
 	 *
 	 * @return this builder
 	 */

--- a/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/FileSpec.java
+++ b/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/FileSpec.java
@@ -25,6 +25,8 @@
 package net.fabricmc.loom.api.mappings.layered.spec;
 
 import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.util.Objects;
 
@@ -36,7 +38,7 @@ import org.jetbrains.annotations.ApiStatus;
 
 import net.fabricmc.loom.api.mappings.layered.MappingContext;
 import net.fabricmc.loom.configuration.providers.mappings.utils.DependencyFileSpec;
-import net.fabricmc.loom.configuration.providers.mappings.utils.HttpFileSpec;
+import net.fabricmc.loom.configuration.providers.mappings.utils.URLFileSpec;
 import net.fabricmc.loom.configuration.providers.mappings.utils.LocalFileSpec;
 import net.fabricmc.loom.configuration.providers.mappings.utils.MavenFileSpec;
 
@@ -64,8 +66,12 @@ public interface FileSpec {
 		Objects.requireNonNull(o, "Object cannot be null");
 
 		if (o instanceof CharSequence s) {
-			if (s.toString().startsWith("https://")) {
-				return createFromUrl(s.toString());
+			if (s.toString().startsWith("https://") || s.toString().startsWith("http://")) {
+				try {
+					return create(new URL(s.toString()));
+				} catch (MalformedURLException e) {
+					throw new RuntimeException("Failed to convert string to URL", e);
+				}
 			}
 
 			return createFromMavenDependency(s.toString());
@@ -79,6 +85,8 @@ public interface FileSpec {
 			return createFromFile(p);
 		} else if (o instanceof FileSystemLocation l) {
 			return createFromFile(l);
+		} else if (o instanceof URL url) {
+			return createFromUrl(url);
 		} else if (o instanceof FileSpec s) {
 			return s;
 		}
@@ -106,8 +114,8 @@ public interface FileSpec {
 		return createFromFile(path.toFile());
 	}
 
-	static FileSpec createFromUrl(String url) {
-		return new HttpFileSpec(url);
+	static FileSpec createFromUrl(URL url) {
+		return new URLFileSpec(url);
 	}
 
 	// Note resolved instantly, this is not lazy

--- a/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/FileSpec.java
+++ b/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/FileSpec.java
@@ -36,6 +36,7 @@ import org.jetbrains.annotations.ApiStatus;
 
 import net.fabricmc.loom.api.mappings.layered.MappingContext;
 import net.fabricmc.loom.configuration.providers.mappings.utils.DependencyFileSpec;
+import net.fabricmc.loom.configuration.providers.mappings.utils.HttpFileSpec;
 import net.fabricmc.loom.configuration.providers.mappings.utils.LocalFileSpec;
 import net.fabricmc.loom.configuration.providers.mappings.utils.MavenFileSpec;
 
@@ -63,6 +64,10 @@ public interface FileSpec {
 		Objects.requireNonNull(o, "Object cannot be null");
 
 		if (o instanceof CharSequence s) {
+			if (s.toString().startsWith("https://")) {
+				return createFromUrl(s.toString());
+			}
+
 			return createFromMavenDependency(s.toString());
 		} else if (o instanceof Dependency d) {
 			return createFromDependency(d);
@@ -99,6 +104,10 @@ public interface FileSpec {
 
 	static FileSpec createFromFile(Path path) {
 		return createFromFile(path.toFile());
+	}
+
+	static FileSpec createFromUrl(String url) {
+		return new HttpFileSpec(url);
 	}
 
 	// Note resolved instantly, this is not lazy

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsDependency.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsDependency.java
@@ -48,6 +48,7 @@ import net.fabricmc.loom.LoomGradlePlugin;
 import net.fabricmc.loom.api.mappings.layered.MappingContext;
 import net.fabricmc.loom.api.mappings.layered.MappingLayer;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
+import net.fabricmc.loom.configuration.providers.mappings.extras.unpick.UnpickLayer;
 import net.fabricmc.loom.util.ZipUtils;
 import net.fabricmc.mappingio.adapter.MappingDstNsReorder;
 import net.fabricmc.mappingio.adapter.MappingSourceNsSwitch;
@@ -84,6 +85,7 @@ public class LayeredMappingsDependency implements SelfResolvingDependency, FileC
 
 				writeMapping(processor, layers, mappingsFile);
 				writeSignatureFixes(processor, layers, mappingsFile);
+				writeUnpickData(processor, layers, mappingsFile);
 			} catch (IOException e) {
 				throw new RuntimeException("Failed to resolve layered mappings", e);
 			}
@@ -117,6 +119,17 @@ public class LayeredMappingsDependency implements SelfResolvingDependency, FileC
 		byte[] data = LoomGradlePlugin.OBJECT_MAPPER.writeValueAsString(signatureFixes).getBytes(StandardCharsets.UTF_8);
 
 		ZipUtils.add(mappingsFile, "extras/record_signatures.json", data);
+	}
+
+	private void writeUnpickData(LayeredMappingsProcessor processor, List<MappingLayer> layers, Path mappingsFile) throws IOException {
+		UnpickLayer.UnpickData unpickData = processor.getUnpickData(layers);
+
+		if (unpickData == null) {
+			return;
+		}
+
+		ZipUtils.add(mappingsFile, "extras/definitions.unpick", unpickData.definitions());
+		ZipUtils.add(mappingsFile, "extras/unpick.json", unpickData.metadata().asJson());
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsProcessor.java
@@ -39,6 +39,7 @@ import net.fabricmc.loom.api.mappings.layered.MappingLayer;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.api.mappings.layered.spec.MappingsSpec;
 import net.fabricmc.loom.configuration.providers.mappings.extras.signatures.SignatureFixesLayer;
+import net.fabricmc.loom.configuration.providers.mappings.extras.unpick.UnpickLayer;
 import net.fabricmc.mappingio.adapter.MappingSourceNsSwitch;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
@@ -121,5 +122,30 @@ public class LayeredMappingsProcessor {
 		}
 
 		return Collections.unmodifiableMap(signatureFixes);
+	}
+
+	@Nullable
+	public UnpickLayer.UnpickData getUnpickData(List<MappingLayer> layers) throws IOException {
+		List<UnpickLayer.UnpickData> unpickDataList = new ArrayList<>();
+
+		for (MappingLayer layer : layers) {
+			if (layer instanceof UnpickLayer unpickLayer) {
+				UnpickLayer.UnpickData data = unpickLayer.getUnpickData();
+				if (data == null) continue;
+
+				unpickDataList.add(data);
+			}
+		}
+
+		if (unpickDataList.isEmpty()) {
+			return null;
+		}
+
+		if (unpickDataList.size() != 1) {
+			// TODO merge
+			throw new UnsupportedOperationException("Only one unpick layer is currently supported.");
+		}
+
+		return unpickDataList.get(0);
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsLayer.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsLayer.java
@@ -93,9 +93,12 @@ public record FileMappingsLayer(
 
 	@Override
 	public @Nullable UnpickData getUnpickData() throws IOException {
-		if (!unpick || !ZipUtils.isZip(path)) {
-			// Unpick disabled for this layer or not a zip.
+		if (!unpick) {
 			return null;
+		}
+
+		if (!ZipUtils.isZip(path)) {
+			throw new UnsupportedOperationException("Unpick is only supported for zip file mapping layers.");
 		}
 
 		try (FileSystemUtil.Delegate fileSystem = FileSystemUtil.getJarFileSystem(path)) {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsLayer.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsLayer.java
@@ -25,12 +25,16 @@
 package net.fabricmc.loom.configuration.providers.mappings.file;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.fabricmc.loom.api.mappings.layered.MappingLayer;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
+import net.fabricmc.loom.configuration.providers.mappings.extras.unpick.UnpickLayer;
 import net.fabricmc.loom.configuration.providers.mappings.intermediary.IntermediaryMappingLayer;
 import net.fabricmc.loom.util.FileSystemUtil;
 import net.fabricmc.loom.util.ZipUtils;
@@ -45,8 +49,12 @@ public record FileMappingsLayer(
 		Path path, String mappingPath,
 		String fallbackSourceNamespace, String fallbackTargetNamespace,
 		boolean enigma, // Enigma cannot be automatically detected since it's stored in a directory.
+		boolean unpick,
 		String mergeNamespace
-) implements MappingLayer {
+) implements MappingLayer, UnpickLayer {
+	private static final String UNPICK_METADATA_PATH = "extras/unpick.json";
+	private static final String UNPICK_DEFINITIONS_PATH = "extras/definitions.unpick";
+
 	@Override
 	public void visit(MappingVisitor mappingVisitor) throws IOException {
 		// Bare file
@@ -81,5 +89,25 @@ public record FileMappingsLayer(
 	@Override
 	public List<Class<? extends MappingLayer>> dependsOn() {
 		return List.of(IntermediaryMappingLayer.class);
+	}
+
+	@Override
+	public @Nullable UnpickData getUnpickData() throws IOException {
+		if (!unpick || !ZipUtils.isZip(path)) {
+			// Unpick disabled for this layer or not a zip.
+			return null;
+		}
+
+		try (FileSystemUtil.Delegate fileSystem = FileSystemUtil.getJarFileSystem(path)) {
+			final Path unpickMetadata = fileSystem.get().getPath(UNPICK_METADATA_PATH);
+			final Path unpickDefinitions = fileSystem.get().getPath(UNPICK_DEFINITIONS_PATH);
+
+			if (!Files.exists(unpickMetadata)) {
+				// No unpick in this zip
+				return null;
+			}
+
+			return UnpickData.read(unpickMetadata, unpickDefinitions);
+		}
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsSpecBuilderImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsSpecBuilderImpl.java
@@ -41,7 +41,7 @@ public class FileMappingsSpecBuilderImpl implements FileMappingsSpecBuilder {
 	private String fallbackSourceNamespace = MappingsNamespace.INTERMEDIARY.toString();
 	private String fallbackTargetNamespace = MappingsNamespace.NAMED.toString();
 	private boolean enigma = false;
-	private boolean unpick = true;
+	private boolean unpick = false;
 	private String mergeNamespace = MappingsNamespace.INTERMEDIARY.toString();
 
 	private FileMappingsSpecBuilderImpl(FileSpec fileSpec) {
@@ -72,8 +72,8 @@ public class FileMappingsSpecBuilderImpl implements FileMappingsSpecBuilder {
 	}
 
 	@Override
-	public FileMappingsSpecBuilderImpl disableUnpick() {
-		unpick = false;
+	public FileMappingsSpecBuilderImpl containsUnpick() {
+		unpick = true;
 		return this;
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsSpecBuilderImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsSpecBuilderImpl.java
@@ -41,6 +41,7 @@ public class FileMappingsSpecBuilderImpl implements FileMappingsSpecBuilder {
 	private String fallbackSourceNamespace = MappingsNamespace.INTERMEDIARY.toString();
 	private String fallbackTargetNamespace = MappingsNamespace.NAMED.toString();
 	private boolean enigma = false;
+	private boolean unpick = true;
 	private String mergeNamespace = MappingsNamespace.INTERMEDIARY.toString();
 
 	private FileMappingsSpecBuilderImpl(FileSpec fileSpec) {
@@ -71,6 +72,12 @@ public class FileMappingsSpecBuilderImpl implements FileMappingsSpecBuilder {
 	}
 
 	@Override
+	public FileMappingsSpecBuilderImpl disableUnpick() {
+		unpick = false;
+		return this;
+	}
+
+	@Override
 	public FileMappingsSpecBuilderImpl mergeNamespace(MappingsNamespace namespace) {
 		mergeNamespace = Objects.requireNonNull(namespace, "merge namespace cannot be null").toString();
 		return this;
@@ -89,6 +96,6 @@ public class FileMappingsSpecBuilderImpl implements FileMappingsSpecBuilder {
 	}
 
 	public FileMappingsSpec build() {
-		return new FileMappingsSpec(fileSpec, mappingPath, fallbackSourceNamespace, fallbackTargetNamespace, enigma, mergeNamespace);
+		return new FileMappingsSpec(fileSpec, mappingPath, fallbackSourceNamespace, fallbackTargetNamespace, enigma, unpick, mergeNamespace);
 	}
 }

--- a/src/main/java/net/fabricmc/loom/util/ZipUtils.java
+++ b/src/main/java/net/fabricmc/loom/util/ZipUtils.java
@@ -131,6 +131,10 @@ public class ZipUtils {
 		}
 	}
 
+	public static void add(Path zip, String path, String str) throws IOException {
+		add(zip, path, str.getBytes(StandardCharsets.UTF_8));
+	}
+
 	public static void add(Path zip, String path, byte[] bytes) throws IOException {
 		add(zip, Collections.singleton(new Pair<>(path, bytes)));
 	}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/FileMappingLayerTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/FileMappingLayerTest.groovy
@@ -107,6 +107,9 @@ class FileMappingLayerTest extends LayeredMappingsSpecification {
 		}, {
 			it.mappingPath("mappings").enigmaMappings()
 		}),
+		YARN_V2_URL('yarn url', {
+			YARN_1_17_URL
+		}, { })
 		;
 
 		final String displayName

--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingSpecBuilderTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingSpecBuilderTest.groovy
@@ -114,7 +114,7 @@ class LayeredMappingSpecBuilderTest extends Specification {
             }
             def layers = spec.layers()
         then:
-            spec.version == "layered+hash.1284206205"
+            spec.version == "layered+hash.1133958200"
             layers.size() == 2
             layers[0].class == IntermediaryMappingsSpec
             layers[1].class == FileMappingsSpec

--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingsSpecification.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingsSpecification.groovy
@@ -31,6 +31,7 @@ import net.fabricmc.loom.api.mappings.layered.spec.MappingsSpec
 import net.fabricmc.loom.configuration.providers.mappings.IntermediaryService
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingSpec
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsProcessor
+import net.fabricmc.loom.configuration.providers.mappings.extras.unpick.UnpickLayer
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider
 import net.fabricmc.mappingio.adapter.MappingDstNsReorder
 import net.fabricmc.mappingio.adapter.MappingSourceNsSwitch
@@ -85,6 +86,12 @@ abstract class LayeredMappingsSpecification extends Specification implements Lay
         LayeredMappingSpec spec = new LayeredMappingSpec(specs.toList())
         LayeredMappingsProcessor processor = new LayeredMappingsProcessor(spec)
         return processor.getMappings(processor.resolveLayers(mappingContext))
+    }
+
+    UnpickLayer.UnpickData getUnpickData(MappingsSpec<? extends MappingLayer>... specs) {
+        LayeredMappingSpec spec = new LayeredMappingSpec(specs.toList())
+        LayeredMappingsProcessor processor = new LayeredMappingsProcessor(spec)
+        return processor.getUnpickData(processor.resolveLayers(mappingContext))
     }
 
     String getTiny(MemoryMappingTree mappingTree) {

--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/UnpickLayerTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/UnpickLayerTest.groovy
@@ -22,20 +22,29 @@
  * SOFTWARE.
  */
 
-package net.fabricmc.loom.configuration.providers.mappings.file;
+package net.fabricmc.loom.test.unit.layeredmappings
 
-import net.fabricmc.loom.api.mappings.layered.MappingContext;
-import net.fabricmc.loom.api.mappings.layered.spec.FileSpec;
-import net.fabricmc.loom.api.mappings.layered.spec.MappingsSpec;
+import net.fabricmc.loom.api.mappings.layered.spec.FileSpec
+import net.fabricmc.loom.configuration.providers.mappings.file.FileMappingsSpecBuilderImpl
+import net.fabricmc.loom.configuration.providers.mappings.intermediary.IntermediaryMappingsSpec
 
-public record FileMappingsSpec(
-		FileSpec fileSpec, String mappingPath,
-		String fallbackSourceNamespace, String fallbackTargetNamespace,
-		boolean enigma, boolean unpick,
-		String mergeNamespace
-) implements MappingsSpec<FileMappingsLayer> {
-	@Override
-	public FileMappingsLayer createLayer(MappingContext context) {
-		return new FileMappingsLayer(fileSpec.get(context), mappingPath, fallbackSourceNamespace, fallbackTargetNamespace, enigma, unpick, mergeNamespace);
-	}
+class UnpickLayerTest extends LayeredMappingsSpecification {
+    def "read unpick data from yarn"() {
+        setup:
+            intermediaryUrl = INTERMEDIARY_1_17_URL
+            mockMinecraftProvider.getVersionInfo() >> VERSION_META_1_17
+        when:
+            def builder = FileMappingsSpecBuilderImpl.builder(FileSpec.create(YARN_1_17_URL))
+            def unpickData = getUnpickData(
+                    new IntermediaryMappingsSpec(),
+                    builder.build()
+            )
+            def metadata = unpickData.metadata()
+        then:
+            metadata.version() == 1
+            metadata.unpickGroup() == "net.fabricmc.unpick"
+            metadata.unpickVersion() == "2.2.0"
+
+            unpickData.definitions().length == 56119
+    }
 }

--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/UnpickLayerTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/UnpickLayerTest.groovy
@@ -34,7 +34,7 @@ class UnpickLayerTest extends LayeredMappingsSpecification {
             intermediaryUrl = INTERMEDIARY_1_17_URL
             mockMinecraftProvider.getVersionInfo() >> VERSION_META_1_17
         when:
-            def builder = FileMappingsSpecBuilderImpl.builder(FileSpec.create(YARN_1_17_URL))
+            def builder = FileMappingsSpecBuilderImpl.builder(FileSpec.create(YARN_1_17_URL)).containsUnpick()
             def unpickData = getUnpickData(
                     new IntermediaryMappingsSpec(),
                     builder.build()


### PR DESCRIPTION
This can go into 0.11 as unpick is now disabled by default, you will need to add your own constants jar to the compileOnly classpath.