### PR TITLE
Add an internal API to allow 3rd party loom extensions to add library processors.

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -30,6 +30,8 @@ import java.util.List;
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.provider.ListProperty;
+import org.jetbrains.annotations.ApiStatus;
 
 import net.fabricmc.loom.api.LoomGradleExtensionAPI;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
@@ -38,12 +40,14 @@ import net.fabricmc.loom.configuration.LoomDependencyManager;
 import net.fabricmc.loom.configuration.accesswidener.AccessWidenerFile;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
+import net.fabricmc.loom.configuration.providers.minecraft.library.LibraryProcessorManager;
 import net.fabricmc.loom.configuration.providers.minecraft.mapped.IntermediaryMinecraftProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.mapped.NamedMinecraftProvider;
 import net.fabricmc.loom.extension.LoomFiles;
 import net.fabricmc.loom.extension.MixinExtension;
 import net.fabricmc.loom.util.download.DownloadBuilder;
 
+@ApiStatus.Internal
 public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 	static LoomGradleExtension get(Project project) {
 		return (LoomGradleExtension) project.getExtensions().getByName("loom");
@@ -109,4 +113,6 @@ public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 	 * <p>You can enable it by setting the Gradle property {@code fabric.loom.multiProjectOptimisation} to {@code true}.
 	 */
 	boolean multiProjectOptimisation();
+
+	ListProperty<LibraryProcessorManager.LibraryProcessorFactory> getLibraryProcessors();
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftLibraryProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftLibraryProvider.java
@@ -56,7 +56,7 @@ public class MinecraftLibraryProvider {
 	public MinecraftLibraryProvider(MinecraftProvider minecraftProvider, Project project) {
 		this.project = project;
 		this.minecraftProvider = minecraftProvider;
-		this.processorManager = new LibraryProcessorManager(platform, project.getRepositories(), getEnabledProcessors());
+		this.processorManager = new LibraryProcessorManager(platform, project.getRepositories(), LoomGradleExtension.get(project).getLibraryProcessors().get(), getEnabledProcessors());
 	}
 
 	private List<String> getEnabledProcessors() {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/LibraryProcessorManager.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/LibraryProcessorManager.java
@@ -43,7 +43,7 @@ import net.fabricmc.loom.configuration.providers.minecraft.library.processors.Ru
 import net.fabricmc.loom.util.Platform;
 
 public class LibraryProcessorManager {
-	private static final List<LibraryProcessorFactory<?>> LIBRARY_PROCESSORS = List.of(
+	public static final List<LibraryProcessorFactory> DEFAULT_LIBRARY_PROCESSORS = List.of(
 			ArmNativesLibraryProcessor::new,
 			LegacyASMLibraryProcessor::new,
 			LoomNativeSupportLibraryProcessor::new,
@@ -55,22 +55,25 @@ public class LibraryProcessorManager {
 
 	private final Platform platform;
 	private final RepositoryHandler repositories;
+	private final List<LibraryProcessorFactory> libraryProcessorFactories;
 	private final List<String> enabledProcessors;
 
-	public LibraryProcessorManager(Platform platform, RepositoryHandler repositories, List<String> enabledProcessors) {
+	public LibraryProcessorManager(Platform platform, RepositoryHandler repositories, List<LibraryProcessorFactory> libraryProcessorFactories, List<String> enabledProcessors) {
 		this.platform = platform;
 		this.repositories = repositories;
+		this.libraryProcessorFactories = libraryProcessorFactories;
 		this.enabledProcessors = enabledProcessors;
 	}
 
+	@VisibleForTesting
 	public LibraryProcessorManager(Platform platform, RepositoryHandler repositories) {
-		this(platform, repositories, Collections.emptyList());
+		this(platform, repositories, DEFAULT_LIBRARY_PROCESSORS, Collections.emptyList());
 	}
 
 	private List<LibraryProcessor> getProcessors(LibraryContext context) {
 		var processors = new ArrayList<LibraryProcessor>();
 
-		for (LibraryProcessorFactory<?> factory : LIBRARY_PROCESSORS) {
+		for (LibraryProcessorFactory factory : libraryProcessorFactories) {
 			final LibraryProcessor processor = factory.apply(platform, context);
 			final LibraryProcessor.ApplicationResult applicationResult = processor.getApplicationResult();
 
@@ -122,6 +125,6 @@ public class LibraryProcessorManager {
 		return Collections.unmodifiableList(libraries);
 	}
 
-	public interface LibraryProcessorFactory<T extends LibraryProcessor> extends BiFunction<Platform, LibraryContext, T> {
+	public interface LibraryProcessorFactory extends BiFunction<Platform, LibraryContext, LibraryProcessor> {
 	}
 }

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
@@ -33,6 +33,7 @@ import java.util.Objects;
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
 
 import net.fabricmc.loom.LoomGradleExtension;
@@ -44,6 +45,7 @@ import net.fabricmc.loom.configuration.accesswidener.AccessWidenerFile;
 import net.fabricmc.loom.configuration.providers.mappings.IntermediaryMappingsProvider;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
+import net.fabricmc.loom.configuration.providers.minecraft.library.LibraryProcessorManager;
 import net.fabricmc.loom.configuration.providers.minecraft.mapped.IntermediaryMinecraftProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.mapped.NamedMinecraftProvider;
 import net.fabricmc.loom.util.Constants;
@@ -67,6 +69,7 @@ public class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl implemen
 	private InstallerData installerData;
 	private boolean refreshDeps;
 	private Provider<Boolean> multiProjectOptimisation;
+	private final ListProperty<LibraryProcessorManager.LibraryProcessorFactory> libraryProcessorFactories;
 
 	public LoomGradleExtensionImpl(Project project, LoomFiles files) {
 		super(project, files);
@@ -87,6 +90,9 @@ public class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl implemen
 
 		refreshDeps = manualRefreshDeps();
 		multiProjectOptimisation = GradleUtils.getBooleanPropertyProvider(project, Constants.Properties.MULTI_PROJECT_OPTIMISATION);
+		libraryProcessorFactories = project.getObjects().listProperty(LibraryProcessorManager.LibraryProcessorFactory.class);
+		libraryProcessorFactories.addAll(LibraryProcessorManager.DEFAULT_LIBRARY_PROCESSORS);
+		libraryProcessorFactories.finalizeValueOnRead();
 
 		if (refreshDeps) {
 			project.getLogger().lifecycle("Refresh dependencies is in use, loom will be significantly slower.");
@@ -234,6 +240,11 @@ public class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl implemen
 	@Override
 	public boolean multiProjectOptimisation() {
 		return multiProjectOptimisation.getOrElse(false);
+	}
+
+	@Override
+	public ListProperty<LibraryProcessorManager.LibraryProcessorFactory> getLibraryProcessors() {
+		return libraryProcessorFactories;
 	}
 
 	@Override

--- a/src/test/groovy/net/fabricmc/loom/test/unit/library/LibraryProcessorManagerTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/library/LibraryProcessorManagerTest.groovy
@@ -82,7 +82,7 @@ class LibraryProcessorManagerTest extends LibraryProcessorTest {
 		when:
 		def platform = PlatformTestUtils.WINDOWS_X64
 		def (original, context) = getLibs("1.19.2", platform)
-		def processed = new LibraryProcessorManager(platform, GradleTestUtil.mockRepositoryHandler(), [
+		def processed = new LibraryProcessorManager(platform, GradleTestUtil.mockRepositoryHandler(), LibraryProcessorManager.DEFAULT_LIBRARY_PROCESSORS, [
 			RuntimeLog4jLibraryProcessor.class.simpleName
 		]).processLibraries(original, context)
 


### PR DESCRIPTION
Add an internal API to allow 3rd party loom extensions to add library processors.
Stability of this API will not be guaranteed, fixes #904 