### PR TITLE
Clear Fernflower context after decompiling

### DIFF
--- a/src/main/java/net/fabricmc/loom/decompilers/fernflower/FabricFernFlowerDecompiler.java
+++ b/src/main/java/net/fabricmc/loom/decompilers/fernflower/FabricFernFlowerDecompiler.java
@@ -61,6 +61,11 @@ public final class FabricFernFlowerDecompiler implements LoomDecompiler {
 		}
 
 		ff.addSource(compiledJar.toFile());
-		ff.decompileContext();
+
+		try {
+			ff.decompileContext();
+		} finally {
+			ff.clearContext();
+		}
 	}
 }


### PR DESCRIPTION
This clears up some of the resources used by Fernflower and mirrors [what is done in the CLI decompiler](https://github.com/FabricMC/intellij-fernflower/blob/49f5561beca2d4efbf94762452858f032841b31e/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java#L119-L126).