### PR TITLE
Add DSL to configure mod class path groups.

### DIFF
--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -84,6 +84,16 @@ public interface LoomGradleExtensionAPI {
 
 	void mixin(Action<MixinExtensionAPI> action);
 
+	/**
+	 * Optionally register and configure a {@link ModSettings} object. The name should match the modid.
+	 * This is generally only required when the mod spans across multiple classpath directories, such as when using split sourcesets.
+	 */
+	@ApiStatus.Experimental
+	void mods(Action<NamedDomainObjectContainer<ModSettings>> action);
+
+	@ApiStatus.Experimental
+	NamedDomainObjectContainer<ModSettings> getMods();
+
 	@ApiStatus.Experimental
 	// TODO: move this from LoomGradleExtensionAPI to LoomGradleExtension once getRefmapName & setRefmapName is removed.
 	MixinExtensionAPI getMixin();

--- a/src/main/java/net/fabricmc/loom/api/ModSettings.java
+++ b/src/main/java/net/fabricmc/loom/api/ModSettings.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2022 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.api;
+
+import java.io.File;
+
+import org.gradle.api.Named;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetOutput;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * A {@link Named} object for setting mod realted values. The {@link Named#getName()} should match the modid.
+ */
+@ApiStatus.Experimental
+public abstract class ModSettings implements Named {
+	/**
+	 * List of classpath directories, used to populate the `fabric.classPathGroups` Fabric Loader system property.
+	 */
+	public abstract ListProperty<File> getClasspath();
+
+	/**
+	 * Mark a {@link SourceSet} output directories part of the named mod.
+	 */
+	public void sourceSet(SourceSet sourceSet) {
+		final SourceSetOutput output = sourceSet.getOutput();
+		final File resources = output.getResourcesDir();
+
+		getClasspath().addAll(output.getClassesDirs().getFiles());
+
+		if (resources != null) {
+			getClasspath().add(resources);
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/api/ModSettings.java
+++ b/src/main/java/net/fabricmc/loom/api/ModSettings.java
@@ -24,35 +24,32 @@
 
 package net.fabricmc.loom.api;
 
-import java.io.File;
+import javax.inject.Inject;
 
 import org.gradle.api.Named;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.SourceSet;
-import org.gradle.api.tasks.SourceSetOutput;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
- * A {@link Named} object for setting mod realted values. The {@link Named#getName()} should match the modid.
+ * A {@link Named} object for setting mod-related values. The {@linkplain Named#getName() name} should match the mod id.
  */
 @ApiStatus.Experimental
 public abstract class ModSettings implements Named {
 	/**
 	 * List of classpath directories, used to populate the `fabric.classPathGroups` Fabric Loader system property.
 	 */
-	public abstract ListProperty<File> getClasspath();
+	public abstract ListProperty<SourceSet> getSourceSets();
+
+	@Inject
+	public ModSettings() {
+		getSourceSets().finalizeValueOnRead();
+	}
 
 	/**
 	 * Mark a {@link SourceSet} output directories part of the named mod.
 	 */
 	public void sourceSet(SourceSet sourceSet) {
-		final SourceSetOutput output = sourceSet.getOutput();
-		final File resources = output.getResourcesDir();
-
-		getClasspath().addAll(output.getClassesDirs().getFiles());
-
-		if (resources != null) {
-			getClasspath().add(resources);
-		}
+		getSourceSets().add(sourceSet);
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
@@ -50,6 +50,7 @@ import org.w3c.dom.Node;
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.configuration.InstallerData;
 import net.fabricmc.loom.configuration.ide.idea.IdeaSyncTask;
+import net.fabricmc.loom.configuration.ide.idea.IdeaUtils;
 import net.fabricmc.loom.configuration.providers.BundleMetadata;
 import net.fabricmc.loom.util.Constants;
 
@@ -99,16 +100,6 @@ public class RunConfig {
 
 		parent.appendChild(e);
 		return e;
-	}
-
-	private static String getIdeaModuleName(Project project, SourceSet srcs) {
-		String module = project.getName() + "." + srcs.getName();
-
-		while ((project = project.getParent()) != null) {
-			module = project.getName() + "." + module;
-		}
-
-		return module;
 	}
 
 	private static void populate(Project project, LoomGradleExtension extension, RunConfig runConfig, String environment) {
@@ -166,7 +157,7 @@ public class RunConfig {
 		RunConfig runConfig = new RunConfig();
 		runConfig.configName = configName;
 		populate(project, extension, runConfig, environment);
-		runConfig.ideaModuleName = getIdeaModuleName(project, sourceSet);
+		runConfig.ideaModuleName = IdeaUtils.getIdeaModuleName(project, sourceSet);
 		runConfig.runDirIdeaUrl = "file://$PROJECT_DIR$/" + runDir;
 		runConfig.runDir = runDir;
 		runConfig.sourceSet = sourceSet;

--- a/src/main/java/net/fabricmc/loom/configuration/ide/idea/IdeaUtils.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/idea/IdeaUtils.java
@@ -26,6 +26,9 @@ package net.fabricmc.loom.configuration.ide.idea;
 
 import java.util.Objects;
 
+import org.gradle.api.Project;
+import org.gradle.api.tasks.SourceSet;
+
 public class IdeaUtils {
 	public static boolean isIdeaSync() {
 		return Boolean.parseBoolean(System.getProperty("idea.sync.active", "false"));
@@ -41,5 +44,15 @@ public class IdeaUtils {
 		final int major = Integer.parseInt(split[0]);
 		final int minor = Integer.parseInt(split[1]);
 		return major > 2021 || (major == 2021 && minor >= 3);
+	}
+
+	public static String getIdeaModuleName(Project project, SourceSet srcs) {
+		String module = project.getName() + "." + srcs.getName();
+
+		while ((project = project.getParent()) != null) {
+			module = project.getName() + "." + module;
+		}
+
+		return module;
 	}
 }

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -39,6 +39,7 @@ import org.gradle.api.tasks.SourceSet;
 import net.fabricmc.loom.api.InterfaceInjectionExtensionAPI;
 import net.fabricmc.loom.api.LoomGradleExtensionAPI;
 import net.fabricmc.loom.api.MixinExtensionAPI;
+import net.fabricmc.loom.api.ModSettings;
 import net.fabricmc.loom.api.decompilers.DecompilerOptions;
 import net.fabricmc.loom.api.mappings.intermediate.IntermediateMappingsProvider;
 import net.fabricmc.loom.api.mappings.layered.spec.LayeredMappingSpecBuilder;
@@ -77,6 +78,7 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 
 	private final NamedDomainObjectContainer<RunConfigSettings> runConfigs;
 	private final NamedDomainObjectContainer<DecompilerOptions> decompilers;
+	private final NamedDomainObjectContainer<ModSettings> mods;
 
 	protected LoomGradleExtensionApiImpl(Project project, LoomFiles directories) {
 		this.jarProcessors = project.getObjects().listProperty(JarProcessor.class)
@@ -106,6 +108,7 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 		this.runConfigs = project.container(RunConfigSettings.class,
 				baseName -> new RunConfigSettings(project, baseName));
 		this.decompilers = project.getObjects().domainObjectContainer(DecompilerOptions.class);
+		this.mods = project.getObjects().domainObjectContainer(ModSettings.class);
 
 		this.minecraftJarConfiguration = project.getObjects().property(MinecraftJarConfiguration.class).convention(MinecraftJarConfiguration.MERGED);
 		this.minecraftJarConfiguration.finalizeValueOnRead();
@@ -280,6 +283,16 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	@Override
 	public InterfaceInjectionExtensionAPI getInterfaceInjection() {
 		return interfaceInjectionExtension;
+	}
+
+	@Override
+	public void mods(Action<NamedDomainObjectContainer<ModSettings>> action) {
+		action.execute(getMods());
+	}
+
+	@Override
+	public NamedDomainObjectContainer<ModSettings> getMods() {
+		return mods;
 	}
 
 	// This is here to ensure that LoomGradleExtensionApiImpl compiles without any unimplemented methods

--- a/src/main/java/net/fabricmc/loom/task/launch/GenerateDLIConfigTask.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/GenerateDLIConfigTask.java
@@ -74,6 +74,10 @@ public abstract class GenerateDLIConfigTask extends AbstractLoomTask {
 			launchConfig.property("fabric.gameJarPath", getGameJarPath("common"));
 		}
 
+		if (!getExtension().getMods().isEmpty()) {
+			launchConfig.property("fabric.classPathGroups", getClassPathGroups());
+		}
+
 		final boolean plainConsole = getProject().getGradle().getStartParameter().getConsoleOutput() == ConsoleOutput.Plain;
 		final boolean ansiSupportedIDE = new File(getProject().getRootDir(), ".vscode").exists()
 				|| new File(getProject().getRootDir(), ".idea").exists()
@@ -101,6 +105,19 @@ public abstract class GenerateDLIConfigTask extends AbstractLoomTask {
 		case "common" -> split.getCommonJar().toAbsolutePath().toString();
 		default -> throw new UnsupportedOperationException();
 		};
+	}
+
+	/**
+	 * See: https://github.com/FabricMC/fabric-loader/pull/585.
+	 */
+	private String getClassPathGroups() {
+		return getExtension().getMods().stream()
+				.map(modSettings ->
+						modSettings.getClasspath().get().stream()
+							.map(File::getAbsolutePath)
+							.collect(Collectors.joining(File.pathSeparator))
+				)
+				.collect(Collectors.joining(File.pathSeparator+File.pathSeparator));
 	}
 
 	public static class LaunchConfig {

--- a/src/main/java/net/fabricmc/loom/task/launch/GenerateDLIConfigTask.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/GenerateDLIConfigTask.java
@@ -42,7 +42,7 @@ import org.gradle.api.tasks.TaskAction;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftVersionMeta;
 import net.fabricmc.loom.configuration.providers.minecraft.mapped.MappedMinecraftProvider;
 import net.fabricmc.loom.task.AbstractLoomTask;
-import net.fabricmc.loom.util.gradle.SourceSetsHelper;
+import net.fabricmc.loom.util.gradle.SourceSetHelper;
 
 public abstract class GenerateDLIConfigTask extends AbstractLoomTask {
 	@TaskAction
@@ -114,7 +114,7 @@ public abstract class GenerateDLIConfigTask extends AbstractLoomTask {
 	private String getClassPathGroups() {
 		return getExtension().getMods().stream()
 				.map(modSettings ->
-						SourceSetsHelper.getClasspath(modSettings, getProject()).stream()
+						SourceSetHelper.getClasspath(modSettings, getProject()).stream()
 							.map(File::getAbsolutePath)
 							.collect(Collectors.joining(File.pathSeparator))
 				)

--- a/src/main/java/net/fabricmc/loom/task/launch/GenerateDLIConfigTask.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/GenerateDLIConfigTask.java
@@ -42,6 +42,7 @@ import org.gradle.api.tasks.TaskAction;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftVersionMeta;
 import net.fabricmc.loom.configuration.providers.minecraft.mapped.MappedMinecraftProvider;
 import net.fabricmc.loom.task.AbstractLoomTask;
+import net.fabricmc.loom.util.gradle.SourceSetsHelper;
 
 public abstract class GenerateDLIConfigTask extends AbstractLoomTask {
 	@TaskAction
@@ -113,7 +114,7 @@ public abstract class GenerateDLIConfigTask extends AbstractLoomTask {
 	private String getClassPathGroups() {
 		return getExtension().getMods().stream()
 				.map(modSettings ->
-						modSettings.getClasspath().get().stream()
+						SourceSetsHelper.getClasspath(modSettings, getProject()).stream()
 							.map(File::getAbsolutePath)
 							.collect(Collectors.joining(File.pathSeparator))
 				)

--- a/src/main/java/net/fabricmc/loom/util/gradle/SourceSetsHelper.java
+++ b/src/main/java/net/fabricmc/loom/util/gradle/SourceSetsHelper.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2022 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util.gradle;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.gradle.api.Project;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetOutput;
+
+import net.fabricmc.loom.api.ModSettings;
+
+public final class SourceSetsHelper {
+	private SourceSetsHelper() {
+	}
+
+	public static List<File> getClasspath(ModSettings modSettings, Project project) {
+		return modSettings.getSourceSets().get().stream()
+				.flatMap(sourceSet -> getClasspath(sourceSet, project).stream())
+				.toList();
+	}
+
+	public static List<File> getClasspath(SourceSet sourceSet, Project project) {
+		final List<File> classpath = getGradleClasspath(sourceSet);
+
+		classpath.addAll(getIdeaClasspath(sourceSet, project));
+		classpath.addAll(getEclipseClasspath(sourceSet, project));
+
+		return classpath;
+	}
+
+	private static List<File> getGradleClasspath(SourceSet sourceSet) {
+		final SourceSetOutput output = sourceSet.getOutput();
+		final File resources = output.getResourcesDir();
+
+		final List<File> classpath = new ArrayList<>();
+
+		classpath.addAll(output.getClassesDirs().getFiles());
+
+		if (resources != null) {
+			classpath.add(resources);
+		}
+
+		return classpath;
+	}
+
+	private static List<File> getIdeaClasspath(SourceSet sourceSet, Project project) {
+		// TODO
+		return Collections.emptyList();
+	}
+
+	private static List<File> getEclipseClasspath(SourceSet sourceSet, Project project) {
+		// TODO
+		return Collections.emptyList();
+	}
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/SourceSetHelperTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/SourceSetHelperTest.groovy
@@ -22,34 +22,31 @@
  * SOFTWARE.
  */
 
-package net.fabricmc.loom.api;
+package net.fabricmc.loom.test.unit
 
-import javax.inject.Inject;
+import net.fabricmc.loom.util.gradle.SourceSetHelper
+import org.intellij.lang.annotations.Language
+import spock.lang.Specification
 
-import org.gradle.api.Named;
-import org.gradle.api.provider.ListProperty;
-import org.gradle.api.tasks.SourceSet;
-import org.jetbrains.annotations.ApiStatus;
+class SourceSetHelperTest extends Specification {
 
-/**
- * A {@link Named} object for setting mod-related values. The {@linkplain Named#getName() name} should match the mod id.
- */
-@ApiStatus.Experimental
-public abstract class ModSettings implements Named {
-	/**
-	 * List of classpath directories, used to populate the `fabric.classPathGroups` Fabric Loader system property.
-	 */
-	public abstract ListProperty<SourceSet> getModSourceSets();
+    def "read misc.xml output path"() {
+        given:
+            def miscXml = File.createTempFile("misc", ".xml")
+            miscXml.text = MISC_XML
+        when:
+            def result = SourceSetHelper.evaluateXpath(miscXml, SourceSetHelper.IDEA_OUTPUT_XPATH)
 
-	@Inject
-	public ModSettings() {
-		getModSourceSets().finalizeValueOnRead();
-	}
+        then:
+            result == "file://\$PROJECT_DIR\$/build/out"
+    }
 
-	/**
-	 * Mark a {@link SourceSet} output directories part of the named mod.
-	 */
-	public void sourceSet(SourceSet sourceSet) {
-		getModSourceSets().add(sourceSet);
-	}
+    @Language("xml")
+    private static String MISC_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
+    <output url="file://\$PROJECT_DIR\$/build/out" />
+  </component>
+</project>"""
 }

--- a/src/test/groovy/net/fabricmc/loom/test/unit/SourceSetHelperTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/SourceSetHelperTest.groovy
@@ -25,20 +25,83 @@
 package net.fabricmc.loom.test.unit
 
 import net.fabricmc.loom.util.gradle.SourceSetHelper
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSet
 import org.intellij.lang.annotations.Language
+import spock.lang.Shared
 import spock.lang.Specification
 
 class SourceSetHelperTest extends Specification {
+    @Shared
+    private static File projectDir = File.createTempDir()
 
-    def "read misc.xml output path"() {
+    def "idea classpath"() {
         given:
-            def miscXml = File.createTempFile("misc", ".xml")
+            def miscXml = new File(projectDir, ".idea/misc.xml")
+            miscXml.parentFile.mkdirs()
             miscXml.text = MISC_XML
+
+            def mockProject = Mock(Project)
+            def mockSourceSet = Mock(SourceSet)
+
+            mockProject.getName() >> "UnitTest"
+            mockProject.getRootDir() >> projectDir
+            mockSourceSet.getName() >> "main"
+
         when:
-            def result = SourceSetHelper.evaluateXpath(miscXml, SourceSetHelper.IDEA_OUTPUT_XPATH)
+            def result = SourceSetHelper.getIdeaClasspath(mockSourceSet, mockProject)
 
         then:
-            result == "file://\$PROJECT_DIR\$/build/out"
+            result.size() == 1
+            !result[0].toString().startsWith("file:")
+
+            println(result[0].toString())
+    }
+
+    def "eclipse classpath"() {
+        given:
+            def classpath = new File(projectDir, ".classpath")
+            classpath.createNewFile()
+
+            def binDir = new File(projectDir, "bin")
+            binDir.mkdirs()
+
+            def mockProject = Mock(Project)
+            def mockSourceSet = Mock(SourceSet)
+
+            mockProject.getName() >> "UnitTest"
+            mockProject.getProjectDir() >> projectDir
+            mockSourceSet.getName() >> "main"
+
+        when:
+            def result = SourceSetHelper.getEclipseClasspath(mockSourceSet, mockProject)
+
+        then:
+            result.size() == 1
+            println(result[0].toString())
+    }
+
+    def "vscode classpath"() {
+        given:
+            def dotVscode = new File(projectDir, ".vscode")
+            dotVscode.mkdirs()
+
+            def binDir = new File(projectDir, "bin")
+            binDir.mkdirs()
+
+            def mockProject = Mock(Project)
+            def mockSourceSet = Mock(SourceSet)
+
+            mockProject.getName() >> "UnitTest"
+            mockProject.getProjectDir() >> projectDir
+            mockSourceSet.getName() >> "main"
+
+        when:
+            def result = SourceSetHelper.getVscodeClasspath(mockSourceSet, mockProject)
+
+        then:
+            result.size() == 1
+            println(result[0].toString())
     }
 
     @Language("xml")


### PR DESCRIPTION
## Mod Classpath Settings
This provides a simple way to populate the [`fabric.classPathGroups`](https://github.com/FabricMC/fabric-loader/pull/585) system property, via gradle. This is only required when your mod spans across multiple classpath directories, such as when using split client/common sourcesets.

```gradle
loom {
    mods {
        modid {
            sourceSet sourceSets.main
            sourceSet sourceSets.client
        }
    }
}
```

## Known issues

IDEs such as intelij use a diffrent output location when building without gradle, as far as I can tell gradle has no knowledge where this goes, further investigation needs to be done to figure out what can be done to support building and running only through the IDE. If anyone has any ideas I would appreciate the input. 👍 

## Example:

With this change it is possible to run TechReborn & RebornCore with split client/common sourcesets. This was done with a prototype version of fabric loader.

![](https://s.modm.us/idea64_m05L5TGiEK.png)