### PR TITLE
Fix test artifact names

### DIFF
--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - run: ./gradlew printActionsTestName --name="${{ matrix.test }}" --tests ${{ matrix.test }} --stacktrace --warning-mode fail
+      - run: ./gradlew printActionsTestName --name="${{ matrix.test }}" test --tests ${{ matrix.test }} --stacktrace --warning-mode fail
         env:
           TEST_WARNING_MODE: fail
         id: test

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -56,14 +56,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - run: gradle test --tests ${{ matrix.test }} --stacktrace --warning-mode fail
+      - run: gradle printActionsTestName --name="${{ matrix.test }}" test --tests ${{ matrix.test }} --stacktrace --warning-mode fail
         env:
           TEST_WARNING_MODE: fail
+        id: test
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
-          name: ${{ matrix.test }} (${{ matrix.java }}) Results
+          name: ${{ steps.test.outputs.test }} Results
           path: build/reports/
 
   run_tests_windows:
@@ -83,14 +84,15 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - run: ./gradlew test --tests ${{ matrix.test }} --stacktrace --warning-mode fail
+      - run: ./gradlew printActionsTestName --name="${{ matrix.test }}" --tests ${{ matrix.test }} --stacktrace --warning-mode fail
         env:
           TEST_WARNING_MODE: fail
+        id: test
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
-          name: ${{ matrix.test }} (${{ matrix.java }}) Results
+          name: ${{ steps.test.outputs.test }} (${{ matrix.java }}) Results (Windows)
           path: build/reports/
 
   # Special case this test to run across all os's

--- a/build.gradle
+++ b/build.gradle
@@ -330,3 +330,21 @@ task downloadGradleSources() {
 		gradleApiSources << new URL(url).newInputStream()
 	}
 }
+
+task printActionsTestName(type: PrintActionsTestName) {
+}
+
+/**
+ * Replaces invalid characters in test names for GitHub Actions artifacts.
+ */
+class PrintActionsTestName extends DefaultTask {
+	@Input
+	@Option(option = "name", description = "The test name")
+	String testName
+
+	@TaskAction
+	def run() {
+		def sanitised = testName.replace('*', '_')
+		println "::set-output name=test::$sanitised"
+	}
+}


### PR DESCRIPTION
- Fixes empty parens in Linux artifacts
- Fixes invalid artifact names containing `*` by replacing that character with `_` (a bit like in Scala)
- Fixes Windows artifacts not being different from Linux ones

![](https://user-images.githubusercontent.com/6596629/188911239-b8c08ac9-dc3e-4315-83a6-0ea0cf808cdb.png)