### PR TITLE
Support intermediary metadata

### DIFF
--- a/src/main/java/net/fabricmc/loom/api/mappings/intermediate/IntermediateMappingsProvider.java
+++ b/src/main/java/net/fabricmc/loom/api/mappings/intermediate/IntermediateMappingsProvider.java
@@ -26,6 +26,8 @@ package net.fabricmc.loom.api.mappings.intermediate;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
 import java.util.function.Function;
 
 import org.gradle.api.Named;
@@ -49,4 +51,14 @@ public abstract class IntermediateMappingsProvider implements Named {
 	 * @throws IOException
 	 */
 	public abstract void provide(Path tinyMappings) throws IOException;
+
+	/**
+	 * Return metadata associated with the provided mappings. The metadata will be written the to the mapping jars manifest.
+	 *
+	 * @return A map of metadata, may be empty
+	 * @throws IOException on error
+	 */
+	public Map<String, String> getMetadata() throws IOException {
+		return Collections.emptyMap();
+	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/unit/configuration/IntermediaryMappingsProviderTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/configuration/IntermediaryMappingsProviderTest.groovy
@@ -1,0 +1,78 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2023 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit.configuration
+
+import net.fabricmc.loom.util.download.DownloadBuilder
+import net.fabricmc.mappingio.MappingReader
+import net.fabricmc.mappingio.format.MappingFormat
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.nio.file.Path
+
+class IntermediaryMappingsProviderTest extends Specification {
+	@Shared
+	private static File tempDir = File.createTempDir()
+
+	def "provide"() {
+		given:
+			def download = Mock(DownloadBuilder)
+			def provider = new MockIntermediaryMappingsProvider(download)
+
+			download.defaultCache() >> download
+			download.downloadPath(_) >> { Path path ->
+				MockIntermediaryMappingsProvider.writeIntermediaryJar(path)
+			}
+
+		when:
+			def intermediaryPath = new File(tempDir, "mappings.tiny").toPath()
+			provider.provide(intermediaryPath)
+
+		then:
+			MappingReader.detectFormat(intermediaryPath) == MappingFormat.TINY_2
+	}
+
+	def "read metadata"() {
+		given:
+			def download = Mock(DownloadBuilder)
+			def provider = new MockIntermediaryMappingsProvider(download)
+
+			download.defaultCache() >> download
+			download.downloadPath(_) >> { Path path ->
+				MockIntermediaryMappingsProvider.writeIntermediaryJar(path, manifest)
+			}
+
+		when:
+			def metadata = provider.metadata
+
+		then:
+			metadata == (manifest + ["Manifest-Version": "1.0"])
+
+		where:
+			manifest                                                    | _
+			[:]      								                    | _ // Current shipping
+			["Game-Id": "23w13a", "Game-Version": "1.20-alpha.23.13.a"] | _ // Newer intermediary
+	}
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/configuration/MappingConfigurationTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/configuration/MappingConfigurationTest.groovy
@@ -1,0 +1,78 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2023 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit.configuration
+
+import net.fabricmc.loom.LoomGradleExtension
+import net.fabricmc.loom.configuration.providers.mappings.IntermediateMappingsService
+import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration
+import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider
+import net.fabricmc.loom.test.util.GradleTestUtil
+import net.fabricmc.loom.test.util.ZipTestUtils
+import net.fabricmc.loom.util.ZipUtils
+import net.fabricmc.loom.util.download.DownloadBuilder
+import net.fabricmc.loom.util.service.SharedServiceManager
+import spock.lang.Specification
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+import static org.mockito.Mockito.when
+
+class MappingConfigurationTest extends Specification {
+	def "generateMappingsJar"() {
+		given:
+			def tempDir = File.createTempDir()
+			def mappingsConfig = new MappingConfiguration("test", tempDir.toPath())
+			def project = GradleTestUtil.mockProject()
+			def extension = LoomGradleExtension.get(project)
+			def sharedServiceManager = Mock(SharedServiceManager)
+			def download = Mock(DownloadBuilder)
+			def intermediaryMappingsProvider = new MockIntermediaryMappingsProvider(download)
+			download.defaultCache() >> download
+			download.downloadPath(_) >> { Path path ->
+				MockIntermediaryMappingsProvider.writeIntermediaryJar(path, manifest)
+			}
+			def minecraftProvider = Mock(MinecraftProvider)
+			minecraftProvider.file(_) >> { String name ->
+				return new File(tempDir, name)
+			}
+			def intermediateMappingsService = IntermediateMappingsService.create(intermediaryMappingsProvider, minecraftProvider)
+			when(extension.getIntermediateMappingsProvider()).thenReturn(intermediaryMappingsProvider)
+			sharedServiceManager.getOrCreateService(_, _) >> intermediateMappingsService
+			Files.writeString(mappingsConfig.tinyMappings, "tiny\t2\t0\tofficial\tintermediary\tnamed")
+
+		when:
+			mappingsConfig.generateMappingsJar(project, sharedServiceManager, minecraftProvider)
+
+		then:
+			new String(ZipUtils.unpack(mappingsConfig.tinyMappingsJar, "mappings/mappings.tiny")) == "tiny\t2\t0\tofficial\tintermediary\tnamed"
+			new String(ZipUtils.unpack(mappingsConfig.tinyMappingsJar, "META-INF/MANIFEST.MF")) == ZipTestUtils.manifest(manifest)
+
+		where:
+			manifest                                                    | _
+			[:]      								                    | _ // Current shipping
+			["Game-Id": "23w13a", "Game-Version": "1.20-alpha.23.13.a"] | _ // Newer intermediary
+	}
+}

--- a/src/test/groovy/net/fabricmc/loom/test/util/ZipTestUtils.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/util/ZipTestUtils.groovy
@@ -49,16 +49,16 @@ class ZipTestUtils {
         return file
     }
 
-	static String manifest(String key, String value) {
-		return manifest(Map.of(key, value))
-	}
+    static String manifest(String key, String value) {
+        return manifest(Map.of(key, value))
+    }
 
     static String manifest(Map<String, String> entries) {
         def manifest = new Manifest()
         manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0")
-		entries.entrySet().forEach { entry ->
-			manifest.getMainAttributes().putValue(entry.key, entry.value)
-		}
+        entries.entrySet().forEach { entry ->
+            manifest.getMainAttributes().putValue(entry.key, entry.value)
+        }
 
         def out = new ByteArrayOutputStream()
         manifest.write(out)

--- a/src/test/groovy/net/fabricmc/loom/test/util/ZipTestUtils.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/util/ZipTestUtils.groovy
@@ -49,10 +49,16 @@ class ZipTestUtils {
         return file
     }
 
-    static String manifest(String key, String value) {
+	static String manifest(String key, String value) {
+		return manifest(Map.of(key, value))
+	}
+
+    static String manifest(Map<String, String> entries) {
         def manifest = new Manifest()
         manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0")
-        manifest.getMainAttributes().putValue(key, value)
+		entries.entrySet().forEach { entry ->
+			manifest.getMainAttributes().putValue(entry.key, entry.value)
+		}
 
         def out = new ByteArrayOutputStream()
         manifest.write(out)


### PR DESCRIPTION
At a high level this basically copies the manifest from intermediary to the generated mappings.jar file, this will be used to allow intermediary to drive loaders generated Minecraft version.

In the future this might be expandable to allow mapping layers to add their own metadata, it may also be useful for older versions that do not use the default intermediary provider.

This is a well tested none breaking change for loom 1.1.

Merge pending intermediary and loader changes.