### PR TITLE
Add toString to ModSettings and RemapConfigurationSettings

### DIFF
--- a/src/main/java/net/fabricmc/loom/api/ModSettings.java
+++ b/src/main/java/net/fabricmc/loom/api/ModSettings.java
@@ -122,4 +122,9 @@ public abstract class ModSettings implements Named {
 
 	@Inject
 	public abstract Project getProject();
+
+	@Override
+	public String toString() {
+		return "ModSettings '" + getName() + "'";
+	}
 }

--- a/src/main/java/net/fabricmc/loom/api/RemapConfigurationSettings.java
+++ b/src/main/java/net/fabricmc/loom/api/RemapConfigurationSettings.java
@@ -142,4 +142,9 @@ public abstract class RemapConfigurationSettings implements Named {
 	private Provider<Boolean> defaultDependencyTransforms() {
 		return getSourceSet().map(sourceSet -> sourceSet.getName().equals(SourceSet.MAIN_SOURCE_SET_NAME) || sourceSet.getName().equals("client"));
 	}
+
+	@Override
+	public String toString() {
+		return "RemapConfigurationSettings '" + getName() + "'";
+	}
 }


### PR DESCRIPTION
This helps a bit with debugging code that uses them as you don't have to open the object to see which mod/remap configuration we're investigating.

(The format mirrors Gradle's common `type 'name'` that they use for many named objects)