### PR TITLE
Include projects in jar processor inputs

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/processors/SpecContextImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/SpecContextImpl.java
@@ -46,6 +46,7 @@ import org.gradle.api.tasks.SourceSet;
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.RemapConfigurationSettings;
 import net.fabricmc.loom.api.processor.SpecContext;
+import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.fmj.FabricModJson;
 import net.fabricmc.loom.util.fmj.FabricModJsonFactory;
 import net.fabricmc.loom.util.gradle.GradleUtils;
@@ -78,9 +79,11 @@ public record SpecContextImpl(List<FabricModJson> modDependencies, List<FabricMo
 			}
 		}
 
-		// Add all the dependent projects
-		for (Project dependentProject : getDependentProjects(project).toList()) {
-			mods.addAll(getModsInProject(dependentProject));
+		if (!GradleUtils.getBooleanProperty(project, Constants.Properties.DISABLE_PROJECT_DEPENDENT_MODS)) {
+			// Add all the dependent projects
+			for (Project dependentProject : getDependentProjects(project).toList()) {
+				mods.addAll(getModsInProject(dependentProject));
+			}
 		}
 
 		return sorted(mods);

--- a/src/main/java/net/fabricmc/loom/configuration/processors/SpecContextImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/SpecContextImpl.java
@@ -38,6 +38,9 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.SourceSet;
 
 import net.fabricmc.loom.LoomGradleExtension;
@@ -45,17 +48,20 @@ import net.fabricmc.loom.api.RemapConfigurationSettings;
 import net.fabricmc.loom.api.processor.SpecContext;
 import net.fabricmc.loom.util.fmj.FabricModJson;
 import net.fabricmc.loom.util.fmj.FabricModJsonFactory;
+import net.fabricmc.loom.util.gradle.GradleUtils;
 import net.fabricmc.loom.util.gradle.SourceSetHelper;
 
 /**
  * @param modDependencies External mods that are depended on
- * @param localMods The main mod being built. In the future this may also include other mods.
+ * @param localMods Mods found in the current project.
+ * @param compileRuntimeMods Dependent mods found in both the compile and runtime classpath.
  */
 public record SpecContextImpl(List<FabricModJson> modDependencies, List<FabricModJson> localMods, List<FabricModJson> compileRuntimeMods) implements SpecContext {
 	public static SpecContextImpl create(Project project) {
-		return new SpecContextImpl(getDependentMods(project), getMods(project), getCompileRuntimeMods(project));
+		return new SpecContextImpl(getDependentMods(project), getModsInProject(project), getCompileRuntimeMods(project));
 	}
 
+	// Reruns a list of mods found on both the compile and/or runtime classpaths
 	private static List<FabricModJson> getDependentMods(Project project) {
 		final LoomGradleExtension extension = LoomGradleExtension.get(project);
 		var mods = new ArrayList<FabricModJson>();
@@ -72,12 +78,24 @@ public record SpecContextImpl(List<FabricModJson> modDependencies, List<FabricMo
 			}
 		}
 
-		// TODO supporting projects here should magically allow TAWs and what not to work across project deps :)
+		// Add all the dependent projects
+		for (Project dependentProject : getDependentProjects(project).toList()) {
+			mods.addAll(getModsInProject(dependentProject));
+		}
 
 		return sorted(mods);
 	}
 
-	private static List<FabricModJson> getMods(Project project) {
+	private static Stream<Project> getDependentProjects(Project project) {
+		final Stream<Project> runtimeProjects = getLoomProjectDependencies(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
+		final Stream<Project> compileProjects = getLoomProjectDependencies(project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
+
+		return Stream.concat(runtimeProjects, compileProjects)
+				.distinct();
+	}
+
+	// Returns a list of Mods found in the provided project
+	private static List<FabricModJson> getModsInProject(Project project) {
 		final LoomGradleExtension extension = LoomGradleExtension.get(project);
 		var sourceSets = new ArrayList<SourceSet>();
 		sourceSets.add(SourceSetHelper.getMainSourceSet(project));
@@ -99,7 +117,19 @@ public record SpecContextImpl(List<FabricModJson> modDependencies, List<FabricMo
 		return Collections.emptyList();
 	}
 
+	// Returns a list of mods that are on both to compile and runtime classpath
 	private static List<FabricModJson> getCompileRuntimeMods(Project project) {
+		var mods = new ArrayList<>(getCompileRuntimeModsFromRemapConfigs(project).toList());
+
+		for (Project dependentProject : getCompileRuntimeProjectDependencies(project).toList()) {
+			mods.addAll(getModsInProject(dependentProject));
+		}
+
+		return Collections.unmodifiableList(mods);
+	}
+
+	// Returns a list of jar mods that are found on the compile and runtime remapping configurations
+	private static Stream<FabricModJson> getCompileRuntimeModsFromRemapConfigs(Project project) {
 		final LoomGradleExtension extension = LoomGradleExtension.get(project);
 		final Function<RemapConfigurationSettings, Stream<Path>> resolve = settings ->
 				settings.getSourceConfiguration().get().resolve().stream()
@@ -115,8 +145,25 @@ public record SpecContextImpl(List<FabricModJson> modDependencies, List<FabricMo
 				.map(FabricModJsonFactory::createFromZipOptional)
 				.filter(Optional::isPresent)
 				.map(Optional::get)
-				.sorted(Comparator.comparing(FabricModJson::getId))
-				.toList();
+				.sorted(Comparator.comparing(FabricModJson::getId));
+	}
+
+	// Returns a list of Loom Projects found in both the runtime and compile classpath
+	private static Stream<Project> getCompileRuntimeProjectDependencies(Project project) {
+		final Stream<Project> runtimeProjects = getLoomProjectDependencies(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
+		final List<Project> compileProjects = getLoomProjectDependencies(project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)).toList();
+
+		return runtimeProjects
+				.filter(compileProjects::contains); // Use the intersection of the two configurations.
+	}
+
+	// Returns a list of Loom Projects found in the provided Configuration
+	private static Stream<Project> getLoomProjectDependencies(Configuration configuration) {
+		return configuration.getAllDependencies()
+				.withType(ProjectDependency.class)
+				.stream()
+				.map(ProjectDependency::getDependencyProject)
+				.filter(GradleUtils::isLoomProject);
 	}
 
 	// Sort to ensure stable caching

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -142,5 +142,6 @@ public class Constants {
 		public static final String MULTI_PROJECT_OPTIMISATION = "fabric.loom.multiProjectOptimisation";
 		public static final String DONT_REMAP = "fabric.loom.dontRemap";
 		public static final String DISABLE_REMAPPED_VARIANTS = "fabric.loom.disableRemappedVariants";
+		public static final String DISABLE_PROJECT_DEPENDENT_MODS = "fabric.loom.disableProjectDependentMods";
 	}
 }

--- a/src/main/java/net/fabricmc/loom/util/gradle/GradleUtils.java
+++ b/src/main/java/net/fabricmc/loom/util/gradle/GradleUtils.java
@@ -48,10 +48,14 @@ public final class GradleUtils {
 
 	public static void allLoomProjects(Gradle gradle, Consumer<Project> consumer) {
 		gradle.allprojects(project -> {
-			if (project.getPluginManager().hasPlugin("fabric-loom")) {
+			if (isLoomProject(project)) {
 				consumer.accept(project);
 			}
 		});
+	}
+
+	public static boolean isLoomProject(Project project) {
+		return project.getPluginManager().hasPlugin("fabric-loom");
 	}
 
 	public static Provider<Boolean> getBooleanPropertyProvider(Project project, String key) {

--- a/src/test/groovy/net/fabricmc/loom/test/LoomTestConstants.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/LoomTestConstants.groovy
@@ -27,7 +27,7 @@ package net.fabricmc.loom.test
 import org.gradle.util.GradleVersion
 
 class LoomTestConstants {
-    private final static String NIGHTLY_VERSION = "8.1-20221210231949+0000"
+    private final static String NIGHTLY_VERSION = "8.1-20221229234322+0000"
     private final static boolean NIGHTLY_EXISTS = nightlyExists(NIGHTLY_VERSION)
 
     public final static String DEFAULT_GRADLE = GradleVersion.current().getVersion()

--- a/src/test/resources/projects/multiproject/core/src/main/java/net/fabricmc/core/InjectedInterface.java
+++ b/src/test/resources/projects/multiproject/core/src/main/java/net/fabricmc/core/InjectedInterface.java
@@ -1,0 +1,6 @@
+package net.fabricmc.core;
+
+public interface InjectedInterface {
+	default void newMethodThatDidNotExist() {
+	}
+}

--- a/src/test/resources/projects/multiproject/core/src/main/resources/fabric.mod.json
+++ b/src/test/resources/projects/multiproject/core/src/main/resources/fabric.mod.json
@@ -29,5 +29,10 @@
   },
   "suggests": {
     "another-mod": "*"
+  },
+  "custom": {
+    "loom:injected_interfaces": {
+      "net/minecraft/class_2248": ["net/fabricmc/core/InjectedInterface"]
+    }
   }
 }

--- a/src/test/resources/projects/multiproject/example/src/main/java/net/fabricmc/example/ExampleMod.java
+++ b/src/test/resources/projects/multiproject/example/src/main/java/net/fabricmc/example/ExampleMod.java
@@ -4,6 +4,7 @@ import net.fabricmc.api.ModInitializer;
 import net.minecraft.block.BlockState;
 import techreborn.blocks.cable.CableShapeUtil;
 import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.block.Blocks;
 
 public class ExampleMod implements ModInitializer {
 	@Override
@@ -18,6 +19,9 @@ public class ExampleMod implements ModInitializer {
 			// Just here to make sure it compiles as named, not to test it runs
 			BlockState state = null;
 			VoxelShape shape = new CableShapeUtil(null).getShape(state);
+
+			// Interface is injected by another project that we are depending on.
+			Blocks.AIR.newMethodThatDidNotExist();
 		}
 	}
 }


### PR DESCRIPTION
This enables you to use injected interfaces or TAWs from other (sub)projects.

TODO:

- [x] Test it
- [x] Add an option to disable