### PR TITLE
Use soft reference for shared service caching

### DIFF
--- a/src/test/groovy/net/fabricmc/loom/test/integration/MultiMcVersionTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/MultiMcVersionTest.groovy
@@ -1,0 +1,61 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016-2023 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.integration
+
+import net.fabricmc.loom.test.util.GradleProjectTestTrait
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static net.fabricmc.loom.test.LoomTestConstants.STANDARD_TEST_VERSIONS
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class MultiMcVersionTest extends Specification implements GradleProjectTestTrait {
+	@Unroll
+	def "build (gradle #version)"() {
+		setup:
+			def gradle = gradleProject(project: "multi-mc-versions", version: version)
+
+		when:
+			def result = gradle.run(tasks: "build")
+
+		then:
+			def versions = [
+					'fabric-1.14.4',
+					'fabric-1.15', 'fabric-1.15.2',
+					'fabric-1.16', 'fabric-1.16.5',
+					'fabric-1.17', 'fabric-1.17.1',
+					'fabric-1.18', 'fabric-1.18.2',
+					'fabric-1.19', 'fabric-1.19.3'
+			]
+
+			result.task(":build").outcome == SUCCESS
+			versions.forEach {
+				result.task(":$it:build").outcome == SUCCESS
+			}
+
+		where:
+			version << STANDARD_TEST_VERSIONS
+	}
+}

--- a/src/test/resources/projects/multi-mc-versions/build.gradle
+++ b/src/test/resources/projects/multi-mc-versions/build.gradle
@@ -1,0 +1,56 @@
+import groovy.json.JsonSlurper
+
+plugins {
+	id "java"
+	id 'fabric-loom' apply false
+}
+
+allprojects {
+	group = project.maven_group
+	version = project.mod_version
+}
+
+ext {
+	yarnMeta = new JsonSlurper().parse(new URL("https://meta.fabricmc.net/v2/versions/yarn"))
+}
+
+def getMappingVersion(String mcVersion) {
+	return rootProject.yarnMeta.find { it.gameVersion == mcVersion }.version
+}
+
+subprojects {
+	apply plugin: "fabric-loom"
+
+	archivesBaseName = rootProject.name + "-" + project.name
+
+	def minecraft_version = project.name.substring(7)
+	def yarn_mappings = getMappingVersion(minecraft_version)
+
+	dependencies {
+		// To change the versions see the gradle.properties files
+		minecraft "com.mojang:minecraft:$minecraft_version"
+		mappings "net.fabricmc:yarn:$yarn_mappings:v2"
+		modImplementation "net.fabricmc:fabric-loader:$loader_version"
+	}
+
+	jar {
+		archiveClassifier.set "dev"
+	}
+
+	// Just use the source from the root project
+	compileJava {
+		source(sourceSets.main.java.srcDirs)
+	}
+
+	processResources {
+		from(rootProject.sourceSets.main.resources)
+		inputs.property 'version', project.version
+
+		filesMatching("fabric.mod.json") {
+			expand 'version': project.version, 'minecraft_version': minecraft_version, 'loader_version': project.loader_version
+		}
+	}
+}
+
+compileJava.enabled = false
+processResources.enabled = false

--- a/src/test/resources/projects/multi-mc-versions/gradle.properties
+++ b/src/test/resources/projects/multi-mc-versions/gradle.properties
@@ -1,0 +1,9 @@
+# The project should pass the build with these setting
+org.gradle.jvmargs=-Xmx2560M
+org.gradle.workers.max=3
+
+mod_version = 1.0.0
+maven_group = com.example
+archives_base_name = example-mod
+
+loader_version=0.14.12

--- a/src/test/resources/projects/multi-mc-versions/settings.gradle
+++ b/src/test/resources/projects/multi-mc-versions/settings.gradle
@@ -1,0 +1,9 @@
+rootProject.name = "multi-mc-versions"
+
+// Yes lot of mc version
+include 'fabric-1.14.4'
+include 'fabric-1.15', 'fabric-1.15.2'
+include 'fabric-1.16', 'fabric-1.16.5'
+include 'fabric-1.17', 'fabric-1.17.1'
+include 'fabric-1.18', 'fabric-1.18.2'
+include 'fabric-1.19', 'fabric-1.19.3'

--- a/src/test/resources/projects/multi-mc-versions/src/main/java/com/example/examplemod/ExampleMod.java
+++ b/src/test/resources/projects/multi-mc-versions/src/main/java/com/example/examplemod/ExampleMod.java
@@ -1,0 +1,19 @@
+package com.example.examplemod;
+
+import net.fabricmc.api.ModInitializer;
+import net.minecraft.block.GrassBlock;
+import net.minecraft.client.MinecraftClient;
+
+public class ExampleMod implements ModInitializer {
+	@Override
+	public void onInitialize() {
+		// class_2372 grassBlock = (class_2372) class_2246.field_10219;
+		GrassBlock grassBlock = (GrassBlock) net.minecraft.block.Blocks.GRASS_BLOCK;
+		// class_310 mincecraft = class_310.method_1551();
+		MinecraftClient minecraft = MinecraftClient.getInstance();
+
+		System.out.println("Hello Fabric world!");
+		System.out.println("This is a grass block: " + grassBlock);
+		System.out.println("This is minecraft client: " + minecraft);
+	}
+}

--- a/src/test/resources/projects/multi-mc-versions/src/main/resources/fabric.mod.json
+++ b/src/test/resources/projects/multi-mc-versions/src/main/resources/fabric.mod.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "id": "example-mod",
+  "version": "${version}",
+  "name": "Example Mod",
+  "description": "This is an example description! Tell everyone what your mod is about!",
+  "authors": [
+    "Me!"
+  ],
+  "contact": {
+    "homepage": "https://fabricmc.net/",
+    "sources": "https://github.com/FabricMC/fabric-example-mod"
+  },
+  "license": "CC0-1.0",
+  "environment": "client",
+  "entrypoints": {
+    "main": [
+      "com.example.examplemod.ExampleMod"
+    ]
+  },
+  "depends": {
+    "fabricloader": ">=${loader_version}",
+    "minecraft": "${minecraft_version}"
+  }
+}


### PR DESCRIPTION
This would allow JVM garbage collector clear inactive shared services on demand, eg. when heap memory runs out. Making it possible to build large projects with different mc versions (They can't share remapper service). It should achieve similar effects to #772 without breaking functionality.