### PR TITLE
Update Kotlin to 1.8.10 and Gradle to 8.1.1

### DIFF
--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [8.1.0-jdk17]
+        version: [8.1.1-jdk17]
     runs-on: ubuntu-22.04
     container:
       image: gradle:${{ matrix.version }}
@@ -27,7 +27,7 @@ jobs:
 
     runs-on: ubuntu-22.04
     container:
-      image: gradle:8.1.0-jdk17
+      image: gradle:8.1.1-jdk17
       options: --user root
 
     steps:
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [8.1.0-jdk17]
+        version: [8.1.1-jdk17]
         test: ${{ fromJson(needs.prepare_test_matrix.outputs.matrix) }}
 
     runs-on: ubuntu-22.04

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 	id 'checkstyle'
 	id 'jacoco'
 	id 'codenarc'
-	id "org.jetbrains.kotlin.jvm" version "1.8.0" // Must match the version included with gradle.
+	id "org.jetbrains.kotlin.jvm" version "1.8.10" // Must match the version included with gradle.
 	id "com.diffplug.spotless" version "6.18.0"
 	id "org.gradle.test-retry" version "1.5.2"
 }
@@ -100,7 +100,7 @@ dependencies {
 	}
 
 	// Kapt integration
-	compileOnly('org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0') // Must match the version included with gradle.
+	compileOnly('org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10') // Must match the version included with gradle.
 
 	// Testing
 	testImplementation(gradleTestKit())

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Kotlin 1.8.10 is included with gradle 8 and in the project we mark that we much match kotlin version to the one in gradle so this handles that.  Along with bumping Gradle from 8.1 to 8.1.1 https://docs.gradle.org/8.1.1/release-notes.html
As 8.1.1 is suggested over 8.1 due to some bugs

![image](https://user-images.githubusercontent.com/75751882/234086975-a374958b-f50f-42c7-a9a1-e6d3be02292c.png)
