### PR TITLE
Change zip entry ordering to place manifest first

### DIFF
--- a/src/main/java/net/fabricmc/loom/util/ZipReprocessorUtil.java
+++ b/src/main/java/net/fabricmc/loom/util/ZipReprocessorUtil.java
@@ -45,6 +45,51 @@ public class ZipReprocessorUtil {
 
 	private ZipReprocessorUtil() { }
 
+	private static final String MANIFEST_LOCATION = "META-INF/MANIFEST.MF";
+	private static final String META_INF = "META-INF/";
+
+	// See https://docs.oracle.com/en/java/javase/20/docs/specs/jar/jar.html#signed-jar-file
+	private static boolean isSpecialFile(String zipEntryName) {
+		if (!zipEntryName.startsWith(META_INF)) {
+			return false;
+		}
+
+		String[] parts = zipEntryName.split("/");
+
+		if (parts.length != 2) {
+			return false;
+		}
+
+		return parts[1].startsWith("SIG-")
+				|| parts[1].endsWith(".SF")
+				|| parts[1].endsWith(".DSA")
+				|| parts[1].endsWith(".RSA")
+				|| parts[1].endsWith(".EC");
+	}
+
+	private static int specialOrdering(String name1, String name2) {
+		if (name1.equals(name2)) {
+			return 0;
+		} else if (name1.equals(MANIFEST_LOCATION)) {
+			return -1;
+		} else if (name2.equals(MANIFEST_LOCATION)) {
+			return 1;
+		}
+
+		boolean isName1Special = isSpecialFile(name1);
+		boolean isName2Special = isSpecialFile(name2);
+
+		if (isName1Special && isName2Special) {
+			return name1.compareTo(name2);
+		} else if (isName1Special) {
+			return -1;
+		} else if (isName2Special) {
+			return 1;
+		}
+
+		return name1.compareTo(name2);
+	}
+
 	public static void reprocessZip(File file, boolean reproducibleFileOrder, boolean preserveFileTimestamps) throws IOException {
 		if (!reproducibleFileOrder && preserveFileTimestamps) {
 			return;
@@ -54,17 +99,7 @@ public class ZipReprocessorUtil {
 			ZipEntry[] entries;
 
 			if (reproducibleFileOrder) {
-				entries = zipFile.stream().sorted(Comparator.comparing(ZipEntry::getName, (e1, e2) -> {
-					if (e1.equals(e2)) {
-						return 0;
-					} else if (e1.equals("META-INF/MANIFEST.MF")) {
-						return -1;
-					} else if (e2.equals("META-INF/MANIFEST.MF")) {
-						return 1;
-					}
-
-					return 0;
-				}).thenComparing(ZipEntry::getName)).toArray(ZipEntry[]::new);
+				entries = zipFile.stream().sorted(Comparator.comparing(ZipEntry::getName, ZipReprocessorUtil::specialOrdering)).toArray(ZipEntry[]::new);
 			} else {
 				entries = zipFile.stream().toArray(ZipEntry[]::new);
 			}

--- a/src/main/java/net/fabricmc/loom/util/ZipReprocessorUtil.java
+++ b/src/main/java/net/fabricmc/loom/util/ZipReprocessorUtil.java
@@ -54,7 +54,17 @@ public class ZipReprocessorUtil {
 			ZipEntry[] entries;
 
 			if (reproducibleFileOrder) {
-				entries = zipFile.stream().sorted(Comparator.comparing(ZipEntry::getName)).toArray(ZipEntry[]::new);
+				entries = zipFile.stream().sorted(Comparator.comparing(ZipEntry::getName, (e1, e2) -> {
+					if (e1.equals(e2)) {
+						return 0;
+					} else if (e1.equals("META-INF/MANIFEST.MF")) {
+						return -1;
+					} else if (e2.equals("META-INF/MANIFEST.MF")) {
+						return 1;
+					}
+
+					return 0;
+				}).thenComparing(ZipEntry::getName)).toArray(ZipEntry[]::new);
 			} else {
 				entries = zipFile.stream().toArray(ZipEntry[]::new);
 			}

--- a/src/test/groovy/net/fabricmc/loom/test/integration/ReproducibleBuildTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/ReproducibleBuildTest.groovy
@@ -56,12 +56,12 @@ class ReproducibleBuildTest extends Specification implements GradleProjectTestTr
 		where:
 		version              | modHash                               | sourceHash
 		DEFAULT_GRADLE      | "174c9b52f4bc6d489548d11b42e853cf"    | [
-			"fbf6e2901a229cc4b299e312207c67a8",
-			"5603176bf5924cb4943ace43d2bce36c"
+			"5e6e56df303b4fbaaef372d6f143dbfc",
+			"92b6fbffd0bd14bf3c626750eb86c264"
 		]
 		PRE_RELEASE_GRADLE  | "174c9b52f4bc6d489548d11b42e853cf"    | [
-			"fbf6e2901a229cc4b299e312207c67a8",
-			"5603176bf5924cb4943ace43d2bce36c"
+			"5e6e56df303b4fbaaef372d6f143dbfc",
+			"92b6fbffd0bd14bf3c626750eb86c264"
 		]
 	}
 

--- a/src/test/groovy/net/fabricmc/loom/test/integration/ReproducibleBuildTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/ReproducibleBuildTest.groovy
@@ -55,11 +55,11 @@ class ReproducibleBuildTest extends Specification implements GradleProjectTestTr
 
 		where:
 		version              | modHash                               | sourceHash
-		DEFAULT_GRADLE      | "ed3306ef60f434c55048cba8de5dab95"    | [
+		DEFAULT_GRADLE      | "174c9b52f4bc6d489548d11b42e853cf"    | [
 			"0d9eec9248d93eb6ec4a1cd4d927e609",
 			"436bf54ef015576b0a338d55d9a0bb82"
 		]
-		PRE_RELEASE_GRADLE  | "ed3306ef60f434c55048cba8de5dab95"    | [
+		PRE_RELEASE_GRADLE  | "174c9b52f4bc6d489548d11b42e853cf"    | [
 			"0d9eec9248d93eb6ec4a1cd4d927e609",
 			"436bf54ef015576b0a338d55d9a0bb82"
 		]

--- a/src/test/groovy/net/fabricmc/loom/test/integration/ReproducibleBuildTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/ReproducibleBuildTest.groovy
@@ -55,13 +55,13 @@ class ReproducibleBuildTest extends Specification implements GradleProjectTestTr
 
 		where:
 		version              | modHash                               | sourceHash
-		DEFAULT_GRADLE      | "174c9b52f4bc6d489548d11b42e853cf"    | [
-			"0d9eec9248d93eb6ec4a1cd4d927e609",
-			"436bf54ef015576b0a338d55d9a0bb82"
+		DEFAULT_GRADLE      | "708a05164bfec11ff1d4e0cc29a29944"    | [
+			"fbf6e2901a229cc4b299e312207c67a8",
+			"5603176bf5924cb4943ace43d2bce36c"
 		]
-		PRE_RELEASE_GRADLE  | "174c9b52f4bc6d489548d11b42e853cf"    | [
-			"0d9eec9248d93eb6ec4a1cd4d927e609",
-			"436bf54ef015576b0a338d55d9a0bb82"
+		PRE_RELEASE_GRADLE  | "708a05164bfec11ff1d4e0cc29a29944"    | [
+			"fbf6e2901a229cc4b299e312207c67a8",
+			"5603176bf5924cb4943ace43d2bce36c"
 		]
 	}
 

--- a/src/test/groovy/net/fabricmc/loom/test/integration/ReproducibleBuildTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/ReproducibleBuildTest.groovy
@@ -55,11 +55,11 @@ class ReproducibleBuildTest extends Specification implements GradleProjectTestTr
 
 		where:
 		version              | modHash                               | sourceHash
-		DEFAULT_GRADLE      | "708a05164bfec11ff1d4e0cc29a29944"    | [
+		DEFAULT_GRADLE      | "174c9b52f4bc6d489548d11b42e853cf"    | [
 			"fbf6e2901a229cc4b299e312207c67a8",
 			"5603176bf5924cb4943ace43d2bce36c"
 		]
-		PRE_RELEASE_GRADLE  | "708a05164bfec11ff1d4e0cc29a29944"    | [
+		PRE_RELEASE_GRADLE  | "174c9b52f4bc6d489548d11b42e853cf"    | [
 			"fbf6e2901a229cc4b299e312207c67a8",
 			"5603176bf5924cb4943ace43d2bce36c"
 		]


### PR DESCRIPTION
This should solve #885; I've tested it with the reproduction case I provided for that issue, and it correctly reorders the zip entries.