### PR TITLE
Support 23w16a & Windows ARM64, and fix regression when adding ARM support on older versions.

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/LibraryContext.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/LibraryContext.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import org.gradle.api.JavaVersion;
 
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftVersionMeta;
+import net.fabricmc.loom.util.Platform;
 
 public final class LibraryContext {
 	private final MinecraftVersionMeta versionMeta;
@@ -42,9 +43,15 @@ public final class LibraryContext {
 	/**
 	 * @return True when the Minecraft libraries support ARM64 MacOS
 	 */
-	public boolean supportsArm64MacOS() {
+	public boolean supportsArm64(Platform.OperatingSystem operatingSystem) {
+		final String osName = switch (operatingSystem) {
+		case MAC_OS -> "macos";
+		case WINDOWS -> "windows";
+		case LINUX -> "linux";
+		};
+
 		return versionMeta.libraries().stream()
-				.anyMatch(library -> library.name().startsWith("org.lwjgl:lwjgl:3") && library.name().endsWith(":natives-macos-arm64"));
+				.anyMatch(library -> library.name().startsWith("org.lwjgl:lwjgl:3") && library.name().endsWith(":natives-%s-arm64".formatted(osName)));
 	}
 
 	/**

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/processors/LWJGL3UpgradeLibraryProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/processors/LWJGL3UpgradeLibraryProcessor.java
@@ -85,6 +85,6 @@ public class LWJGL3UpgradeLibraryProcessor extends LibraryProcessor {
 
 	// Add support for macOS
 	private boolean upgradeMacOSArm() {
-		return platform.getOperatingSystem().isMacOS() && platform.getArchitecture().isArm() && !context.supportsArm64MacOS() && !context.hasClasspathNatives();
+		return platform.getOperatingSystem().isMacOS() && platform.getArchitecture().isArm() && !context.supportsArm64(Platform.OperatingSystem.MAC_OS) && !context.hasClasspathNatives();
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/processors/LoomNativeSupportLibraryProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/processors/LoomNativeSupportLibraryProcessor.java
@@ -45,7 +45,7 @@ public class LoomNativeSupportLibraryProcessor extends LibraryProcessor {
 			return ApplicationResult.DONT_APPLY;
 		}
 
-		if (platform.getOperatingSystem().isMacOS() && platform.getArchitecture().isArm() && !context.supportsArm64MacOS()) {
+		if (platform.getOperatingSystem().isMacOS() && platform.getArchitecture().isArm() && !context.supportsArm64(Platform.OperatingSystem.MAC_OS)) {
 			// Add the loom native support mod when adding ARM64 macOS support
 			return ApplicationResult.MUST_APPLY;
 		}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/processors/ObjcBridgeUpgradeLibraryProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/processors/ObjcBridgeUpgradeLibraryProcessor.java
@@ -54,7 +54,7 @@ public class ObjcBridgeUpgradeLibraryProcessor extends LibraryProcessor {
 		}
 
 		// Apply when Arm64 macOS is unsupported by Minecraft
-		return context.supportsArm64MacOS() ? ApplicationResult.DONT_APPLY : ApplicationResult.MUST_APPLY;
+		return context.supportsArm64(Platform.OperatingSystem.MAC_OS) ? ApplicationResult.DONT_APPLY : ApplicationResult.MUST_APPLY;
 	}
 
 	@Override

--- a/src/test/groovy/net/fabricmc/loom/test/unit/library/LibraryContextTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/library/LibraryContextTest.groovy
@@ -24,6 +24,7 @@
 
 package net.fabricmc.loom.test.unit.library
 
+import net.fabricmc.loom.util.Platform
 import org.gradle.api.JavaVersion
 import spock.lang.Specification
 
@@ -37,11 +38,27 @@ class LibraryContextTest extends Specification {
 		def context = new LibraryContext(MinecraftTestUtils.getVersionMeta(id), JavaVersion.VERSION_17)
 
 		then:
-		context.supportsArm64MacOS() == supported
+		context.supportsArm64(Platform.OperatingSystem.MAC_OS) == supported
 
 		where:
 		id       || supported
 		"1.19.4" || true
+		"1.18.2" || false
+		"1.16.5" || false
+		"1.4.7"  || false
+	}
+
+	def "Supports ARM64 windows"() {
+		when:
+		def context = new LibraryContext(MinecraftTestUtils.getVersionMeta(id), JavaVersion.VERSION_17)
+
+		then:
+		context.supportsArm64(Platform.OperatingSystem.WINDOWS) == supported
+
+		where:
+		id       || supported
+		"23w16a" || true
+		"1.19.4" || false
 		"1.18.2" || false
 		"1.16.5" || false
 		"1.4.7"  || false

--- a/src/test/groovy/net/fabricmc/loom/test/unit/library/LibraryContextTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/library/LibraryContextTest.groovy
@@ -24,13 +24,13 @@
 
 package net.fabricmc.loom.test.unit.library
 
-import net.fabricmc.loom.util.Platform
 import org.gradle.api.JavaVersion
 import spock.lang.Specification
 
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftVersionMeta
 import net.fabricmc.loom.configuration.providers.minecraft.library.LibraryContext
 import net.fabricmc.loom.test.util.MinecraftTestUtils
+import net.fabricmc.loom.util.Platform
 
 class LibraryContextTest extends Specification {
 	def "Supports ARM64 macOS"() {

--- a/src/test/groovy/net/fabricmc/loom/test/unit/library/processors/ArmNativesLibraryProcessorTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/library/processors/ArmNativesLibraryProcessorTest.groovy
@@ -57,6 +57,7 @@ class ArmNativesLibraryProcessorTest extends LibraryProcessorTest {
 
 		where:
 		id       || result
+		"23w16a" || LibraryProcessor.ApplicationResult.DONT_APPLY // Supports ARM64 Windows
 		"1.19.4" || LibraryProcessor.ApplicationResult.MUST_APPLY
 		"1.18.2" || LibraryProcessor.ApplicationResult.DONT_APPLY // Only support versions with classpath natives.
 		"1.12.2" || LibraryProcessor.ApplicationResult.DONT_APPLY // Not LWJGL 3


### PR DESCRIPTION
The new library processor system made supporting and testing this much easier :D
![image](https://user-images.githubusercontent.com/4324090/233481358-00c995dd-ce00-424c-a417-139e327e811d.png)
