### PR TITLE
Add getClientOnlySourceSetName

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftSourceSets.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftSourceSets.java
@@ -220,15 +220,15 @@ public abstract sealed class MinecraftSourceSets permits MinecraftSourceSets.Sin
 				// The client only sources to the combined sources jar.
 				jar.from(clientOnlySourceSet.getAllSource());
 			});
+
+			project.getTasks().withType(AbstractRemapJarTask.class, task -> {
+				// Set the default client only source set name
+				task.getClientOnlySourceSetName().convention(CLIENT_ONLY_SOURCE_SET_NAME);
+			});
 		}
 
 		@Override
 		public void afterEvaluate(Project project) {
-		}
-
-		public static SourceSet getClientSourceSet(Project project) {
-			Preconditions.checkArgument(LoomGradleExtension.get(project).areEnvironmentSourceSetsSplit(), "Cannot get client only sourceset as project is not split");
-			return SourceSetHelper.getSourceSetByName(CLIENT_ONLY_SOURCE_SET_NAME, project);
 		}
 	}
 }

--- a/src/main/java/net/fabricmc/loom/task/AbstractRemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractRemapJarTask.java
@@ -51,6 +51,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.build.event.BuildEventsListenerRegistry;
 import org.gradle.jvm.tasks.Jar;
@@ -106,6 +107,7 @@ public abstract class AbstractRemapJarTask extends Jar {
 	public abstract ListProperty<String> getAdditionalClientOnlyEntries();
 
 	@Input
+	@Optional
 	public abstract Property<String> getClientOnlySourceSetName();
 
 	private final Provider<JarManifestService> jarManifestServiceProvider;

--- a/src/main/java/net/fabricmc/loom/task/AbstractRemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractRemapJarTask.java
@@ -147,7 +147,6 @@ public abstract class AbstractRemapJarTask extends Jar {
 		});
 	}
 
-	@Internal
 	protected abstract List<String> getClientOnlyEntries(SourceSet sourceSet);
 
 	public interface AbstractRemapParams extends WorkParameters {

--- a/src/main/java/net/fabricmc/loom/task/AbstractRemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractRemapJarTask.java
@@ -51,6 +51,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.build.event.BuildEventsListenerRegistry;
 import org.gradle.jvm.tasks.Jar;
 import org.gradle.workers.WorkAction;
@@ -64,6 +65,7 @@ import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.task.service.JarManifestService;
 import net.fabricmc.loom.util.ZipReprocessorUtil;
 import net.fabricmc.loom.util.ZipUtils;
+import net.fabricmc.loom.util.gradle.SourceSetHelper;
 
 public abstract class AbstractRemapJarTask extends Jar {
 	public static final String MANIFEST_PATH = "META-INF/MANIFEST.MF";
@@ -103,6 +105,9 @@ public abstract class AbstractRemapJarTask extends Jar {
 	@Input
 	public abstract ListProperty<String> getAdditionalClientOnlyEntries();
 
+	@Input
+	public abstract Property<String> getClientOnlySourceSetName();
+
 	private final Provider<JarManifestService> jarManifestServiceProvider;
 
 	@Inject
@@ -132,7 +137,7 @@ public abstract class AbstractRemapJarTask extends Jar {
 			params.getJarManifestService().set(jarManifestServiceProvider);
 
 			if (getIncludesClientOnlyClasses().get()) {
-				final List<String> clientOnlyEntries = new ArrayList<>(getClientOnlyEntries());
+				final List<String> clientOnlyEntries = new ArrayList<>(getClientOnlyEntries(getClientSourceSet()));
 				clientOnlyEntries.addAll(getAdditionalClientOnlyEntries().get());
 				applyClientOnlyManifestAttributes(params, clientOnlyEntries);
 				params.getClientOnlyEntries().set(clientOnlyEntries.stream().filter(s -> s.endsWith(".class")).toList());
@@ -143,7 +148,7 @@ public abstract class AbstractRemapJarTask extends Jar {
 	}
 
 	@Internal
-	protected abstract List<String> getClientOnlyEntries();
+	protected abstract List<String> getClientOnlyEntries(SourceSet sourceSet);
 
 	public interface AbstractRemapParams extends WorkParameters {
 		RegularFileProperty getInputFile();
@@ -240,5 +245,10 @@ public abstract class AbstractRemapJarTask extends Jar {
 	@Internal
 	protected LoomGradleExtension getLoomExtension() {
 		return LoomGradleExtension.get(getProject());
+	}
+
+	private SourceSet getClientSourceSet() {
+		Preconditions.checkArgument(LoomGradleExtension.get(getProject()).areEnvironmentSourceSetsSplit(), "Cannot get client sourceset as project is not split");
+		return SourceSetHelper.getSourceSetByName(getClientOnlySourceSetName().get(), getProject());
 	}
 }

--- a/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
@@ -64,7 +64,6 @@ import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.build.nesting.IncludedJarFactory;
 import net.fabricmc.loom.build.nesting.JarNester;
 import net.fabricmc.loom.configuration.accesswidener.AccessWidenerFile;
-import net.fabricmc.loom.configuration.providers.minecraft.MinecraftSourceSets;
 import net.fabricmc.loom.extension.MixinExtension;
 import net.fabricmc.loom.task.service.TinyRemapperService;
 import net.fabricmc.loom.util.Constants;
@@ -321,9 +320,7 @@ public abstract class RemapJarTask extends AbstractRemapJarTask {
 	}
 
 	@Override
-	protected List<String> getClientOnlyEntries() {
-		final SourceSet clientSourceSet = MinecraftSourceSets.Split.getClientSourceSet(getProject());
-
+	protected List<String> getClientOnlyEntries(SourceSet clientSourceSet) {
 		final ConfigurableFileCollection output = getProject().getObjects().fileCollection();
 		output.from(clientSourceSet.getOutput().getClassesDirs());
 		output.from(clientSourceSet.getOutput().getResourcesDir());

--- a/src/main/java/net/fabricmc/loom/task/RemapSourcesJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapSourcesJarTask.java
@@ -38,7 +38,6 @@ import org.gradle.api.tasks.TaskAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import net.fabricmc.loom.configuration.providers.minecraft.MinecraftSourceSets;
 import net.fabricmc.loom.task.service.SourceRemapperService;
 import net.fabricmc.loom.util.service.BuildSharedServiceManager;
 import net.fabricmc.loom.util.service.UnsafeWorkQueueHelper;
@@ -62,9 +61,7 @@ public abstract class RemapSourcesJarTask extends AbstractRemapJarTask {
 	}
 
 	@Override
-	protected List<String> getClientOnlyEntries() {
-		final SourceSet clientSourceSet = MinecraftSourceSets.Split.getClientSourceSet(getProject());
-
+	protected List<String> getClientOnlyEntries(SourceSet clientSourceSet) {
 		return clientSourceSet.getAllSource().getFiles().stream()
 				.map(relativePath(getRootPaths(clientSourceSet.getAllSource().getSrcDirs())))
 				.toList();


### PR DESCRIPTION
Used to allow creating a split sources jar from the none defualt client sourcset. Use case is the fabric API testmod jar.