### PR TITLE
Updated RESOURCES_BASE to point to https rather than http

### DIFF
--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -35,7 +35,7 @@ import net.fabricmc.loom.util.gradle.GradleSupport;
 
 public class Constants {
 	public static final String LIBRARIES_BASE = "https://libraries.minecraft.net/";
-	public static final String RESOURCES_BASE = "http://resources.download.minecraft.net/";
+	public static final String RESOURCES_BASE = "https://resources.download.minecraft.net/";
 	public static final String VERSION_MANIFESTS = "https://launchermeta.mojang.com/mc/game/version_manifest_v2.json";
 
 	public static final String SYSTEM_ARCH = System.getProperty("os.arch").equals("64") ? "64" : "32";


### PR DESCRIPTION
I recently had a lot of trouble adding a couple of new features to DisFabric that we want for our AOF servers on the All of Fabric discord. I tried updating to a newer version of loom/gradle/etc, but I really needed to be able to build for java 8 so we can just throw this mod on the server and continue.

I tracked down my original problem to this line of code, when I put it in my browser it said that https was required to access it, so I grabbed loom and changed this line, built it, and now I have my new version of DisFabric for AOF3.

It's possibly unlikely to happen, because this is so old and most of us have moved onto 1.19+, but it would be good to get this version of the plugin published so my DisFabric builds stop failing. 

I've spent a long time trying to fix things and I just don't think I can spend any more time to learn how to configure this to publish my own copy at the moment.

Of course, feel free to disregard my PR, I just thought I'd give it a go.

Thanks for everything. It's such a lot of work.