### PR TITLE
Fix non-main source set remap configurations publishing by default

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
+++ b/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
@@ -183,7 +183,11 @@ public final class RemapConfigurations {
 			configuration.getTargetConfigurationName().convention(targetConfiguration);
 			configuration.getOnCompileClasspath().convention(compileClasspath);
 			configuration.getOnRuntimeClasspath().convention(runtimeClasspath);
-			configuration.getPublishingMode().convention(publishingMode);
+
+			// Publish only for the main source set.
+			if (SourceSet.MAIN_SOURCE_SET_NAME.equals(sourceSet.getName())) {
+				configuration.getPublishingMode().convention(publishingMode);
+			}
 		};
 	}
 


### PR DESCRIPTION
Fixes #890.

Note that there is *no simple way* to enable publishing for remap configurations created this way anymore as the publishing mode is read during the `createRemapConfigurations` call.

This also changes the behaviour of `modClientX` configurations to no longer publish. If that is wanted, I can add a `createRemapConfigurations()` overload with some kind of configurability.