### PR TITLE
Fix + test minecraft metadata downloading

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/ManifestVersion.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/ManifestVersion.java
@@ -27,8 +27,18 @@ package net.fabricmc.loom.configuration.providers.minecraft;
 import java.util.List;
 import java.util.Map;
 
+import org.jetbrains.annotations.Nullable;
+
 public record ManifestVersion(List<Versions> versions, Map<String, String> latest) {
 	public static class Versions {
 		public String id, url, sha1;
+	}
+
+	@Nullable
+	public Versions getVersion(String id) {
+		return versions.stream()
+				.filter(versions -> versions.id.equalsIgnoreCase(id))
+				.findFirst()
+				.orElse(null);
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
@@ -1,0 +1,161 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2023 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.configuration.providers.minecraft;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Function;
+
+import org.gradle.api.Project;
+import org.jetbrains.annotations.Nullable;
+
+import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.LoomGradlePlugin;
+import net.fabricmc.loom.util.MirrorUtil;
+import net.fabricmc.loom.util.download.DownloadBuilder;
+
+public final class MinecraftMetadataProvider {
+	private final Options options;
+	private final Function<String, DownloadBuilder> download;
+
+	private ManifestVersion.Versions versionEntry;
+	private MinecraftVersionMeta versionMeta;
+
+	public MinecraftMetadataProvider(Options options, Function<String, DownloadBuilder> download) {
+		this.options = options;
+		this.download = download;
+	}
+
+	public MinecraftVersionMeta getVersionMeta() {
+		try {
+			if (versionEntry == null) {
+				versionEntry = getVersionEntry();
+			}
+
+			if (versionMeta == null) {
+				versionMeta = readVersionMeta();
+			}
+		} catch (IOException e) {
+			throw new UncheckedIOException(e.getMessage(), e);
+		}
+
+		return versionMeta;
+	}
+
+	private ManifestVersion.Versions getVersionEntry() throws IOException {
+		// Custom URL always takes priority
+		if (options.customManifestUrl() != null) {
+			ManifestVersion.Versions customVersion = new ManifestVersion.Versions();
+			customVersion.id = options.minecraftVersion();
+			customVersion.url = options.customManifestUrl();
+			return customVersion;
+		}
+
+		final List<ManifestVersionSupplier> suppliers = List.of(
+				// First try finding the version with caching
+				() -> getVersions(false),
+				// Then try finding the experimental version with caching
+				() -> getExperimentalVersions(false),
+				// Then force download Mojang's metadata to find the version
+				() -> getVersions(true),
+				// Finally try a force downloaded experimental metadata.
+				() -> getExperimentalVersions(true)
+		);
+
+		for (ManifestVersionSupplier supplier : suppliers) {
+			final ManifestVersion.Versions version = supplier.get().getVersion(options.minecraftVersion());
+
+			if (version != null) {
+				return version;
+			}
+		}
+
+		throw new RuntimeException("Failed to find minecraft version: " + options.minecraftVersion());
+	}
+
+	private ManifestVersion getVersions(boolean forceDownload) throws IOException {
+		return getVersions(options.versionManifestUrl(), options.versionManifestPath(), forceDownload);
+	}
+
+	private ManifestVersion getExperimentalVersions(boolean forceDownload) throws IOException {
+		return getVersions(options.experimentalVersionManifestUrl(), options.experimentalVersionManifestPath(), forceDownload);
+	}
+
+	private ManifestVersion getVersions(String url, Path cacheFile, boolean forceDownload) throws IOException {
+		DownloadBuilder builder = download.apply(url);
+
+		if (forceDownload) {
+			builder = builder.forceDownload();
+		} else {
+			builder = builder.defaultCache();
+		}
+
+		final String versionManifest = builder.downloadString(cacheFile);
+		return LoomGradlePlugin.OBJECT_MAPPER.readValue(versionManifest, ManifestVersion.class);
+	}
+
+	private MinecraftVersionMeta readVersionMeta() throws IOException {
+		final DownloadBuilder builder = download.apply(versionEntry.url);
+
+		if (versionEntry.sha1 != null) {
+			builder.sha1(versionEntry.sha1);
+		} else {
+			builder.defaultCache();
+		}
+
+		final String json = builder.downloadString(options.minecraftMetadataPath());
+		return LoomGradlePlugin.OBJECT_MAPPER.readValue(json, MinecraftVersionMeta.class);
+	}
+
+	public record Options(String minecraftVersion,
+					String versionManifestUrl,
+					String experimentalVersionManifestUrl,
+					@Nullable String customManifestUrl,
+					Path versionManifestPath,
+					Path experimentalVersionManifestPath,
+					Path minecraftMetadataPath) {
+		public static Options create(String minecraftVersion, Project project, Path minecraftMetadataPath) {
+			final LoomGradleExtension extension = LoomGradleExtension.get(project);
+			final Path userCache = extension.getFiles().getUserCache().toPath();
+
+			return new Options(
+					minecraftVersion,
+					MirrorUtil.getVersionManifests(project),
+					MirrorUtil.getExperimentalVersions(project),
+					extension.getCustomMinecraftManifest().getOrNull(),
+					userCache.resolve("version_manifest.json"),
+					userCache.resolve("experimental_version_manifest.json"),
+					minecraftMetadataPath
+			);
+		}
+	}
+
+	@FunctionalInterface
+	private interface ManifestVersionSupplier {
+		ManifestVersion get() throws IOException;
+	}
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/download/DownloadFileTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/download/DownloadFileTest.groovy
@@ -252,7 +252,7 @@ class DownloadFileTest extends DownloadTest {
 
 	def "Progress: String"() {
 		setup:
-		server.get("/progressString") {
+		server.get("/progressFile") {
 			it.result("Hello World")
 		}
 

--- a/src/test/groovy/net/fabricmc/loom/test/unit/download/DownloadTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/download/DownloadTest.groovy
@@ -25,17 +25,14 @@
 package net.fabricmc.loom.test.unit.download
 
 import io.javalin.Javalin
-import spock.lang.Shared
 import spock.lang.Specification
 
 abstract class DownloadTest extends Specification {
 	static final String PATH = "http://127.0.0.1:9081"
 
-	@Shared
-	Javalin server = Javalin.create { config ->
-	}.start(9081)
+	Javalin server = Javalin.create().start(9081)
 
-	def cleanupSpec() {
+	def cleanup() {
 		server.stop()
 	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/unit/providers/MinecraftMetadataProviderTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/providers/MinecraftMetadataProviderTest.groovy
@@ -1,0 +1,220 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2023 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit.providers
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+import org.intellij.lang.annotations.Language
+
+import net.fabricmc.loom.configuration.providers.minecraft.MinecraftMetadataProvider
+import net.fabricmc.loom.test.LoomTestConstants
+import net.fabricmc.loom.test.unit.download.DownloadTest
+import net.fabricmc.loom.util.download.Download
+
+class MinecraftMetadataProviderTest extends DownloadTest {
+	Path testDir
+
+	def setup() {
+		testDir = LoomTestConstants.TEST_DIR.toPath().resolve("MinecraftMetadataProviderTest")
+
+		testDir.toFile().deleteDir()
+		Files.createDirectories(testDir)
+	}
+
+	def "Cached result"() {
+		setup:
+		int calls = 0
+		server.get("/versionManifest") {
+			it.result(VERSION_MANIFEST_1)
+			calls++
+		}
+
+		when:
+		// Test the builtin caching of the metadata provider
+		def metaProvider = provider("1.20.1")
+		metaProvider.getVersionMeta()
+		def meta = metaProvider.getVersionMeta()
+
+		// Create a new provider to test download caching
+		def meta2 = provider("1.20.1").getVersionMeta()
+
+		then:
+		meta.id() == "1.20.1"
+		meta2.id() == "1.20.1"
+		calls == 1
+	}
+
+	// Tests a fix to https://github.com/FabricMC/fabric-loom/issues/886
+	def "Force download with new version"() {
+		setup:
+		int calls = 0
+		server.get("/versionManifest") {
+			it.result(calls == 0 ? VERSION_MANIFEST_1 : VERSION_MANIFEST_2)
+			calls++
+		}
+		server.get("/experimentalVersionManifest") {
+			it.result(EXP_VERSION_MANIFEST)
+			calls++
+		}
+
+		when:
+		def meta = provider("1.20.1").getVersionMeta()
+		def meta2 = provider("1.20.1-rc1").getVersionMeta()
+
+		then:
+		meta.id() == "1.20.1"
+		meta2.id() == "1.20.1-rc1"
+		calls == 3
+	}
+
+	def "Experimental"() {
+		setup:
+		int calls = 0
+		server.get("/versionManifest") {
+			it.result(VERSION_MANIFEST_1)
+			calls++
+		}
+		server.get("/experimentalVersionManifest") {
+			it.result(EXP_VERSION_MANIFEST)
+			calls++
+		}
+
+		when:
+		def meta = provider("1.19_deep_dark_experimental_snapshot-1").getVersionMeta()
+
+		then:
+		meta.id() == "1.19_deep_dark_experimental_snapshot-1"
+		calls == 2
+	}
+
+	def "Custom manifest"() {
+		setup:
+		server.get("/customManifest") {
+			it.result('{"id": "2.0.0"}')
+		}
+
+		when:
+		def meta = provider("2.0.0", "$PATH/customManifest").getVersionMeta()
+
+		then:
+		meta.id() == "2.0.0"
+	}
+
+	def "Get unknown"() {
+		setup:
+		int calls = 0
+		server.get("/versionManifest") {
+			it.result(VERSION_MANIFEST_1)
+			calls++
+		}
+		server.get("/experimentalVersionManifest") {
+			it.result(EXP_VERSION_MANIFEST)
+			calls++
+		}
+
+		when:
+		provider("2.0.0").getVersionMeta()
+
+		then:
+		def e = thrown(RuntimeException)
+		e.message == "Failed to find minecraft version: 2.0.0"
+		calls == 4
+	}
+
+	private MinecraftMetadataProvider provider(String version, String customUrl = null) {
+		return new MinecraftMetadataProvider(
+				options(version, customUrl),
+				Download.&create
+				)
+	}
+
+	private MinecraftMetadataProvider.Options options(String version, String customUrl) {
+		return new MinecraftMetadataProvider.Options(
+				version,
+				"$PATH/versionManifest",
+				"$PATH/experimentalVersionManifest",
+				customUrl,
+				testDir.resolve("version_manifest.json"),
+				testDir.resolve("experimental_version_manifest.json"),
+				testDir.resolve("${version}.json")
+				)
+	}
+
+	@Language("json")
+	private static final String VERSION_MANIFEST_1 = """
+{
+  "latest": {
+    "release": "1.20.1",
+    "snapshot": "1.20.1"
+  },
+  "versions": [
+    {
+      "id": "1.20.1",
+      "url": "https://piston-meta.mojang.com/v1/packages/715ccf3330885e75b205124f09f8712542cbe7e0/1.20.1.json",
+      "sha1": "715ccf3330885e75b205124f09f8712542cbe7e0"
+    }
+  ]
+}
+"""
+
+	@Language("json")
+	private static final String VERSION_MANIFEST_2 = """
+{
+  "latest": {
+    "release": "1.20.1",
+    "snapshot": "1.20.1"
+  },
+  "versions": [
+    {
+      "id": "1.20.1",
+      "url": "https://piston-meta.mojang.com/v1/packages/715ccf3330885e75b205124f09f8712542cbe7e0/1.20.1.json",
+      "sha1": "715ccf3330885e75b205124f09f8712542cbe7e0"
+    },
+    {
+      "id": "1.20.1-rc1",
+      "url": "https://piston-meta.mojang.com/v1/packages/61c85d1e228b4ca6e48d2da903d2399c12b6a880/1.20.1-rc1.json",
+      "sha1": "61c85d1e228b4ca6e48d2da903d2399c12b6a880"
+    }
+  ]
+}
+"""
+	@Language("json")
+	private static final String EXP_VERSION_MANIFEST = """
+{
+  "latest": {
+    "release": "1.19_deep_dark_experimental_snapshot-1",
+    "snapshot": "1.19_deep_dark_experimental_snapshot-1"
+  },
+  "versions": [
+    {
+      "id": "1.19_deep_dark_experimental_snapshot-1",
+      "url": "https://maven.fabricmc.net/net/minecraft/1_19_deep_dark_experimental_snapshot-1.json",
+      "sha1": "c5b59acb75db612cf446b4ed4bd59b01e10092d1"
+    }
+  ]
+}
+"""
+}


### PR DESCRIPTION
Moved the metadata downloading/parsing out of MinecraftProvider and into MinecraftMetadataProvider + add some unit tests.

Fixes #886 