### PR TITLE
Add ability to mark client config as authenticated using DevLogin

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
@@ -105,6 +105,13 @@ public class LoomRepositoryPlugin implements Plugin<PluginAware> {
 			repo.patternLayout(layout -> layout.artifact("[revision]/[artifact](-[classifier])(.[ext])"));
 			repo.metadataSources(IvyArtifactRepository.MetadataSources::artifact);
 		});
+
+		// Add covers1624 repo for DevLogin runtime dependency
+		repositories.maven(repo -> {
+			repo.setName("Covers1624");
+			repo.setUrl("https://maven.covers1624.net");
+			repo.mavenContent(content -> content.includeGroup("net.covers1624"));
+		});
 	}
 
 	public static void setupForLegacyVersions(Project project) {

--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -48,6 +48,7 @@ import net.fabricmc.loom.build.mixin.KaptApInvoker;
 import net.fabricmc.loom.build.mixin.ScalaApInvoker;
 import net.fabricmc.loom.configuration.accesswidener.AccessWidenerJarProcessor;
 import net.fabricmc.loom.configuration.accesswidener.TransitiveAccessWidenerJarProcessor;
+import net.fabricmc.loom.configuration.ide.RunConfigSettings;
 import net.fabricmc.loom.configuration.ifaceinject.InterfaceInjectionProcessor;
 import net.fabricmc.loom.configuration.processors.JarProcessorManager;
 import net.fabricmc.loom.configuration.processors.ModJavadocProcessor;
@@ -117,8 +118,12 @@ public final class CompileConfiguration {
 		project.getDependencies().add(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME, Constants.Dependencies.JETBRAINS_ANNOTATIONS + Constants.Dependencies.Versions.JETBRAINS_ANNOTATIONS);
 		project.getDependencies().add(JavaPlugin.TEST_COMPILE_ONLY_CONFIGURATION_NAME, Constants.Dependencies.JETBRAINS_ANNOTATIONS + Constants.Dependencies.Versions.JETBRAINS_ANNOTATIONS);
 
-		// Add DevLogin to runtimeClasspath configuration
-		project.getDependencies().add(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME, Constants.Dependencies.DEV_LOGIN + Constants.Dependencies.Versions.DEV_LOGIN);
+		project.afterEvaluate(prj -> {
+			if (extension.getRunConfigs().stream().anyMatch(RunConfigSettings::isAuthenticated)) {
+				// Add DevLogin to runtimeClasspath configuration
+				prj.getDependencies().add(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME, Constants.Dependencies.DEV_LOGIN + Constants.Dependencies.Versions.DEV_LOGIN);
+			}
+		});
 	}
 
 	public static void configureCompile(Project project) {

--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -116,6 +116,9 @@ public final class CompileConfiguration {
 		project.getDependencies().add(Constants.Configurations.LOOM_DEVELOPMENT_DEPENDENCIES, Constants.Dependencies.TERMINAL_CONSOLE_APPENDER + Constants.Dependencies.Versions.TERMINAL_CONSOLE_APPENDER);
 		project.getDependencies().add(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME, Constants.Dependencies.JETBRAINS_ANNOTATIONS + Constants.Dependencies.Versions.JETBRAINS_ANNOTATIONS);
 		project.getDependencies().add(JavaPlugin.TEST_COMPILE_ONLY_CONFIGURATION_NAME, Constants.Dependencies.JETBRAINS_ANNOTATIONS + Constants.Dependencies.Versions.JETBRAINS_ANNOTATIONS);
+
+		// Add DevLogin to runtimeClasspath configuration
+		project.getDependencies().add(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME, Constants.Dependencies.DEV_LOGIN + Constants.Dependencies.Versions.DEV_LOGIN);
 	}
 
 	public static void configureCompile(Project project) {

--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
@@ -183,25 +183,28 @@ public class RunConfig {
 		runConfig.environmentVariables.putAll(settings.getEnvironmentVariables());
 		runConfig.projectName = project.getName();
 
-		if(settings.isAuthenticated()) {
-			var oldMain = runConfig.mainClass;
+		if (settings.isAuthenticated()) {
+			String oldMain = runConfig.mainClass;
 			runConfig.mainClass = "net.covers1624.devlogin.DevLogin";
-			var addArg = true;
+			boolean addArg = true;
 
 			// DevLogin uses `--launch_target <main>` to invoke the original main class
 			// if param exists for what ever reason, swap out its current value to what it should be
 			// if it doesnt exist, add it
-			for(var i = 0; i < runConfig.programArgs.size(); i++) {
-				if(runConfig.programArgs.get(i).equalsIgnoreCase("--launch_target")) {
-					if(i + 1 < runConfig.programArgs.size()) runConfig.programArgs.set(i, oldMain);
-					else runConfig.programArgs.add(oldMain);
+			for (int i = 0; i < runConfig.programArgs.size(); i++) {
+				if (runConfig.programArgs.get(i).equalsIgnoreCase("--launch_target")) {
+					if (i + 1 < runConfig.programArgs.size()) {
+						runConfig.programArgs.set(i, oldMain);
+					} else {
+						runConfig.programArgs.add(oldMain);
+					}
 
 					addArg = false;
 					break;
 				}
 			}
 
-			if(addArg) {
+			if (addArg) {
 				runConfig.programArgs.add("--launch_target");
 				runConfig.programArgs.add(oldMain);
 			}

--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
@@ -183,6 +183,30 @@ public class RunConfig {
 		runConfig.environmentVariables.putAll(settings.getEnvironmentVariables());
 		runConfig.projectName = project.getName();
 
+		if(settings.isAuthenticated()) {
+			var oldMain = runConfig.mainClass;
+			runConfig.mainClass = "net.covers1624.devlogin.DevLogin";
+			var addArg = true;
+
+			// DevLogin uses `--launch_target <main>` to invoke the original main class
+			// if param exists for what ever reason, swap out its current value to what it should be
+			// if it doesnt exist, add it
+			for(var i = 0; i < runConfig.programArgs.size(); i++) {
+				if(runConfig.programArgs.get(i).equalsIgnoreCase("--launch_target")) {
+					if(i + 1 < runConfig.programArgs.size()) runConfig.programArgs.set(i, oldMain);
+					else runConfig.programArgs.add(oldMain);
+
+					addArg = false;
+					break;
+				}
+			}
+
+			if(addArg) {
+				runConfig.programArgs.add("--launch_target");
+				runConfig.programArgs.add(oldMain);
+			}
+		}
+
 		return runConfig;
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
@@ -95,6 +95,12 @@ public final class RunConfigSettings implements Named {
 	 * <p>By default only run configs on the root project will be generated.
 	 */
 	private boolean ideConfigGenerated;
+	/**
+	 * When true will use <a href="https://github.com/covers1624/DevLogin#devlogin">DevLogin</a> and attempt to authenticate against Mojang account servers.
+	 * <p>
+	 * Only affective for client configs
+	 */
+	private boolean authenticated = false;
 
 	private final Map<String, Object> environmentVariables = new HashMap<>();
 
@@ -316,5 +322,17 @@ public final class RunConfigSettings implements Named {
 
 	public void setIdeConfigGenerated(boolean ideConfigGenerated) {
 		this.ideConfigGenerated = ideConfigGenerated;
+	}
+
+	public void authenticated() {
+		setAuthenticated(true);
+	}
+
+	public void setAuthenticated(boolean authenticated) {
+		this.authenticated = authenticated;
+	}
+
+	public boolean isAuthenticated() {
+		return environment.equalsIgnoreCase("client") && authenticated;
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
@@ -97,8 +97,8 @@ public final class RunConfigSettings implements Named {
 	private boolean ideConfigGenerated;
 	/**
 	 * When true will use <a href="https://github.com/covers1624/DevLogin#devlogin">DevLogin</a> and attempt to authenticate against Mojang account servers.
-	 * <p>
-	 * Only affective for client configs
+	 *
+	 * <p>Only affective for client configs
 	 */
 	private boolean authenticated = false;
 

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -85,6 +85,7 @@ public class Constants {
 		public static final String TERMINAL_CONSOLE_APPENDER = "net.minecrell:terminalconsoleappender:";
 		public static final String JETBRAINS_ANNOTATIONS = "org.jetbrains:annotations:";
 		public static final String NATIVE_SUPPORT = "net.fabricmc:fabric-loom-native-support:";
+		public static final String DEV_LOGIN = "net.covers1624:DevLogin:";
 
 		private Dependencies() {
 		}
@@ -98,6 +99,7 @@ public class Constants {
 			public static final String TERMINAL_CONSOLE_APPENDER = "1.2.0";
 			public static final String JETBRAINS_ANNOTATIONS = "23.0.0";
 			public static final String NATIVE_SUPPORT_VERSION = "1.0.1";
+			public static final String DEV_LOGIN = "0.1.0.2";
 
 			private Versions() {
 			}


### PR DESCRIPTION
This PR brings the ability to mark client run configs as being authenticated. These configs use Covers1624 DevLogin tool to login & authenticate against Mojangs account servers on launch.

See [here](https://github.com/covers1624/DevLogin#devlogin) for more details on DevLogin.

---

I have added Covers maven repo to be able to pull in the DevLogin jar, and have needed to change the main class for the client run config generated to `net.covers1624.devlogin.DevLogin` aswell as append a new program arg `--launch_target <original main>`.
[_Following the [wiki](https://github.com/covers1624/DevLogin/wiki/ForgeGradle-Setup) as a setup guide_]

---

To mark a config as being authenticated the user must specify `authenticated` in their gradle file like so
```groovy
loom {
	runs {
		client {
			// ...
			authenticated()
			// ...
		}
	}
}
```