### PR TITLE
Rewrite the internals of mod configuration remapping to fix bugs

### DIFF
--- a/src/main/java/net/fabricmc/loom/api/RemapConfigurationSettings.java
+++ b/src/main/java/net/fabricmc/loom/api/RemapConfigurationSettings.java
@@ -28,21 +28,16 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import com.google.common.base.Preconditions;
 import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.Property;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.SourceSet;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
-
-import net.fabricmc.loom.LoomGradleExtension;
-import net.fabricmc.loom.configuration.providers.minecraft.MinecraftJarConfiguration;
 
 /**
  * A {@link Named} object for configuring "proxy" configurations that remap artifacts.

--- a/src/main/java/net/fabricmc/loom/api/RemapConfigurationSettings.java
+++ b/src/main/java/net/fabricmc/loom/api/RemapConfigurationSettings.java
@@ -128,46 +128,8 @@ public abstract class RemapConfigurationSettings implements Named {
 
 	@ApiStatus.Internal
 	@Internal
-	public final Provider<String> getClientRemappedConfigurationName() {
-		return getClientSourceConfigurationName().map(s -> s + "Mapped");
-	}
-
-	@ApiStatus.Internal
-	@Internal
 	public final NamedDomainObjectProvider<Configuration> getSourceConfiguration() {
 		return getConfigurationByName(getName());
-	}
-
-	@ApiStatus.Internal
-	@Internal
-	public final NamedDomainObjectProvider<Configuration> getRemappedConfiguration() {
-		return getConfigurationByName(getRemappedConfigurationName());
-	}
-
-	@ApiStatus.Internal
-	@Internal
-	public final NamedDomainObjectProvider<Configuration> getTargetConfiguration() {
-		return getConfigurationByName(getTargetConfigurationName().get());
-	}
-
-	@ApiStatus.Internal
-	@Internal
-	public final Provider<Configuration> getClientTargetConfiguration() {
-		return getProject().provider(() -> {
-			boolean split = LoomGradleExtension.get(getProject()).getMinecraftJarConfiguration().get() == MinecraftJarConfiguration.SPLIT;
-			Preconditions.checkArgument(split, "Cannot get client target configuration when project is not split");
-			return getConfigurationByName(getClientSourceConfigurationName().get()).get();
-		});
-	}
-
-	@ApiStatus.Internal
-	@Internal
-	public final Provider<Configuration> getClientRemappedConfiguration() {
-		return getProject().provider(() -> {
-			boolean split = LoomGradleExtension.get(getProject()).getMinecraftJarConfiguration().get() == MinecraftJarConfiguration.SPLIT;
-			Preconditions.checkArgument(split, "Cannot get client remapped configuration when project is not split");
-			return getConfigurationByName(getClientRemappedConfigurationName().get()).get();
-		});
 	}
 
 	@Internal

--- a/src/main/java/net/fabricmc/loom/api/RemapConfigurationSettings.java
+++ b/src/main/java/net/fabricmc/loom/api/RemapConfigurationSettings.java
@@ -34,6 +34,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.SourceSet;
 import org.jetbrains.annotations.ApiStatus;

--- a/src/main/java/net/fabricmc/loom/api/RemapConfigurationSettings.java
+++ b/src/main/java/net/fabricmc/loom/api/RemapConfigurationSettings.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2022 FabricMC
+ * Copyright (c) 2022-2023 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
+++ b/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
@@ -116,6 +116,9 @@ public final class RemapConfigurations {
 	 *                  if {@code false}, returns the compile-time one
 	 * @return the collector configuration
 	 */
