### PR TITLE
Preserve extraInt in kotlin metadata remapper

### DIFF
--- a/src/main/kotlin/net/fabricmc/loom/kotlin/remapping/KotlinClassMetadataRemappingAnnotationVisitor.kt
+++ b/src/main/kotlin/net/fabricmc/loom/kotlin/remapping/KotlinClassMetadataRemappingAnnotationVisitor.kt
@@ -48,7 +48,7 @@ class KotlinClassMetadataRemappingAnnotationVisitor(private val remapper: Remapp
                 val klass = metadata.toKmClass()
                 val writer = KotlinClassMetadata.Class.Writer()
                 klass.accept(RemappingKmVisitors(remapper).RemappingKmClassVisitor(writer))
-                writeClassHeader(writer.write().header)
+                writeClassHeader(writer.write(extraInt = metadata.header.extraInt).header)
             }
             is KotlinClassMetadata.SyntheticClass -> {
                 val klambda = metadata.toKmLambda()
@@ -56,7 +56,7 @@ class KotlinClassMetadataRemappingAnnotationVisitor(private val remapper: Remapp
                 if (klambda != null) {
                     val writer = KotlinClassMetadata.SyntheticClass.Writer()
                     klambda.accept(RemappingKmVisitors(remapper).RemappingKmLambdaVisitor(writer))
-                    writeClassHeader(writer.write().header)
+                    writeClassHeader(writer.write(extraInt = metadata.header.extraInt).header)
                 } else {
                     accept(next)
                 }


### PR DESCRIPTION
The `extraInt` (`xs`, [1]) parameter of Kotlin's Metadata annotation does not become
part of the KmClass/KmLambda and must be preserved explicitly to not be lost
during remapping.

It does carry important information though, so we must not neglect it.
In particular, bit 7 indicates that the class is used in the scope of an inline
function and is therefore implicitly part of the public API. If this flag is
missing from a class which requires it, then it becomes impossible to use that
inline function because the Kotlin compiler will crash hitting an assertion
while trying to inline the required code [2].

Based on the descriptions in [1], it looks like none of this data should be
affected by our remapping in any way, so it seems safe to simply copy over the
value from the original annotation. And that's what this commit does.

[1]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-metadata/extra-int.html
[2]: https://i.johni0702.de/sOpA8.png