### PR TITLE
Add Eclipse to ANSI-supporting IDEs

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/launch/GenerateDLIConfigTask.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/GenerateDLIConfigTask.java
@@ -85,6 +85,7 @@ public abstract class GenerateDLIConfigTask extends AbstractLoomTask {
 		final boolean plainConsole = getProject().getGradle().getStartParameter().getConsoleOutput() == ConsoleOutput.Plain;
 		final boolean ansiSupportedIDE = new File(getProject().getRootDir(), ".vscode").exists()
 				|| new File(getProject().getRootDir(), ".idea").exists()
+				|| new File(getProject().getRootDir(), ".project").exists()
 				|| (Arrays.stream(getProject().getRootDir().listFiles()).anyMatch(file -> file.getName().endsWith(".iws")));
 
 		//Enable ansi by default for idea and vscode when gradle is not ran with plain console.


### PR DESCRIPTION
This pull request fixes #726.
It's hard to think of an IDE that doesn't support it now.

Supersedes #727. I had to create another pull request because you can't change the source branch :(