### PR TITLE
Warn when using `clientOnlyMinecraftJar()` on versions newer than 1.3

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/SingleJarMinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/SingleJarMinecraftProvider.java
@@ -68,6 +68,11 @@ public final class SingleJarMinecraftProvider extends MinecraftProvider {
 	public void provide() throws Exception {
 		super.provide();
 
+		// Server only JARs are supported on any version, client only JARs are pretty much useless after 1.3.
+		if (provideClient() && getVersionInfo().isVersionOrNewer("2012-07-25T22:00:00+00:00" /* 1.3 release date */)) {
+			getProject().getLogger().warn("Using `clientOnlyMinecraftJar()` is not recommended for Minecraft versions 1.3 or newer.");
+		}
+
 		boolean requiresRefresh = getExtension().refreshDeps() || Files.notExists(minecraftEnvOnlyJar);
 
 		if (!requiresRefresh) {


### PR DESCRIPTION
Single JARs break things like source generation on newer versions and pretty much have no difference there, so we should log a warning, similar to what we do for merged JARs not being supported on 1.2.5 or older.