### PR TITLE
Disallow insecure downloads

### DIFF
--- a/src/test/groovy/net/fabricmc/loom/test/unit/download/DownloadFileTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/download/DownloadFileTest.groovy
@@ -339,6 +339,15 @@ class DownloadFileTest extends DownloadTest {
 			Files.readAllBytes(output) == data
 	}
 
+	def "File: Insecure protocol"() {
+		setup:
+			def output = new File(File.createTempDir(), "file").toPath()
+		when:
+			def result = Download.create("http://fabricmc.net").downloadPath(output)
+		then:
+			thrown IllegalArgumentException
+	}
+
 	// Known
 	def "Download Mojang Mappings"() {
 		setup:

--- a/src/test/groovy/net/fabricmc/loom/test/unit/download/DownloadStringTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/download/DownloadStringTest.groovy
@@ -109,4 +109,11 @@ class DownloadStringTest extends DownloadTest {
 		then:
 			result == "Hello World!"
 	}
+
+	def "String: Insecure protocol"() {
+		when:
+			def result = Download.create("http://fabricmc.net").downloadString()
+		then:
+			thrown IllegalArgumentException
+	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/unit/download/DownloadTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/download/DownloadTest.groovy
@@ -29,7 +29,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 abstract class DownloadTest extends Specification {
-	static final String PATH = "http://localhost:9081"
+	static final String PATH = "http://127.0.0.1:9081"
 
 	@Shared
 	Javalin server = Javalin.create { config ->


### PR DESCRIPTION
This uses the same logic used by gradle (for maven repositories).

All downloads should already be done over https. Unsecure downloads are allowed only from `127.0.0.1` 

See: https://github.com/gradle/gradle/blob/master/subprojects/base-services/src/main/java/org/gradle/util/internal/GUtil.java#L530-L548