### PR TITLE
Fix incorrect log level in logger config

### DIFF
--- a/src/main/resources/log4j2.fabric.xml
+++ b/src/main/resources/log4j2.fabric.xml
@@ -52,7 +52,7 @@
 	</Appenders>
 	<Loggers>
 		<Logger level="${sys:fabric.log.level:-info}" name="net.minecraft"/>
-		<Root level="all">
+		<Root level="${sys:fabric.log.debug.level:-debug}">
 			<AppenderRef ref="DebugFile" level="${sys:fabric.log.debug.level:-debug}"/>
 			<AppenderRef ref="SysOut" level="${sys:fabric.log.level:-info}"/>
 			<AppenderRef ref="LatestFile" level="${sys:fabric.log.level:-info}"/>


### PR DESCRIPTION
The old level="all" meant that if the trace level would pretend to be enabled when it was not. This can make some libraries like [ModLauncher](https://github.com/McModLauncher/modlauncher/blob/0ef7e830a51df41af4de50967f57d832ae8d60a0/src/main/java/cpw/mods/modlauncher/ClassTransformer.java#L134) very spammy.

This is also *slightly* broken: if fabric.log.level is a finer level than fabric.debug.log.level, it will report the less fine level.