### PR TITLE
Make remapping tasks use the archive file from the Jar API

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/RemapSourcesJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapSourcesJarTask.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2021 FabricMC
+ * Copyright (c) 2021-2022 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,15 +25,13 @@
 package net.fabricmc.loom.task;
 
 import java.io.IOException;
-import java.nio.file.Files;
+import java.nio.file.Path;
 
 import javax.inject.Inject;
 
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.TaskAction;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import net.fabricmc.loom.task.service.SourceRemapperService;
 import net.fabricmc.loom.util.service.UnsafeWorkQueueHelper;
@@ -58,8 +56,6 @@ public abstract class RemapSourcesJarTask extends AbstractRemapJarTask {
 	}
 
 	public abstract static class RemapSourcesAction extends AbstractRemapAction<RemapSourcesParams> {
-		private static final Logger LOGGER = LoggerFactory.getLogger(RemapSourcesAction.class);
-
 		private final SourceRemapperService sourceRemapperService;
 
 		public RemapSourcesAction() {
@@ -69,20 +65,9 @@ public abstract class RemapSourcesJarTask extends AbstractRemapJarTask {
 		}
 
 		@Override
-		public void execute() {
-			try {
-				sourceRemapperService.remapSourcesJar(inputFile, outputFile);
-
-				rewriteJar();
-			} catch (Exception e) {
-				try {
-					Files.deleteIfExists(outputFile);
-				} catch (IOException ex) {
-					LOGGER.error("Failed to delete output file", ex);
-				}
-
-				throw new RuntimeException("Failed to remap sources", e);
-			}
+		public void execute(Path inputFile) throws IOException {
+			sourceRemapperService.remapSourcesJar(inputFile, outputFile);
+			rewriteJar();
 		}
 	}
 }


### PR DESCRIPTION
Remapping only works for sources jars at this point, not sure what's going on with code jars.

Other minor changes:
- Exception messages now include the absolute path of the jar file
- `RemapSourcesJarTask` now also uses descriptive wrappers instead of a direct `new RuntimeException(...)`