### PR TITLE
Fix invalid run config for module names with spaces

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/ide/idea/IdeaUtils.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/idea/IdeaUtils.java
@@ -55,6 +55,6 @@ public class IdeaUtils {
 			module = project.getName() + "." + module;
 		}
 
-		return module;
+		return module.replace(' ', '_');
 	}
 }


### PR DESCRIPTION
See https://github.com/minecraft-dev/MinecraftDev/issues/2033

It looks like IDEA (or the Gradle integration specifically?) replaces spaces with underscores in module names. Unfortunately I could not find where exactly this happens but this change is enough to fix the issue linked above.