### PR TITLE
Added jetbrains annotations to test compile

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -130,6 +130,7 @@ public final class CompileConfiguration {
 		project.getDependencies().add(Constants.Configurations.LOOM_DEVELOPMENT_DEPENDENCIES, Constants.Dependencies.DEV_LAUNCH_INJECTOR + Constants.Dependencies.Versions.DEV_LAUNCH_INJECTOR);
 		project.getDependencies().add(Constants.Configurations.LOOM_DEVELOPMENT_DEPENDENCIES, Constants.Dependencies.TERMINAL_CONSOLE_APPENDER + Constants.Dependencies.Versions.TERMINAL_CONSOLE_APPENDER);
 		project.getDependencies().add(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME, Constants.Dependencies.JETBRAINS_ANNOTATIONS + Constants.Dependencies.Versions.JETBRAINS_ANNOTATIONS);
+		project.getDependencies().add(JavaPlugin.TEST_COMPILE_ONLY_CONFIGURATION_NAME, Constants.Dependencies.JETBRAINS_ANNOTATIONS + Constants.Dependencies.Versions.JETBRAINS_ANNOTATIONS);
 	}
 
 	public static void configureCompile(Project p) {


### PR DESCRIPTION
So I'm not too sure on the specifics of this one, but basically if you clone 
```
https://github.com/jaredlll08/MultiLoader-Template
```
then add:
```java
package com.example.examplemod;

import net.minecraft.client.Minecraft;
import net.minecraft.client.gui.components.AbstractSelectionList;
import net.minecraft.client.gui.narration.NarrationElementOutput;

public class BadList<E extends AbstractSelectionList.Entry<E>> extends AbstractSelectionList<E> {

    public BadList(Minecraft mc) {

        super(mc, 0, 0, 43, 0, 50);
    }

    @Override
    public void updateNarration(NarrationElementOutput narrator) {

    }
}
```
to the Common project and try and build it, you get a very useless error message of:
```
> Task :Fabric:compileTestJava FAILED
An exception has occurred in the compiler (17.0.1). Please file a bug against the Java compiler via the Java bug reporting page (http://bugreport.java.com) after checking the Bug Database (http://bugs.java.com) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
com.sun.tools.javac.code.Symbol$CompletionFailure: class file for org.jetbrains.annotations.Nullable not found
```

With absolutely no information as to what file errored or what even requires that annotation.

It only happens when running `compileTestJava` and changing the template to only bring in Common code when `compileJava` is called builds fine (although that is not a solution).

Changing the JB annotations to instead be `implementation`, which is what the [docs](https://www.jetbrains.com/help/idea/annotating-source-code.html) uses, fixes the issue.

As noted [here](https://discuss.gradle.org/t/compileonly-dependencies-are-not-available-in-tests/15366/6) `compileOnly` does not propagate to tests and `implementation` should be used instead.
