### PR TITLE
Add option to set the default decompiler.

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2016-2021 FabricMC
+ * Copyright (c) 2016-2022 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,6 +38,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 
 import net.fabricmc.loom.api.LoomGradleExtensionAPI;
+import net.fabricmc.loom.api.decompilers.DecompilerOptions;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.configuration.InstallerData;
 import net.fabricmc.loom.configuration.LoomDependencyManager;
@@ -118,4 +119,6 @@ public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 	List<AccessWidenerFile> getTransitiveAccessWideners();
 
 	void addTransitiveAccessWideners(List<AccessWidenerFile> accessWidenerFiles);
+
+	DecompilerOptions getDefaultDecompiler();
 }

--- a/src/main/java/net/fabricmc/loom/api/decompilers/DecompilerOptions.java
+++ b/src/main/java/net/fabricmc/loom/api/decompilers/DecompilerOptions.java
@@ -32,6 +32,7 @@ import org.gradle.api.Named;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
+import org.jetbrains.annotations.ApiStatus;
 
 public abstract class DecompilerOptions implements Named {
 	/**
@@ -59,12 +60,26 @@ public abstract class DecompilerOptions implements Named {
 	 */
 	public abstract Property<Integer> getMaxThreads();
 
+	/**
+	 * When set to true this decompiler will be used as the default when running the parent "genSources" task.
+	 * If multiple decompilers are set as default project evaluation will fail.
+	 *
+	 * <p>Plugins should <strong>NOT</strong> set their own decompiler as default.
+	 */
+	public abstract Property<Boolean> getIsDefault();
+
 	public DecompilerOptions() {
 		getDecompilerClassName().finalizeValueOnRead();
 		getClasspath().finalizeValueOnRead();
 		getOptions().finalizeValueOnRead();
 		getMemory().convention(4096L).finalizeValueOnRead();
 		getMaxThreads().convention(Runtime.getRuntime().availableProcessors()).finalizeValueOnRead();
+		getIsDefault().convention(false).finalizeValueOnRead();
+	}
+
+	@ApiStatus.Internal
+	public final String getNameForTask() {
+		return getName().substring(0, 1).toUpperCase() + getName().substring(1);
 	}
 
 	// Done to work around weird issues with the workers, possibly https://github.com/gradle/gradle/issues/13422

--- a/src/main/java/net/fabricmc/loom/configuration/decompile/SplitDecompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/decompile/SplitDecompileConfiguration.java
@@ -26,13 +26,12 @@ package net.fabricmc.loom.configuration.decompile;
 
 import java.io.File;
 
-import net.fabricmc.loom.api.decompilers.DecompilerOptions;
-
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.tasks.TaskProvider;
 
+import net.fabricmc.loom.api.decompilers.DecompilerOptions;
 import net.fabricmc.loom.configuration.providers.minecraft.mapped.MappedMinecraftProvider;
 import net.fabricmc.loom.task.GenerateSourcesTask;
 import net.fabricmc.loom.task.UnpickJarTask;

--- a/src/main/java/net/fabricmc/loom/decompilers/DecompilerConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/decompilers/DecompilerConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2018-2020 FabricMC
+ * Copyright (c) 2018-2022 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,12 +32,16 @@ import net.fabricmc.loom.decompilers.cfr.LoomCFRDecompiler;
 import net.fabricmc.loom.decompilers.fernflower.FabricFernFlowerDecompiler;
 
 public final class DecompilerConfiguration {
+	public static final String FERN_FLOWER = "fernFlower";
+	public static final String CFR = "cfr";
+	public static final String DEFAULT = CFR;
+
 	private DecompilerConfiguration() {
 	}
 
 	public static void setup(Project project) {
-		registerDecompiler(project, "fernFlower", FabricFernFlowerDecompiler.class);
-		registerDecompiler(project, "cfr", LoomCFRDecompiler.class);
+		registerDecompiler(project, FERN_FLOWER, FabricFernFlowerDecompiler.class);
+		registerDecompiler(project, CFR, LoomCFRDecompiler.class);
 	}
 
 	private static void registerDecompiler(Project project, String name, Class<? extends LoomDecompiler> decompilerClass) {

--- a/src/test/groovy/net/fabricmc/loom/test/integration/DecompileTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/DecompileTest.groovy
@@ -59,9 +59,17 @@ class DecompileTest extends Specification implements GradleProjectTestTrait {
                     minecraft "com.mojang:minecraft:1.18.1"
                     mappings "net.fabricmc:yarn:1.18.1+build.18:v2"
                 }
+                
+                loom {
+                	decompilers {
+                		custom {
+                			isDefault = true
+                		}
+                	}
+                }
             '''
 		when:
-			def result = gradle.run(task: "genSourcesWithCustom")
+			def result = gradle.run(task: "genSources")
 
 		then:
 			result.task(":genSourcesWithCustom").outcome == SUCCESS


### PR DESCRIPTION
```
loom {
   decompilers {
      fernFlower {
         isDefault = true
      }
   }
}
```

This is not designed to allow plugins to set their own default decompiler, doing so will stop users from changing the decompiler.