### PR TITLE
Start looking at production run tasks

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/InstallerData.java
+++ b/src/main/java/net/fabricmc/loom/configuration/InstallerData.java
@@ -33,9 +33,10 @@ import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.LoomRepositoryPlugin;
 import net.fabricmc.loom.configuration.ide.idea.IdeaUtils;
+import net.fabricmc.loom.configuration.mods.ArtifactRef;
 import net.fabricmc.loom.util.Constants;
 
-public record InstallerData(String version, JsonObject installerJson) {
+public record InstallerData(ArtifactRef artifact, JsonObject installerJson) {
 	public void applyToProject(Project project) {
 		LoomGradleExtension extension = LoomGradleExtension.get(project);
 
@@ -75,5 +76,18 @@ public record InstallerData(String version, JsonObject installerJson) {
 				}
 			}
 		});
+	}
+
+	public String mainClass(Environment environment) {
+		return null;
+	}
+
+	public String version() {
+		return artifact.version();
+	}
+
+	public enum Environment {
+		CLIENT,
+		SERVER
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactMetadata.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactMetadata.java
@@ -70,7 +70,7 @@ public record ArtifactMetadata(boolean isFabricMod, RemapRequirements remapRequi
 
 			if (isFabricMod && Files.exists(installerPath)) {
 				final JsonObject jsonObject = LoomGradlePlugin.GSON.fromJson(Files.readString(installerPath, StandardCharsets.UTF_8), JsonObject.class);
-				installerData = new InstallerData(artifact.version(), jsonObject);
+				installerData = new InstallerData(artifact, jsonObject);
 			}
 		}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftProvider.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2018-2021 FabricMC
+ * Copyright (c) 2018-2022 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -257,6 +257,20 @@ public abstract class MinecraftProvider {
 
 	public MinecraftVersionMeta getVersionInfo() {
 		return versionInfo;
+	}
+
+	public String getAssetIndex() {
+		return getVersionInfo().assetIndex().fabricId(minecraftVersion());
+	}
+
+	public File getAssetsDirectory() {
+		File assetsDirectory = new File(getExtension().getFiles().getUserCache(), "assets");
+
+		if (versionInfo.assets().equals("legacy")) {
+			assetsDirectory = new File(assetsDirectory, "/legacy/" + versionInfo.id());
+		}
+
+		return assetsDirectory;
 	}
 
 	@Nullable

--- a/src/main/java/net/fabricmc/loom/task/AbstractLoomJavaExecTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractLoomJavaExecTask.java
@@ -1,0 +1,156 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2022 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.tasks.JavaExec;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An implementation of {@link JavaExec} that supports using arg files.
+ */
+public abstract class AbstractLoomJavaExecTask extends JavaExec {
+	// We control the classpath, as we use a ArgFile to pass it over the command line: https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javac.html#commandlineargfile
+	private final ConfigurableFileCollection classpath = getProject().getObjects().fileCollection();
+
+	private boolean canUseArgFile() {
+		// @-files were added for java (not javac) in Java 9, see https://bugs.openjdk.org/browse/JDK-8027634
+		return getJavaVersion().isJava9Compatible();
+	}
+
+	@Override
+	public void exec() {
+		if (canUseArgFile()) {
+			getProject().getLogger().debug("Using arg file for {}", getName());
+			// We're using an arg file, pass an empty classpath to the super JavaExec.
+			super.setClasspath(getProject().files());
+		} else {
+			getProject().getLogger().debug("Using bare classpath for {}", getName());
+			// The classpath is passed normally, so pass the full classpath to the super JavaExec.
+			super.setClasspath(classpath);
+		}
+
+		super.exec();
+	}
+
+	@Override
+	public List<String> getJvmArgs() {
+		final List<String> superArgs = super.getJvmArgs();
+		final List<String> args = new ArrayList<>();
+
+		if (canUseArgFile()) {
+			final String content = "-classpath\n" + this.classpath.getFiles().stream()
+					.map(File::getAbsolutePath)
+					.map(AbstractLoomJavaExecTask::quoteArg)
+					.collect(Collectors.joining(System.getProperty("path.separator")));
+
+			try {
+				final Path argsFile = Files.createTempFile("loom-classpath", ".args");
+				Files.writeString(argsFile, content, StandardCharsets.UTF_8);
+				args.add("@" + argsFile.toAbsolutePath());
+			} catch (IOException e) {
+				throw new UncheckedIOException("Failed to create classpath file", e);
+			}
+		}
+
+		if (superArgs != null) {
+			args.addAll(superArgs);
+		}
+
+		return args;
+	}
+
+	// Based off https://github.com/JetBrains/intellij-community/blob/295dd68385a458bdfde638152e36d19bed18b666/platform/util/src/com/intellij/execution/CommandLineWrapperUtil.java#L87
+	private static String quoteArg(String arg) {
+		final String specials = " #'\"\n\r\t\f";
+
+		if (!containsAnyChar(arg, specials)) {
+			return arg;
+		}
+
+		final StringBuilder sb = new StringBuilder(arg.length() * 2);
+
+		for (int i = 0; i < arg.length(); i++) {
+			char c = arg.charAt(i);
+
+			switch (c) {
+			case ' ', '#', '\'' -> sb.append('"').append(c).append('"');
+			case '"' -> sb.append("\"\\\"\"");
+			case '\n' -> sb.append("\"\\n\"");
+			case '\r' -> sb.append("\"\\r\"");
+			case '\t' -> sb.append("\"\\t\"");
+			case '\f' -> sb.append("\"\\f\"");
+			default -> sb.append(c);
+			}
+		}
+
+		return sb.toString();
+	}
+
+	// https://github.com/JetBrains/intellij-community/blob/295dd68385a458bdfde638152e36d19bed18b666/platform/util/base/src/com/intellij/openapi/util/text/Strings.java#L100-L118
+	private static boolean containsAnyChar(final @NotNull String value, final @NotNull String chars) {
+		return chars.length() > value.length()
+			? containsAnyChar(value, chars, 0, value.length())
+			: containsAnyChar(chars, value, 0, chars.length());
+	}
+
+	private static boolean containsAnyChar(final @NotNull String value, final @NotNull String chars, final int start, final int end) {
+		for (int i = start; i < end; i++) {
+			if (chars.indexOf(value.charAt(i)) >= 0) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	@Override
+	public @NotNull JavaExec setClasspath(@NotNull FileCollection classpath) {
+		this.classpath.setFrom(classpath);
+		return this;
+	}
+
+	@Override
+	public @NotNull JavaExec classpath(Object @NotNull... paths) {
+		this.classpath.from(paths);
+		return this;
+	}
+
+	@Override
+	public @NotNull ConfigurableFileCollection getClasspath() {
+		return this.classpath;
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2018-2021 FabricMC
+ * Copyright (c) 2018-2022 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,31 +25,22 @@
 package net.fabricmc.loom.task;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
+
+import javax.inject.Inject;
 
 import org.gradle.api.Project;
-import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.specs.Spec;
-import org.gradle.api.tasks.JavaExec;
-import org.jetbrains.annotations.NotNull;
 
 import net.fabricmc.loom.configuration.ide.RunConfig;
 import net.fabricmc.loom.util.Constants;
 
-public abstract class AbstractRunTask extends JavaExec {
+public abstract class AbstractRunTask extends AbstractLoomJavaExecTask {
 	private final RunConfig config;
-	// We control the classpath, as we use a ArgFile to pass it over the command line: https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javac.html#commandlineargfile
-	private final ConfigurableFileCollection classpath = getProject().getObjects().fileCollection();
 
+	@Inject
 	public AbstractRunTask(Function<Project, RunConfig> configProvider) {
 		super();
 		setGroup(Constants.TaskGroup.FABRIC);
@@ -61,23 +52,8 @@ public abstract class AbstractRunTask extends JavaExec {
 		getMainClass().set(config.mainClass);
 	}
 
-	private boolean canUseArgFile() {
-		// @-files were added for java (not javac) in Java 9, see https://bugs.openjdk.org/browse/JDK-8027634
-		return getJavaVersion().isJava9Compatible();
-	}
-
 	@Override
 	public void exec() {
-		if (canUseArgFile()) {
-			getProject().getLogger().debug("Using arg file for {}", getName());
-			// We're using an arg file, pass an empty classpath to the super JavaExec.
-			super.setClasspath(getProject().files());
-		} else {
-			getProject().getLogger().debug("Using bare classpath for {}", getName());
-			// The classpath is passed normally, so pass the full classpath to the super JavaExec.
-			super.setClasspath(classpath);
-		}
-
 		setWorkingDir(new File(getProject().getProjectDir(), config.runDir));
 		environment(config.environmentVariables);
 
@@ -95,91 +71,9 @@ public abstract class AbstractRunTask extends JavaExec {
 
 	@Override
 	public List<String> getJvmArgs() {
-		final List<String> superArgs = super.getJvmArgs();
-		final List<String> args = new ArrayList<>();
-
-		if (canUseArgFile()) {
-			final String content = "-classpath\n" + this.classpath.getFiles().stream()
-					.map(File::getAbsolutePath)
-					.map(AbstractRunTask::quoteArg)
-					.collect(Collectors.joining(System.getProperty("path.separator")));
-
-			try {
-				final Path argsFile = Files.createTempFile("loom-classpath", ".args");
-				Files.writeString(argsFile, content, StandardCharsets.UTF_8);
-				args.add("@" + argsFile.toAbsolutePath());
-			} catch (IOException e) {
-				throw new UncheckedIOException("Failed to create classpath file", e);
-			}
-		}
-
-		if (superArgs != null) {
-			args.addAll(superArgs);
-		}
-
+		final List<String> args = new ArrayList<>(super.getJvmArgs());
 		args.addAll(config.vmArgs);
 		return args;
-	}
-
-	// Based off https://github.com/JetBrains/intellij-community/blob/295dd68385a458bdfde638152e36d19bed18b666/platform/util/src/com/intellij/execution/CommandLineWrapperUtil.java#L87
-	private static String quoteArg(String arg) {
-		final String specials = " #'\"\n\r\t\f";
-
-		if (!containsAnyChar(arg, specials)) {
-			return arg;
-		}
-
-		final StringBuilder sb = new StringBuilder(arg.length() * 2);
-
-		for (int i = 0; i < arg.length(); i++) {
-			char c = arg.charAt(i);
-
-			switch (c) {
-			case ' ', '#', '\'' -> sb.append('"').append(c).append('"');
-			case '"' -> sb.append("\"\\\"\"");
-			case '\n' -> sb.append("\"\\n\"");
-			case '\r' -> sb.append("\"\\r\"");
-			case '\t' -> sb.append("\"\\t\"");
-			case '\f' -> sb.append("\"\\f\"");
-			default -> sb.append(c);
-			}
-		}
-
-		return sb.toString();
-	}
-
-	// https://github.com/JetBrains/intellij-community/blob/295dd68385a458bdfde638152e36d19bed18b666/platform/util/base/src/com/intellij/openapi/util/text/Strings.java#L100-L118
-	public static boolean containsAnyChar(final @NotNull String value, final @NotNull String chars) {
-		return chars.length() > value.length()
-				? containsAnyChar(value, chars, 0, value.length())
-				: containsAnyChar(chars, value, 0, chars.length());
-	}
-
-	public static boolean containsAnyChar(final @NotNull String value, final @NotNull String chars, final int start, final int end) {
-		for (int i = start; i < end; i++) {
-			if (chars.indexOf(value.charAt(i)) >= 0) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	@Override
-	public @NotNull JavaExec setClasspath(@NotNull FileCollection classpath) {
-		this.classpath.setFrom(classpath);
-		return this;
-	}
-
-	@Override
-	public @NotNull JavaExec classpath(Object @NotNull... paths) {
-		this.classpath.from(paths);
-		return this;
-	}
-
-	@Override
-	public @NotNull FileCollection getClasspath() {
-		return this.classpath;
 	}
 
 	private class LibraryFilter implements Spec<File> {

--- a/src/main/java/net/fabricmc/loom/task/prod/AbstractProdRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/prod/AbstractProdRunTask.java
@@ -1,0 +1,93 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2022 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.prod;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import org.jetbrains.annotations.ApiStatus;
+
+import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.configuration.InstallerData;
+import net.fabricmc.loom.task.AbstractLoomJavaExecTask;
+
+public abstract class AbstractProdRunTask extends AbstractLoomJavaExecTask {
+	@Input
+	public abstract ConfigurableFileCollection getMods();
+
+	@Inject
+	public AbstractProdRunTask() {
+		setWorkingDir(getProject().file("run"));
+	}
+
+	@Override
+	public void exec() {
+		getWorkingDir().mkdirs();
+		super.exec();
+	}
+
+	@Override
+	public List<String> getJvmArgs() {
+		List<String> jvmArgs = new ArrayList<>(super.getJvmArgs());
+
+		final String mods = getMods().getFiles().stream()
+				.map(File::getAbsolutePath)
+				.collect(Collectors.joining(File.pathSeparator));
+
+		// TODO ideally needs to go in the args file, AbstractLoomJavaExecTask needs a bit of refactoring
+		jvmArgs.add("-Dfabric.addMods=" + mods);
+
+		return jvmArgs;
+	}
+
+	@Internal
+	protected Provider<FileCollection> dependencyProvider(Provider<String> dependencyNotationProvider) {
+		return getProject().provider(() -> {
+			return getProject().getConfigurations().detachedConfiguration(
+					getProject().getDependencies().create(dependencyNotationProvider.get())
+			);
+		});
+	}
+
+	@Internal
+	@ApiStatus.Internal
+	protected String getMinecraftVersion() {
+		return LoomGradleExtension.get(getProject()).getMinecraftProvider().minecraftVersion();
+	}
+
+	@Internal
+	protected InstallerData getFabricLoaderData() {
+		return LoomGradleExtension.get(getProject()).getInstallerData();
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/prod/ProdRunClientTask.java
+++ b/src/main/java/net/fabricmc/loom/task/prod/ProdRunClientTask.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2022 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.prod;
+
+import javax.inject.Inject;
+
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.ConfigurableFileCollection;
+
+import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.configuration.InstallerData;
+import net.fabricmc.loom.util.Constants;
+
+public abstract class ProdRunClientTask extends AbstractProdRunTask {
+	@Inject
+	public ProdRunClientTask() {
+		super();
+		dependsOn("configureClientLaunch");
+		final ConfigurationContainer configurations = getProject().getConfigurations();
+
+		getClasspath().from(getFabricLoaderData().artifact().path().toFile());
+		getClasspath().from(configurations.named(Constants.Configurations.MINECRAFT_DEPENDENCIES));
+		getClasspath().from(configurations.named(Constants.Configurations.MINECRAFT_RUNTIME_DEPENDENCIES));
+		getClasspath().from(configurations.named(Constants.Configurations.LOADER_DEPENDENCIES));
+		// TODO this wont use any custom intermediary versions
+		getClasspath().from(configurations.detachedConfiguration(
+				getProject().getDependencies().create("net.fabrimc:intermediary:" + getMinecraftVersion())
+		));
+	}
+
+	@Override
+	public void exec() {
+		final LoomGradleExtension extension = LoomGradleExtension.get(getProject());
+
+		getMainClass().convention(getFabricLoaderData().mainClass(InstallerData.Environment.CLIENT));
+		// TODO dont duplicate this with the DLI config?
+		args("--assetIndex", extension.getMinecraftProvider().getAssetIndex());
+		args("--assetsDir", extension.getMinecraftProvider().getAssetIndex());
+		args("--gameDir", getWorkingDir());
+
+		final ConfigurableFileCollection classpath = getClasspath();
+
+		classpath.from(extension.getMinecraftProvider().getMinecraftClientJar());
+
+		super.exec();
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/prod/ProdRunServerTask.java
+++ b/src/main/java/net/fabricmc/loom/task/prod/ProdRunServerTask.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2022 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.prod;
+
+import java.io.File;
+import java.io.IOException;
+
+import javax.inject.Inject;
+
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.jetbrains.annotations.ApiStatus;
+
+import net.fabricmc.loom.task.AbstractLoomTask;
+import net.fabricmc.loom.util.ZipUtils;
+
+public abstract class ProdRunServerTask extends AbstractProdRunTask {
+	@Nested
+	public abstract Property<String> getInstallerVersion();
+
+	@Inject
+	public ProdRunServerTask() {
+		final var propertiesJarTask = getProject().getTasks().register(getName() + "ServerPropertiesJar", ServerPropertiesJarTask.class, task -> {
+			task.getMinecraftVersion().convention(getMinecraftVersion());
+			task.getFabricLoaderVersion().convention(getFabricLoaderData().version());
+			task.getOutput().set(new File(getWorkingDir(), ".fabric/server-properties.jar"));
+		});
+
+		// Add the installer server launcher and jar containing the properties to the classpath
+		getClasspath().from(propertiesJarTask.map(ServerPropertiesJarTask::getOutput));
+		getClasspath().from(dependencyProvider(getInstallerVersion().map("net.fabricmc:fabric-installer:%s:server"::formatted)));
+	}
+
+	// Small task to generate the install.properties used by the server launcher
+	@ApiStatus.Internal
+	public abstract static class ServerPropertiesJarTask extends AbstractLoomTask {
+		private static final String INSTALL_PROPERTIES_NAME = "install.properties";
+
+		@Input
+		public abstract Property<String> getFabricLoaderVersion();
+
+		@Input
+		public abstract Property<String> getMinecraftVersion();
+
+		@OutputFile
+		public abstract RegularFileProperty getOutput();
+
+		@TaskAction
+		public void run() throws IOException {
+			final String content = String.join(
+					"\n",
+					"fabric-loader-version=" + getFabricLoaderVersion().get(),
+					"game-version=" + getMinecraftVersion().get()
+			);
+
+			ZipUtils.add(getOutput().get().getAsFile().toPath(), INSTALL_PROPERTIES_NAME, content);
+		}
+	}
+}


### PR DESCRIPTION
Production run tasks, will require manual registration. Somewhat similar to what I did in API here: https://github.com/FabricMC/fabric/blob/1.19.3/build.gradle#L408-L489

Closes https://github.com/FabricMC/fabric-loom/issues/90

TODO:

- Tests
- Documentation
- Run client test on GHA? (WIll need splitting out of the other tests)
- Refactor `AbstractLoomJavaExecTask` to put all args in the args file
- Support older versions in client prod run test + remove duplication with GenerateDLIConfigTask
- Possibly fix/refactor custom intermediary providers to work witht this? (How will this work for the server test?)

Out of scope:

- Debugging support/remapping
- MS auth