+	// Note: this method is generally called on demand, so these configurations
+	// won't exist at buildscript evaluation time. There's no need for them anyway
+	// since they're internals.
 	public static Configuration getOrCreateCollectorConfiguration(Project project, SourceSet sourceSet, boolean runtime) {
 		final String configurationName = "mod"
 				+ (runtime ? "Runtime" : "Compile")
@@ -131,10 +134,13 @@ public final class RemapConfigurations {
 			// Don't get transitive deps of already remapped mods
 			configuration.setTransitive(false);
 
-			// Set usage roles to fetch the correct artifacts.
+			// Set the usage attribute to fetch the correct artifacts.
+			// Note: Even though most deps are resolved via copies of mod* configurations,
+			// non-remapped mods that get added straight to these collectors will need the attribute.
 			final Usage usage = project.getObjects().named(Usage.class, runtime ? Usage.JAVA_RUNTIME : Usage.JAVA_API);
 			configuration.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
 
+			// The main classpath also applies to the test source set like with normal dependencies.
 			final boolean isMainSourceSet = sourceSet.getName().equals("main");
 
 			if (runtime) {

--- a/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
+++ b/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
@@ -183,6 +183,14 @@ public final class RemapConfigurations {
 		final Configuration configuration = project.getConfigurations().create(settings.getName());
 		configuration.setTransitive(true);
 
+		for (String outgoingConfigurationName : settings.getPublishingMode().get().outgoingConfigurations()) {
+			extendsFrom(outgoingConfigurationName, configuration, project);
+		}
+	}
+
+	public static void setupCollectorConfigurations(Project project, RemapConfigurationSettings settings) {
+		final Configuration configuration = project.getConfigurations().getByName(settings.getName());
+
 		if (settings.getOnCompileClasspath().get()) {
 			final Configuration collector = getOrCreateCollectorConfiguration(project, settings, false, false);
 			extendsFrom(collector.getName(), configuration, project);
@@ -193,10 +201,6 @@ public final class RemapConfigurations {
 			final Configuration collector = getOrCreateCollectorConfiguration(project, settings, true, false);
 			extendsFrom(collector.getName(), configuration, project);
 			getOrCreateCollectorConfiguration(project, settings, true, true);
-		}
-
-		for (String outgoingConfigurationName : settings.getPublishingMode().get().outgoingConfigurations()) {
-			extendsFrom(outgoingConfigurationName, configuration, project);
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
+++ b/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2022 FabricMC
+ * Copyright (c) 2022-2023 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
+++ b/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
@@ -132,11 +132,11 @@ public final class RemapConfigurations {
 	 * @return the collector configuration
 	 */
 	public static Configuration getOrCreateCollectorConfiguration(Project project, SourceSet sourceSet, boolean runtime, boolean remapped) {
-		final String configurationName = "mod" +
-				(runtime ? "Runtime" : "Compile") +
-				"Classpath" +
-				Strings.capitalize(sourceSet.getName()) +
-				(remapped ? "Mapped" : "");
+		final String configurationName = "mod"
+				+ (runtime ? "Runtime" : "Compile")
+				+ "Classpath"
+				+ Strings.capitalize(sourceSet.getName())
+				+ (remapped ? "Mapped" : "");
 		final ConfigurationContainer configurations = project.getConfigurations();
 		Configuration configuration = configurations.findByName(configurationName);
 

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
@@ -178,6 +178,8 @@ public class ModConfigurationRemapper {
 
 			final Configuration clientRemappedConfig = clientConfigsToRemap.get(sourceConfig);
 			final boolean refreshDeps = LoomGradleExtension.get(project).refreshDeps();
+			// TODO: With the same artifacts being considered multiple times for their different
+			//   usage attributes, this should probably not process them multiple times even with refreshDeps.
 			final List<ModDependency> toRemap = modDependencies.stream()
 					.filter(dependency -> refreshDeps || dependency.isCacheInvalid(project, null))
 					.toList();

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
@@ -31,6 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -76,7 +77,7 @@ public class ModConfigurationRemapper {
 		final DependencyHandler dependencies = project.getDependencies();
 		// The configurations where the source and remapped artifacts go.
 		// key: source, value: target
-		final Map<Configuration, Configuration> configsToRemap = new HashMap<>();
+		final Map<Configuration, Configuration> configsToRemap = new LinkedHashMap<>();
 		// Client remapped dep collectors for split source sets. Same keys and values.
 		final Map<Configuration, Configuration> clientConfigsToRemap = new HashMap<>();
 

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
@@ -106,18 +106,18 @@ public class ModConfigurationRemapper {
 					final Configuration clientTarget = RemapConfigurations.getOrCreateCollectorConfiguration(project, clientSourceSet, runtime);
 					clientConfigsToRemap.put(sourceCopy, clientTarget);
 				}
-
-				// Export to other projects.
-				if (entry.getTargetConfigurationName().get().equals(JavaPlugin.API_CONFIGURATION_NAME)) {
-					// Note: legacy (pre-1.1) behavior is kept for this remapping since
-					// we don't have a modApiElements/modRuntimeElements kind of configuration.
-					// TODO: Expose API/runtime usage attributes for namedElements to make it work like normal project dependencies.
-					final Configuration remappedConfig = project.getConfigurations().maybeCreate(entry.getRemappedConfigurationName());
-					remappedConfig.setTransitive(false);
-					project.getConfigurations().getByName(Constants.Configurations.NAMED_ELEMENTS).extendsFrom(remappedConfig);
-					configsToRemap.put(entry.getSourceConfiguration().get(), remappedConfig);
-				}
 			});
+
+			// Export to other projects.
+			if (entry.getTargetConfigurationName().get().equals(JavaPlugin.API_CONFIGURATION_NAME)) {
+				// Note: legacy (pre-1.1) behavior is kept for this remapping since
+				// we don't have a modApiElements/modRuntimeElements kind of configuration.
+				// TODO: Expose API/runtime usage attributes for namedElements to make it work like normal project dependencies.
+				final Configuration remappedConfig = project.getConfigurations().maybeCreate(entry.getRemappedConfigurationName());
+				remappedConfig.setTransitive(false);
+				project.getConfigurations().getByName(Constants.Configurations.NAMED_ELEMENTS).extendsFrom(remappedConfig);
+				configsToRemap.put(entry.getSourceConfiguration().get(), remappedConfig);
+			}
 		}
 
 		configsToRemap.forEach((sourceConfig, remappedConfig) -> {

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import com.google.common.collect.ImmutableMap;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.FileCollectionDependency;
@@ -83,9 +84,9 @@ public class ModConfigurationRemapper {
 
 		for (RemapConfigurationSettings entry : extension.getRemapConfigurations()) {
 			// key: true if runtime, false if compile
-			final Map<Boolean, Boolean> envToEnabled = Map.of(
-					true, entry.getOnRuntimeClasspath().get(),
-					false, entry.getOnCompileClasspath().get()
+			final Map<Boolean, Boolean> envToEnabled = ImmutableMap.of(
+					false, entry.getOnCompileClasspath().get(),
+					true, entry.getOnRuntimeClasspath().get()
 			);
 
 			envToEnabled.forEach((runtime, enabled) -> {

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
@@ -77,6 +77,7 @@ public class ModConfigurationRemapper {
 		// The configurations where the source and remapped artifacts go.
 		// key: source, value: target
 		final Map<Configuration, Configuration> configsToRemap = new HashMap<>();
+		// Client remapped dep collectors for split source sets. Same keys and values.
 		final Map<Configuration, Configuration> clientConfigsToRemap = new HashMap<>();
 
 		for (RemapConfigurationSettings entry : extension.getRemapConfigurations()) {
@@ -96,6 +97,8 @@ public class ModConfigurationRemapper {
 				sourceCopy.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
 				configsToRemap.put(sourceCopy, target);
 
+				// If our remap configuration entry targets the client source set as well,
+				// let's set up a collector for it too.
 				if (entry.getClientSourceConfigurationName().isPresent()) {
 					final SourceSet clientSourceSet = SourceSetHelper.getSourceSetByName(MinecraftSourceSets.Split.CLIENT_ONLY_SOURCE_SET_NAME, project);
 					final Configuration clientTarget = RemapConfigurations.getOrCreateCollectorConfiguration(project, clientSourceSet, runtime);

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
@@ -92,8 +92,8 @@ public class ModConfigurationRemapper {
 				final Configuration targetCollector = RemapConfigurations.getOrCreateCollectorConfiguration(project, entry, runtime, true);
 
 				if (entry.getClientSourceConfigurationName().isPresent()) {
-					// Don't use collectors for source since they can contain other configurations.
-					// Instead, we copy the source configuration with the desired usage type.
+					// Don't use collectors for the source config since they can contain other configurations.
+					// Instead, we copy it with the desired usage type.
 					final Configuration sourceCopy = entry.getSourceConfiguration().get().copy();
 					final Usage usage = project.getObjects().named(Usage.class, runtime ? Usage.JAVA_RUNTIME : Usage.JAVA_API);
 					sourceCopy.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
@@ -104,6 +104,7 @@ public class ModConfigurationRemapper {
 					configsToRemap.put(sourceCopy, targetCollector);
 					clientConfigsToRemap.put(sourceCopy, clientTargetCollector);
 				} else {
+					RemapConfigurations.setupCollectorConfigurations(project, entry);
 					final Configuration sourceCollector = RemapConfigurations.getOrCreateCollectorConfiguration(project, entry, runtime, false);
 					configsToRemap.put(sourceCollector, targetCollector);
 				}

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModProcessor.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2018-2021 FabricMC
+ * Copyright (c) 2018-2023 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModProcessor.java
@@ -87,6 +87,9 @@ public class ModProcessor {
 		}
 	}
 
+	// Creates a human-readable descriptive string for the configuration.
+	// This consists primarily of the name with any copy suffixes stripped
+	// (they're not informative), and the usage attribute if present.
 	private String describeConfiguration(Configuration configuration) {
 		String description = configuration.getName();
 		final Matcher copyMatcher = COPY_CONFIGURATION_PATTERN.matcher(description);
@@ -101,6 +104,7 @@ public class ModProcessor {
 			}
 		}
 
+		// Add the usage if present, e.g. "modImplementation (java-api)"
 		final Usage usage = configuration.getAttributes().getAttribute(Usage.USAGE_ATTRIBUTE);
 
 		if (usage != null) {

--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SplitModDependency.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SplitModDependency.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2022 FabricMC
+ * Copyright (c) 2022-2023 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -33,6 +33,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.api.ModSettings;
 import net.fabricmc.loom.configuration.mods.ArtifactRef;
 import net.fabricmc.loom.configuration.mods.JarSplitter;
 
@@ -120,11 +121,10 @@ public final class SplitModDependency extends ModDependency {
 
 	private void createModGroup(Path commonJar, Path clientJar) {
 		LoomGradleExtension extension = LoomGradleExtension.get(project);
-		extension.getMods().register(String.format("%s-%s-%s", getRemappedGroup(), name, version), modSettings ->
-				modSettings.getModFiles().from(
-					commonJar.toFile(),
-					clientJar.toFile()
-				)
+		final ModSettings modSettings = extension.getMods().maybeCreate(String.format("%s-%s-%s", getRemappedGroup(), name, version));
+		modSettings.getModFiles().from(
+				commonJar.toFile(),
+				clientJar.toFile()
 		);
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftSourceSets.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftSourceSets.java
@@ -126,7 +126,7 @@ public abstract sealed class MinecraftSourceSets permits MinecraftSourceSets.Sin
 		private static final String MINECRAFT_CLIENT_ONLY_NAMED = "minecraftClientOnlyNamed";
 		private static final String MINECRAFT_COMBINED_NAMED = "minecraftCombinedNamed";
 
-		private static final String CLIENT_ONLY_SOURCE_SET_NAME = "client";
+		public static final String CLIENT_ONLY_SOURCE_SET_NAME = "client";
 
 		private static final Split INSTANCE = new Split();
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftSourceSets.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftSourceSets.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2022 FabricMC
+ * Copyright (c) 2022-2023 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/net/fabricmc/loom/util/Strings.java
+++ b/src/main/java/net/fabricmc/loom/util/Strings.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2023 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util;
+
+public final class Strings {
+	public static String capitalize(String word) {
+		// Don't capitalize empty strings
+		if (word.isBlank()) {
+			return word;
+		}
+
+		final StringBuilder builder = new StringBuilder();
+		final int codePointCount = word.codePointCount(0, word.length());
+		final int first = Character.toUpperCase(word.codePointAt(0));
+		builder.append(Character.toString(first));
+
+		if (codePointCount > 1) {
+			for (int codePoint = 1; codePoint < codePointCount; codePoint++) {
+				builder.append(Character.toString(word.codePointAt(codePoint)));
+			}
+		}
+
+		return builder.toString();
+	}
+}

--- a/src/test/groovy/net/fabricmc/loom/test/integration/DependencyOrderTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/DependencyOrderTest.groovy
@@ -31,7 +31,7 @@ import spock.lang.Unroll
 import static net.fabricmc.loom.test.LoomTestConstants.*
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
-class InstallerDataTest extends Specification implements GradleProjectTestTrait {
+class DependencyOrderTest extends Specification implements GradleProjectTestTrait {
     // Regression test for a bug introduced in 1.1 development where
     // if Fabric Loader is resolved after another mod dependency,
     // Gradle will crash because loaderLibraries has been resolved before

--- a/src/test/groovy/net/fabricmc/loom/test/integration/InstallerDataTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/InstallerDataTest.groovy
@@ -1,0 +1,58 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2023 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.integration
+
+import net.fabricmc.loom.test.util.GradleProjectTestTrait
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static net.fabricmc.loom.test.LoomTestConstants.*
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class InstallerDataTest extends Specification implements GradleProjectTestTrait {
+    // Regression test for a bug introduced in 1.1 development where
+    // if Fabric Loader is resolved after another mod dependency,
+    // Gradle will crash because loaderLibraries has been resolved before
+    // Loader's dependencies have been added to it.
+    @Unroll
+    def "build with loader as the second dependency (gradle #version)"() {
+        setup:
+            def gradle = gradleProject(project: "minimalBase", version: version)
+            gradle.buildGradle << """
+            dependencies {
+                minecraft 'com.mojang:minecraft:1.19.3'
+                mappings 'net.fabricmc:yarn:1.19.3+build.5:v2'
+                modApi 'net.fabricmc.fabric-api:fabric-api:0.73.0+1.19.3'
+                modImplementation 'net.fabricmc:fabric-loader:0.14.13'
+            }
+            """.stripIndent()
+        when:
+            def result = gradle.run(task: "build")
+        then:
+            result.task(":build").outcome == SUCCESS
+        where:
+            version << STANDARD_TEST_VERSIONS
+    }
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/StringsTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/StringsTest.groovy
@@ -1,0 +1,47 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2023 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit
+
+import net.fabricmc.loom.util.Strings
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class StringsTest extends Specification {
+    @Unroll
+    def "capitalize '#input'"() {
+        when:
+            def result = Strings.capitalize(input)
+        then:
+            result == expected
+
+        where:
+            input | expected
+            '' | ''
+            ' \n ' | ' \n '
+            'world' | 'World'
+            'helloWorld' | 'HelloWorld'
+            '\u00E4mp\u00E4ri' | '\u00C4mp\u00E4ri'
+    }
+}

--- a/src/test/resources/projects/kotlin/build.gradle.kts
+++ b/src/test/resources/projects/kotlin/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 	kotlin("jvm") version "1.7.22"
 	kotlin("plugin.serialization") version "1.7.22"
 	id("fabric-loom")
+	`maven-publish`
 }
 
 java {
@@ -11,6 +12,7 @@ java {
 	targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+group = "com.example"
 version = "0.0.1"
 
 dependencies {
@@ -18,4 +20,12 @@ dependencies {
 	mappings(group = "net.fabricmc", name = "yarn", version = "1.16.5+build.5", classifier = "v2")
 	modImplementation("net.fabricmc:fabric-loader:0.12.12")
 	modImplementation(group = "net.fabricmc", name = "fabric-language-kotlin", version = "1.8.7+kotlin.1.7.22")
+}
+
+publishing {
+	publications {
+		create<MavenPublication>("mavenKotlin") {
+			from(components["java"])
+		}
+	}
 }

--- a/src/test/resources/projects/maven/build.gradle
+++ b/src/test/resources/projects/maven/build.gradle
@@ -23,3 +23,31 @@ dependencies {
 
 	modImplementation System.getProperty("loom.test.resolve")
 }
+
+task checkClasspaths {
+	// Check that only compileClasspath contains the biome API and only runtimeClasspath contains the command API.
+	// See https://github.com/FabricMC/fabric-loom/issues/801.
+
+	doLast {
+		def compile = configurations.compileClasspath.resolve().collect { it.name }
+		def runtime = configurations.runtimeClasspath.resolve().collect { it.name }
+
+		if (!compile.any { it.contains('biome-api') }) {
+			throw new RuntimeException('No biome API on compile classpath')
+		}
+
+		if (compile.any { it.contains('command-api') }) {
+			throw new RuntimeException('Command API on compile classpath')
+		}
+
+		if (!runtime.any { it.contains('command-api') }) {
+			throw new RuntimeException('No command API on runtime classpath')
+		}
+
+		if (runtime.any { it.contains('biome-api') }) {
+			throw new RuntimeException('Biome API on runtime classpath')
+		}
+	}
+}
+
+check.dependsOn checkClasspaths

--- a/src/test/resources/projects/mavenLibrary/build.gradle
+++ b/src/test/resources/projects/mavenLibrary/build.gradle
@@ -13,6 +13,8 @@ dependencies {
 	minecraft "com.mojang:minecraft:1.16.5"
 	mappings "net.fabricmc:yarn:1.16.5+build.5:v2"
 	modImplementation "net.fabricmc:fabric-loader:0.11.2"
+	modCompileOnlyApi fabricApi.module('fabric-biome-api-v1', '0.42.0+1.16')
+	modRuntimeOnly fabricApi.module('fabric-command-api-v1', '0.42.0+1.16')
 }
 
 processResources {


### PR DESCRIPTION
Fixes #801. Fixes #572.

Needs a bit of testing, esp. with split builds and split dependencies.

- Loom now remaps mods to "collector configs" that are specific to the execution type (compile-time/API vs runtime).
  - For example, `modImplementation` remaps to `modCompileClasspathMain` and `modRuntimeClasspathMain`.
  - This lets us use Gradle's `org.gradle.usage` attributes to select whether it's a compile-time or runtime dependency
  - Note: Remap configurations sourcing from `api` are partially left intact due to their special logic in the `namedElements` configuration.
- Setting the proper usages fixes #801.
- No dependency files are added to the real target configurations (like `api` and `implementation`) anymore.
  - This fixes #572, since `runtimeClasspath` and `compileClasspath` don't leak transitive dependencies unlike `implementation` etc.