### PR TITLE
Downloader improvements

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/DownloadAssetsTask.java
+++ b/src/main/java/net/fabricmc/loom/task/DownloadAssetsTask.java
@@ -71,7 +71,7 @@ public abstract class DownloadAssetsTask extends AbstractLoomTask {
 
 		getAssetsDirectory().set(assetsDir);
 		getAssetsHash().set(versionInfo.assetIndex().sha1());
-		getDownloadThreads().convention(Runtime.getRuntime().availableProcessors());
+		getDownloadThreads().convention(Math.min(Runtime.getRuntime().availableProcessors(), 10));
 		getMinecraftVersion().set(versionInfo.id());
 		getMinecraftVersion().finalizeValue();
 

--- a/src/test/groovy/net/fabricmc/loom/test/LoomTestConstants.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/LoomTestConstants.groovy
@@ -27,7 +27,7 @@ package net.fabricmc.loom.test
 import org.gradle.util.GradleVersion
 
 class LoomTestConstants {
-	private final static String NIGHTLY_VERSION = "8.2-20230415221329+0000"
+	private final static String NIGHTLY_VERSION = "8.3-20230430222526+0000"
 	private final static boolean NIGHTLY_EXISTS = nightlyExists(NIGHTLY_VERSION)
 
 	// Test against the version of Gradle being used to build loom

--- a/src/test/groovy/net/fabricmc/loom/test/unit/library/LibraryContextTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/library/LibraryContextTest.groovy
@@ -58,7 +58,7 @@ class LibraryContextTest extends Specification {
 		where:
 		id       || supported
 		"23w16a" || true
-		"1.19.4" || false
+		"1.19.4" || true
 		"1.18.2" || false
 		"1.16.5" || false
 		"1.4.7"  || false

--- a/src/test/groovy/net/fabricmc/loom/test/unit/library/processors/ArmNativesLibraryProcessorTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/library/processors/ArmNativesLibraryProcessorTest.groovy
@@ -58,7 +58,7 @@ class ArmNativesLibraryProcessorTest extends LibraryProcessorTest {
 		where:
 		id       || result
 		"23w16a" || LibraryProcessor.ApplicationResult.DONT_APPLY // Supports ARM64 Windows
-		"1.19.4" || LibraryProcessor.ApplicationResult.MUST_APPLY
+		"1.19.4" || LibraryProcessor.ApplicationResult.DONT_APPLY
 		"1.18.2" || LibraryProcessor.ApplicationResult.DONT_APPLY // Only support versions with classpath natives.
 		"1.12.2" || LibraryProcessor.ApplicationResult.DONT_APPLY // Not LWJGL 3
 	}
@@ -116,23 +116,6 @@ class ArmNativesLibraryProcessorTest extends LibraryProcessorTest {
 		"1.16.5" | _
 		"1.15.2" | _
 		"1.14.4" | _
-	}
-
-	def "Add windows arm64 natives"() {
-		when:
-		def (original, context) = getLibs("1.19.4", PlatformTestUtils.WINDOWS_ARM64)
-		def processor = new ArmNativesLibraryProcessor(PlatformTestUtils.WINDOWS_ARM64, context)
-		def processed = mockLibraryProcessorManager().processLibraries([processor], original)
-
-		then:
-		// Test that the arm64 natives are added alongside the existing ones
-		def originalNatives = original.findAll { it.is("org.lwjgl") && it.target() == Library.Target.NATIVES }
-		originalNatives.count { it.classifier() == "natives-windows-arm64" } == 0
-		originalNatives.count { it.classifier() == "natives-windows" } > 0
-
-		def processedNatives = processed.findAll { it.is("org.lwjgl") && it.target() == Library.Target.NATIVES }
-		processedNatives.count { it.classifier() == "natives-windows-arm64" } > 0
-		processedNatives.count { it.classifier() == "natives-windows" } > 0
 	}
 
 	def "Add linux arm64 natives"() {


### PR DESCRIPTION
- Fixes #878
- Hopefully fixes #877
- "Forcing downloading" error should show much less often.
- Progress loggers get closed when download fails.
- Download assets uses a maxmium of 10 threads.
- Update tests to run against 8.3 nightlys.