### PR TITLE
Allow users to modify host when they are downloading Minecraft resource.

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftProvider.java
@@ -124,7 +124,10 @@ public abstract class MinecraftProvider {
 				.defaultCache()
 				.downloadString(versionManifestJson.toPath());
 
-		final ManifestVersion mcManifest = LoomGradlePlugin.OBJECT_MAPPER.readValue(versionManifest, ManifestVersion.class);
+		final ManifestVersion mcManifest = LoomGradlePlugin.OBJECT_MAPPER.readValue(
+				MirrorUtil.applyMojangHostMapping(versionManifest, getProject()),
+				ManifestVersion.class
+		);
 		ManifestVersion.Versions version = null;
 
 		if (getExtension().getCustomMinecraftManifest().isPresent()) {
@@ -185,7 +188,7 @@ public abstract class MinecraftProvider {
 				DownloadExecutor executor = new DownloadExecutor(2)) {
 			if (provideClient()) {
 				final MinecraftVersionMeta.Download client = versionInfo.download("client");
-				getExtension().download(client.url())
+				getExtension().download(MirrorUtil.applyMojangHostMapping(client.url(), getProject()))
 						.sha1(client.sha1())
 						.progress(new GradleDownloadProgressListener("Minecraft client", progressGroup::createProgressLogger))
 						.downloadPathAsync(minecraftClientJar.toPath(), executor);
@@ -193,7 +196,7 @@ public abstract class MinecraftProvider {
 
 			if (provideServer()) {
 				final MinecraftVersionMeta.Download server = versionInfo.download("server");
-				getExtension().download(server.url())
+				getExtension().download(MirrorUtil.applyMojangHostMapping(server.url(), getProject()))
 						.sha1(server.sha1())
 						.progress(new GradleDownloadProgressListener("Minecraft server", progressGroup::createProgressLogger))
 						.downloadPathAsync(minecraftServerJar.toPath(), executor);

--- a/src/main/java/net/fabricmc/loom/task/DownloadAssetsTask.java
+++ b/src/main/java/net/fabricmc/loom/task/DownloadAssetsTask.java
@@ -118,7 +118,8 @@ public abstract class DownloadAssetsTask extends AbstractLoomTask {
 		final MinecraftVersionMeta.AssetIndex assetIndex = getAssetIndexMeta();
 		final File indexFile = new File(getAssetsDirectory().get().getAsFile(), "indexes" + File.separator + assetIndex.fabricId(minecraftProvider.minecraftVersion()) + ".json");
 
-		final String json = extension.download(assetIndex.url())
+		final String url = MirrorUtil.applyMojangHostMapping(assetIndex.url(), getProject());
+		final String json = extension.download(url)
 				.sha1(assetIndex.sha1())
 				.downloadString(indexFile.toPath());
 

--- a/src/main/java/net/fabricmc/loom/util/MirrorUtil.java
+++ b/src/main/java/net/fabricmc/loom/util/MirrorUtil.java
@@ -66,4 +66,19 @@ public class MirrorUtil {
 
 		return Constants.FABRIC_REPOSITORY;
 	}
+
+	public static String getMojangHostMapping(ExtensionAware aware) {
+		if (aware.getExtensions().getExtraProperties().has("mojang_host_mapping")) {
+			return String.valueOf(aware.getExtensions().getExtraProperties().get("mojang_host_mapping"));
+		}
+
+		return null;
+	}
+
+	public static String applyMojangHostMapping(String content, ExtensionAware aware) {
+		String mapping = MirrorUtil.getMojangHostMapping(aware);
+		return mapping != null
+				? content.replaceAll("(piston-meta|piston-data|launchermeta)\\.mojang\\.com", mapping)
+				: content;
+	}
 }


### PR DESCRIPTION
Reason: Version manifests provided by some Minecraft mirror sites keeps orginal URL, which makes some users failed to download.

允许用户在下载 Minecraft 资源时更改下载域名

原因: 一些 Minecraft 镜像站提供的版本清单保留了原始 URL, 导致用户仍然无法下载