### PR TITLE
Add RemapConfigurationSettings.getApplyDependencyTransforms to close #797

### DIFF
--- a/src/main/java/net/fabricmc/loom/api/RemapConfigurationSettings.java
+++ b/src/main/java/net/fabricmc/loom/api/RemapConfigurationSettings.java
@@ -60,6 +60,7 @@ public abstract class RemapConfigurationSettings implements Named {
 		getOnCompileClasspath().finalizeValueOnRead();
 		getOnRuntimeClasspath().finalizeValueOnRead();
 		getPublishingMode().convention(PublishingMode.NONE).finalizeValueOnRead();
+		getApplyDependencyTransforms().convention(defaultDependencyTransforms()).finalizeValueOnRead();
 	}
 
 	@Override
@@ -99,6 +100,11 @@ public abstract class RemapConfigurationSettings implements Named {
 	 * @return the {@link PublishingMode} for the configuration.
 	 */
 	public abstract Property<PublishingMode> getPublishingMode();
+
+	/**
+	 * @return true when dependencies should be evaluated for minecraft jar transforms such as transitive Access Wideners or Injected interfaces.
+	 */
+	public abstract Property<Boolean> getApplyDependencyTransforms();
 
 	public enum PublishingMode {
 		NONE,
@@ -173,5 +179,9 @@ public abstract class RemapConfigurationSettings implements Named {
 	@Internal
 	private NamedDomainObjectProvider<Configuration> getConfigurationByName(String name) {
 		return getProject().getConfigurations().named(name);
+	}
+
+	private Provider<Boolean> defaultDependencyTransforms() {
+		return getSourceSet().map(sourceSet -> sourceSet.getName().equals(SourceSet.MAIN_SOURCE_SET_NAME) || sourceSet.getName().equals("client"));
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/processors/SpecContextImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/SpecContextImpl.java
@@ -113,10 +113,12 @@ public record SpecContextImpl(List<FabricModJson> modDependencies, List<FabricMo
 						.map(File::toPath);
 
 		final List<Path> runtimeEntries = extension.getRuntimeRemapConfigurations().stream()
+				.filter(settings -> settings.getApplyDependencyTransforms().get())
 				.flatMap(resolve)
 				.toList();
 
 		return extension.getCompileRemapConfigurations().stream()
+				.filter(settings -> settings.getApplyDependencyTransforms().get())
 				.flatMap(resolve)
 				.filter(runtimeEntries::contains) // Use the intersection of the two configurations.
 				.map(FabricModJsonFactory::createFromZipOptional)


### PR DESCRIPTION
Closes #797

By default this will no longer apply transitive access widners or injected interfaces found in mods from remapping configurations other than `main` or `client`. An API is provided to allow opting back into this behaviour.

This is technically a breaking change, but I dont think many if anyone depended on this odd behaviour.