### PR TITLE
Fix mods on custom remap configs always being applied to the main sourceset.

### DIFF
--- a/src/main/java/net/fabricmc/loom/api/RemapConfigurationSettings.java
+++ b/src/main/java/net/fabricmc/loom/api/RemapConfigurationSettings.java
@@ -37,6 +37,7 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.SourceSet;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -53,6 +54,7 @@ public abstract class RemapConfigurationSettings implements Named {
 	public RemapConfigurationSettings(String name) {
 		this.name = name;
 
+		getSourceSet().finalizeValueOnRead();
 		getTargetConfigurationName().finalizeValueOnRead();
 		getClientSourceConfigurationName().finalizeValueOnRead();
 		getOnCompileClasspath().finalizeValueOnRead();
@@ -64,6 +66,11 @@ public abstract class RemapConfigurationSettings implements Named {
 	public @NotNull String getName() {
 		return name;
 	}
+
+	/**
+	 * @return The target source set
+	 */
+	public abstract Property<SourceSet> getSourceSet();
 
 	/**
 	 * @return The target configuration name

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -340,6 +340,9 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	public RemapConfigurationSettings addRemapConfiguration(String name, Action<RemapConfigurationSettings> action) {
 		final RemapConfigurationSettings configurationSettings = getProject().getObjects().newInstance(RemapConfigurationSettings.class, name);
 
+		// TODO remove in 2.0, this is a fallback to mimic the previous (Broken) behaviour
+		configurationSettings.getSourceSet().convention(SourceSetHelper.getMainSourceSet(getProject()));
+
 		action.execute(configurationSettings);
 		RemapConfigurations.applyToProject(getProject(), configurationSettings);
 		remapConfigurations.add(configurationSettings);


### PR DESCRIPTION
This does remove them from the test configs as well, im unsure if this is something we want to do, but I think it makes sense to do so. The API will fallback to the old broken state if a sourceset isnt specified.

No idea how no one (including me) failed to spot/report this 😆 