### PR TITLE
Client annotation processor configuration extendsFrom "annotationProcessor"

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftSourceSets.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftSourceSets.java
@@ -190,6 +190,9 @@ public abstract sealed class MinecraftSourceSets permits MinecraftSourceSets.Sin
 			extendsFrom(project, MINECRAFT_CLIENT_ONLY_NAMED.runtime(), MINECRAFT_COMMON_NAMED.runtime());
 			extendsFrom(project, MINECRAFT_CLIENT_ONLY_NAMED.compile(), MINECRAFT_COMMON_NAMED.compile());
 
+			// Client annotation processor configuration extendsFrom "annotationProcessor"
+			extendsFrom(project, clientOnlySourceSet.getAnnotationProcessorConfigurationName(), JavaPlugin.ANNOTATION_PROCESSOR_CONFIGURATION_NAME);
+
 			clientOnlySourceSet.setCompileClasspath(
 					clientOnlySourceSet.getCompileClasspath()
 							.plus(mainSourceSet.getCompileClasspath())


### PR DESCRIPTION
Seems this is causing a little bit of unwanted confusion, I cannot think of a major issue with doing this.