### PR TITLE
Add kotlin tests to actions matrix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -285,8 +285,11 @@ task writeActionsTestMatrix() {
 			}
 		}
 
-		// Run all the unit tests togeather
+		// Run all the unit tests together
 		testMatrix.add("net.fabricmc.loom.test.unit.*")
+
+		// Kotlin tests
+		testMatrix.add("net.fabricmc.loom.test.kotlin.*")
 
 		def json = groovy.json.JsonOutput.toJson(testMatrix)
 		def output = file("build/test_matrix.json")


### PR DESCRIPTION
`KotlinClassMetadataRemappingAnnotationVisitorTest` was failing for me locally, and I noticed it doesn't get run by actions.