### PR TITLE
fix: remapping of jars without a fabric.mod.json

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/mods/AccessWidenerUtils.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/AccessWidenerUtils.java
@@ -60,6 +60,7 @@ public class AccessWidenerUtils {
 		if (!FabricModJsonFactory.isModJar(inputJar)) {
 			return null;
 		}
+
 		final FabricModJson fabricModJson = FabricModJsonFactory.createFromZip(inputJar);
 		final List<String> classTweakers = List.copyOf(fabricModJson.getClassTweakers().keySet());
 

--- a/src/main/java/net/fabricmc/loom/configuration/mods/AccessWidenerUtils.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/AccessWidenerUtils.java
@@ -57,6 +57,9 @@ public class AccessWidenerUtils {
 	}
 
 	public static AccessWidenerData readAccessWidenerData(Path inputJar) throws IOException {
+		if (!FabricModJsonFactory.isModJar(inputJar)) {
+			return null;
+		}
 		final FabricModJson fabricModJson = FabricModJsonFactory.createFromZip(inputJar);
 		final List<String> classTweakers = List.copyOf(fabricModJson.getClassTweakers().keySet());
 


### PR DESCRIPTION
Jars that have `Fabric-Loom-Remap: true` without a `fabric.mod.json` fail to remap, as loom searches for accesswideners in the FMJ (which doesn't exist in the jar).