### PR TITLE
Only force re-downloads when manually refreshing deps

### DIFF
--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
@@ -85,7 +85,7 @@ public class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl implemen
 			provider.getRefreshDeps().set(project.provider(() -> LoomGradleExtension.get(project).refreshDeps()));
 		});
 
-		refreshDeps = project.getGradle().getStartParameter().isRefreshDependencies() || Boolean.getBoolean("loom.refresh");
+		refreshDeps = manualRefreshDeps();
 		multiProjectOptimisation = GradleUtils.getBooleanPropertyProvider(project, Constants.Properties.MULTI_PROJECT_OPTIMISATION);
 
 		if (refreshDeps) {
@@ -210,11 +210,15 @@ public class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl implemen
 			builder.offline();
 		}
 
-		if (refreshDeps()) {
+		if (manualRefreshDeps()) {
 			builder.forceDownload();
 		}
 
 		return builder;
+	}
+
+	private boolean manualRefreshDeps() {
+		return project.getGradle().getStartParameter().isRefreshDependencies() || Boolean.getBoolean("loom.refresh");
 	}
 
 	@Override


### PR DESCRIPTION
This prevents loom from re-downloading the MC jars after a build failuire. Downloaded files have their own lock, so a canceling the build during a download should still recover as expected.