### PR TITLE
Fix issues with downloading assets

### DIFF
--- a/src/main/java/net/fabricmc/loom/util/download/Download.java
+++ b/src/main/java/net/fabricmc/loom/util/download/Download.java
@@ -63,6 +63,7 @@ public final class Download {
 	private static final String E_TAG = "ETag";
 	private static final Logger LOGGER = LoggerFactory.getLogger(Download.class);
 
+	private static HttpClient HTTP_CLIENT;
 	public static DownloadBuilder create(String url) throws URISyntaxException {
 		return DownloadBuilder.create(url);
 	}
@@ -94,10 +95,16 @@ public final class Download {
 			throw error("Unable to download %s in offline mode", this.url);
 		}
 
-		return HttpClient.newBuilder()
+		if (HTTP_CLIENT != null) {
+			return HTTP_CLIENT;
+		}
+
+		HTTP_CLIENT = HttpClient.newBuilder()
 				.followRedirects(HttpClient.Redirect.ALWAYS)
 				.proxy(ProxySelector.getDefault())
 				.build();
+
+		return HTTP_CLIENT;
 	}
 
 	private HttpRequest getRequest() {


### PR DESCRIPTION
this change makes HttpClient instance static to ensure the internal thread pool is used, preventing thousands of threads from being spawned

leading to 2x speed improvment in downloading game assets, and atleast on my system solving issue #877 as commented on the issue thread