### PR TITLE
Fix getRuntimeRemapConfigurations() returning the wrong classpath.

### DIFF
--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -99,7 +99,7 @@ public interface LoomGradleExtensionAPI {
 	}
 
 	default List<RemapConfigurationSettings> getRuntimeRemapConfigurations() {
-		return getRemapConfigurations().stream().filter(element -> element.getOnCompileClasspath().get()).toList();
+		return getRemapConfigurations().stream().filter(element -> element.getOnRuntimeClasspath().get()).toList();
 	}
 
 	@ApiStatus.Experimental


### PR DESCRIPTION
Opps :) Fixes #759

Hopefully this doesnt cause any unexpected breaking changes going into 1.0?