### PR TITLE
fix: Colored logging in neovim

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/GenVsCodeProjectTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenVsCodeProjectTask.java
@@ -123,7 +123,7 @@ public class GenVsCodeProjectTask extends AbstractLoomTask {
 		public String name;
 		public String request = "launch";
 		public String cwd;
-		public String console = "internalConsole";
+		public String console = "integratedTerminal";
 		public boolean stopOnEntry = false;
 		public String mainClass;
 		public String vmArgs;


### PR DESCRIPTION
Fix for #794

Example of how it looks in NeoVim:
![Screenshot from 2023-01-09 23-54-06](https://user-images.githubusercontent.com/52473614/211465509-0a38d89d-74da-4b4c-8133-9ae1ab11de22.png)

Example of how it looks in VSCodium:
![Screenshot from 2023-01-09 23-55-31](https://user-images.githubusercontent.com/52473614/211465587-a63d6337-d09f-4a9a-b43e-e56305035fdb.png)