### PR TITLE
Mod provided javadoc

### DIFF
--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -140,6 +140,13 @@ public interface LoomGradleExtensionAPI {
 	 */
 	Property<Boolean> getEnableTransitiveAccessWideners();
 
+	/**
+	 * When true loom will apply mod provided javadoc from dependencies.
+	 *
+	 * @return the property controlling the mod provided javadoc
+	 */
+	Property<Boolean> getEnableModProvidedJavadoc();
+
 	@ApiStatus.Experimental
 	IntermediateMappingsProvider getIntermediateMappingsProvider();
 

--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -45,6 +45,7 @@ import net.fabricmc.loom.build.mixin.ScalaApInvoker;
 import net.fabricmc.loom.configuration.accesswidener.AccessWidenerJarProcessor;
 import net.fabricmc.loom.configuration.accesswidener.TransitiveAccessWidenerJarProcessor;
 import net.fabricmc.loom.configuration.ifaceinject.InterfaceInjectionProcessor;
+import net.fabricmc.loom.configuration.mods.ModJavadocProcessor;
 import net.fabricmc.loom.configuration.processors.JarProcessorManager;
 import net.fabricmc.loom.configuration.providers.mappings.MappingsProviderImpl;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftJarConfiguration;
@@ -236,6 +237,15 @@ public final class CompileConfiguration {
 
 			if (!jarProcessor.isEmpty()) {
 				extension.getGameJarProcessors().add(jarProcessor);
+			}
+		}
+
+		if (extension.getEnableModProvidedJavadoc().get()) {
+			// This doesn't do any processing on the compiled jar, but it does have an effect on the generated sources.
+			final ModJavadocProcessor javadocProcessor = ModJavadocProcessor.create(project);
+
+			if (javadocProcessor != null) {
+				extension.getGameJarProcessors().add(javadocProcessor);
 			}
 		}
 

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModJavadocProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModJavadocProcessor.java
@@ -1,0 +1,158 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2022 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.configuration.mods;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import com.google.gson.JsonObject;
+import org.gradle.api.Project;
+import org.jetbrains.annotations.Nullable;
+
+import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
+import net.fabricmc.loom.configuration.RemappedConfigurationEntry;
+import net.fabricmc.loom.task.GenerateSourcesTask;
+import net.fabricmc.loom.util.Constants;
+import net.fabricmc.loom.util.ModUtils;
+import net.fabricmc.loom.util.ZipUtils;
+import net.fabricmc.mappingio.MappedElementKind;
+import net.fabricmc.mappingio.MappingReader;
+import net.fabricmc.mappingio.MappingVisitor;
+import net.fabricmc.mappingio.adapter.ForwardingMappingVisitor;
+import net.fabricmc.mappingio.tree.MemoryMappingTree;
+
+public final class ModJavadocProcessor implements GenerateSourcesTask.MappingsProcessor {
+	private final List<ModJavadoc> javadocs;
+
+	private ModJavadocProcessor(List<ModJavadoc> javadocs) {
+		this.javadocs = javadocs;
+	}
+
+	@Nullable
+	public static ModJavadocProcessor create(Project project) {
+		final LoomGradleExtension extension = LoomGradleExtension.get(project);
+		final List<ModJavadoc> javadocs = new ArrayList<>();
+
+		for (RemappedConfigurationEntry entry : Constants.MOD_COMPILE_ENTRIES) {
+			Set<File> artifacts = extension.getLazyConfigurationProvider(entry.sourceConfiguration())
+					.get()
+					.resolve();
+
+			for (File artifact : artifacts) {
+				if (!ModUtils.isMod(artifact.toPath())) {
+					continue;
+				}
+
+				final ModJavadoc modJavadoc;
+
+				try {
+					modJavadoc = ModJavadoc.fromModJar(artifact.toPath());
+				} catch (IOException e) {
+					throw new UncheckedIOException("Failed to read mod jar (%s)".formatted(artifact), e);
+				}
+
+				if (modJavadoc != null) {
+					javadocs.add(modJavadoc);
+				}
+			}
+		}
+
+		if (javadocs.isEmpty()) {
+			return null;
+		}
+
+		return new ModJavadocProcessor(javadocs);
+	}
+
+	@Override
+	public boolean transform(MemoryMappingTree mappings) {
+		for (ModJavadoc javadoc : javadocs) {
+			try {
+				// TODO I think this overrides existing comments, might need to get a bit more creative.
+				javadoc.mappingTree().accept(new ForwardingJavadocMappingVisitor(mappings, javadoc.modId()));
+			} catch (IOException e) {
+				throw new UncheckedIOException("Failed to apply javadoc from mod (%s)".formatted(javadoc.modId()), e);
+			}
+		}
+
+		return true;
+	}
+
+	public record ModJavadoc(String modId, MemoryMappingTree mappingTree) {
+		@Nullable
+		public static ModJavadoc fromModJar(Path path) throws IOException {
+			JsonObject jsonObject = ModUtils.getFabricModJson(path);
+
+			if (jsonObject == null || !jsonObject.has("custom")) {
+				return null;
+			}
+
+			final String modId = jsonObject.get("id").getAsString();
+			final JsonObject custom = jsonObject.getAsJsonObject("custom");
+
+			if (!custom.has(Constants.CustomModJsonKeys.PROVIDED_JAVADOC)) {
+				return null;
+			}
+
+			final String javaDocPath = custom.getAsJsonPrimitive(Constants.CustomModJsonKeys.PROVIDED_JAVADOC).getAsString();
+			final byte[] data = ZipUtils.unpack(path, javaDocPath);
+			final MemoryMappingTree mappings = new MemoryMappingTree();
+
+			try (Reader reader = new InputStreamReader(new ByteArrayInputStream(data))) {
+				MappingReader.read(reader, mappings);
+			}
+
+			if (!mappings.getSrcNamespace().equals(MappingsNamespace.INTERMEDIARY.toString())) {
+				throw new IllegalStateException("Javadoc provided by mod (%s) must be have an intermediary source namespace".formatted(modId));
+			}
+
+			return new ModJavadoc(modId, mappings);
+		}
+	}
+
+	// Ensure the mappings don't try to change names.
+	private static final class ForwardingJavadocMappingVisitor extends ForwardingMappingVisitor {
+		private final String modId;
+
+		ForwardingJavadocMappingVisitor(MappingVisitor next, String modId) {
+			super(next);
+			this.modId = modId;
+		}
+
+		@Override
+		public void visitDstName(MappedElementKind targetKind, int namespace, String name) {
+			throw new UnsupportedOperationException("Javadoc provided from mod (%s) attempted to map dst name".formatted(modId));
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -67,6 +67,7 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	protected final Property<String> customManifest;
 	protected final Property<Boolean> setupRemappedVariants;
 	protected final Property<Boolean> transitiveAccessWideners;
+	protected final Property<Boolean> modProvidedJavadoc;
 	protected final Property<String> intermediary;
 	protected final Property<IntermediateMappingsProvider> intermediateMappingsProvider;
 	private final Property<Boolean> runtimeOnlyLog4j;
@@ -98,6 +99,9 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 		this.transitiveAccessWideners = project.getObjects().property(Boolean.class)
 				.convention(true);
 		this.transitiveAccessWideners.finalizeValueOnRead();
+		this.modProvidedJavadoc = project.getObjects().property(Boolean.class)
+				.convention(true);
+		this.modProvidedJavadoc.finalizeValueOnRead();
 		this.intermediary = project.getObjects().property(String.class)
 				.convention("https://maven.fabricmc.net/net/fabricmc/intermediary/%1$s/intermediary-%1$s-v2.jar");
 
@@ -232,6 +236,11 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	@Override
 	public Property<Boolean> getEnableTransitiveAccessWideners() {
 		return transitiveAccessWideners;
+	}
+
+	@Override
+	public Property<Boolean> getEnableModProvidedJavadoc() {
+		return modProvidedJavadoc;
 	}
 
 	protected abstract Project getProject();

--- a/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
@@ -64,6 +64,7 @@ import net.fabricmc.loom.api.decompilers.LoomDecompiler;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.configuration.accesswidener.TransitiveAccessWidenerMappingsProcessor;
 import net.fabricmc.loom.configuration.ifaceinject.InterfaceInjectionProcessor;
+import net.fabricmc.loom.configuration.mods.ModJavadocProcessor;
 import net.fabricmc.loom.decompilers.LineNumberRemapper;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.FileSystemUtil;
@@ -327,6 +328,12 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 
 		if (getExtension().getInterfaceInjection().isEnabled()) {
 			mappingsProcessors.add(new InterfaceInjectionProcessor(getProject()));
+		}
+
+		final ModJavadocProcessor javadocProcessor = ModJavadocProcessor.create(getProject());
+
+		if (javadocProcessor != null) {
+			mappingsProcessors.add(javadocProcessor);
 		}
 
 		if (mappingsProcessors.isEmpty()) {

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -142,4 +142,9 @@ public class Constants {
 		private TaskGroup() {
 		}
 	}
+
+	public static final class CustomModJsonKeys {
+		public static final String INJECTED_INTERFACE = "loom:injected_interfaces";
+		public static final String PROVIDED_JAVADOC = "loom:provided_javadoc";
+	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/integration/ModJavadocTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/ModJavadocTest.groovy
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2016-2022 FabricMC
+ * Copyright (c) 2021 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,45 +22,30 @@
  * SOFTWARE.
  */
 
-package net.fabricmc.loom.util;
+package net.fabricmc.loom.test.integration
 
-import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
+import net.fabricmc.loom.test.util.GradleProjectTestTrait
+import net.fabricmc.loom.util.ZipUtils
+import spock.lang.Specification
+import spock.lang.Unroll
 
-import com.google.gson.JsonObject;
-import org.jetbrains.annotations.Nullable;
+import static net.fabricmc.loom.test.LoomTestConstants.STANDARD_TEST_VERSIONS
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
-import net.fabricmc.loom.LoomGradlePlugin;
+class ModJavadocTest extends Specification implements GradleProjectTestTrait {
+	@Unroll
+	def "mod javadoc (gradle #version)"() {
+		setup:
+			def gradle = gradleProject(project: "modJavadoc", version: version)
+			ZipUtils.pack(new File(gradle.projectDir, "dummyDependency").toPath(), new File(gradle.projectDir, "dummy.jar").toPath())
 
-public final class ModUtils {
-	private ModUtils() {
-	}
+		when:
+			def result = gradle.run(task: "genSources")
 
-	public static boolean isMod(File file) {
-		return isMod(file.toPath());
-	}
+		then:
+			result.task(":genSources").outcome == SUCCESS
 
-	public static boolean isMod(Path input) {
-		return ZipUtils.contains(input, "fabric.mod.json");
-	}
-
-	@Nullable
-	public static JsonObject getFabricModJson(Path path) {
-		final byte[] modJsonBytes;
-
-		try {
-			modJsonBytes = ZipUtils.unpackNullable(path, "fabric.mod.json");
-		} catch (IOException e) {
-			throw new UncheckedIOException("Failed to extract fabric.mod.json from " + path, e);
-		}
-
-		if (modJsonBytes == null) {
-			return null;
-		}
-
-		return LoomGradlePlugin.GSON.fromJson(new String(modJsonBytes, StandardCharsets.UTF_8), JsonObject.class);
+		where:
+			version << STANDARD_TEST_VERSIONS
 	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/integration/ModJavadocTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/ModJavadocTest.groovy
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2021 FabricMC
+ * Copyright (c) 2022 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,6 +29,8 @@ import net.fabricmc.loom.util.ZipUtils
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import java.nio.charset.StandardCharsets
+
 import static net.fabricmc.loom.test.LoomTestConstants.STANDARD_TEST_VERSIONS
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
@@ -41,11 +43,20 @@ class ModJavadocTest extends Specification implements GradleProjectTestTrait {
 
 		when:
 			def result = gradle.run(task: "genSources")
+			def blocks = getClassSource(gradle, "net/minecraft/block/Blocks.java")
 
 		then:
 			result.task(":genSources").outcome == SUCCESS
+			blocks.contains("An example of a mod added class javadoc")
+			blocks.contains("An example of a mod added field javadoc")
+			blocks.contains("An example of a mod added method javadoc")
 
 		where:
 			version << STANDARD_TEST_VERSIONS
+	}
+
+	private static String getClassSource(GradleProject gradle, String classname) {
+		File sourcesJar = gradle.getGeneratedLocalSources("1.17.1/net.fabricmc.yarn.1_17_1.1.17.1+build.59-v2")
+		return new String(ZipUtils.unpack(sourcesJar.toPath(), classname), StandardCharsets.UTF_8)
 	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/util/GradleProjectTestTrait.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/util/GradleProjectTestTrait.groovy
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2021 FabricMC
+ * Copyright (c) 2021-2022 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -232,6 +232,10 @@ trait GradleProjectTestTrait {
 
         File getGeneratedSources(String mappings) {
             return new File(getGradleHomeDir(), "caches/fabric-loom/${mappings}/minecraft-merged-named-sources.jar")
+        }
+
+        File getGeneratedLocalSources(String mappings) {
+            return new File(getProjectDir(), ".gradle/loom-cache/${mappings}/minecraft-project-@-merged-named-sources.jar")
         }
 
         void buildSrc(String name) {

--- a/src/test/resources/projects/modJavadoc/build.gradle
+++ b/src/test/resources/projects/modJavadoc/build.gradle
@@ -1,0 +1,18 @@
+// This is used by a range of tests that append to this file before running the gradle tasks.
+// Can be used for tests that require minimal custom setup
+plugins {
+	id 'fabric-loom'
+	id 'maven-publish'
+}
+
+archivesBaseName = "fabric-example-mod"
+version = "1.0.0"
+group = "com.example"
+
+dependencies {
+	minecraft "com.mojang:minecraft:1.17.1"
+	mappings "net.fabricmc:yarn:1.17.1+build.59:v2"
+	modImplementation "net.fabricmc:fabric-loader:0.11.6"
+
+	modImplementation files("dummy.jar")
+}

--- a/src/test/resources/projects/modJavadoc/dummyDependency/fabric.mod.json
+++ b/src/test/resources/projects/modJavadoc/dummyDependency/fabric.mod.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "id": "dummy",
+  "version": "1",
+  "name": "Dummy Mod",
+  "custom": {
+    "loom:provided_javadoc": "javadoc.tiny"
+  }
+}

--- a/src/test/resources/projects/modJavadoc/dummyDependency/javadoc.tiny
+++ b/src/test/resources/projects/modJavadoc/dummyDependency/javadoc.tiny
@@ -1,0 +1,7 @@
+tiny	2	0	intermediary
+c	net/minecraft/class_2246
+	c	An example of a mod added class javadoc
+	f	Lnet/minecraft/class_2248;	A	field_10382
+	    c	An example of a mod added field javadoc
+    m	(Lnet/minecraft/class_2680;)I	method_24419
+        c	An example of a mod added method javadoc

--- a/src/test/resources/projects/modJavadoc/dummyDependency/javadoc.tiny
+++ b/src/test/resources/projects/modJavadoc/dummyDependency/javadoc.tiny
@@ -1,7 +1,7 @@
 tiny	2	0	intermediary
 c	net/minecraft/class_2246
 	c	An example of a mod added class javadoc
-	f	Lnet/minecraft/class_2248;	A	field_10382
-	    c	An example of a mod added field javadoc
-    m	(Lnet/minecraft/class_2680;)I	method_24419
-        c	An example of a mod added method javadoc
+	f	Lnet/minecraft/class_2248;	field_10382
+		c	An example of a mod added field javadoc
+	m	(I)Ljava/util/function/ToIntFunction;	method_26107
+		c	An example of a mod added method javadoc


### PR DESCRIPTION
This PR allows mods to provide their own javadoc to the decompiled source. Useful for mods like fabric API where it may be useful to point developers in a diffrent direction when reading the MC source.
