### PR TITLE
Remove unnecessary publication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -199,14 +199,6 @@ import org.w3c.dom.Node
 
 publishing {
 	publications {
-		plugin(MavenPublication) { publication ->
-			groupId project.group
-			artifactId project.archivesBaseName
-			version project.version
-
-			from components.java
-		}
-
 		// Also publish a snapshot so people can use the latest version if they wish
 		snapshot(MavenPublication) { publication ->
 			groupId project.group


### PR DESCRIPTION
It's already added by [`java-gradle-plugin`](https://github.com/gradle/gradle/blob/a37ea9b12249997c97af515b2b46443488db5247/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishPlugin.java#L66) resulting in [2 pushes](https://github.com/FabricMC/fabric-loom/runs/5608353563?check_suite_focus=true#step:6:81)