### PR TITLE
Make resolvable copies of configurations not consumable

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
@@ -96,6 +96,7 @@ public class ModConfigurationRemapper {
 				final Configuration sourceCopy = entry.getSourceConfiguration().get().copyRecursive();
 				final Usage usage = project.getObjects().named(Usage.class, runtime ? Usage.JAVA_RUNTIME : Usage.JAVA_API);
 				sourceCopy.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
+				sourceCopy.setCanBeConsumed(false);
 				configsToRemap.put(sourceCopy, target);
 
 				// If our remap configuration entry targets the client source set as well,

--- a/src/main/java/net/fabricmc/loom/configuration/processors/SpecContextImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/SpecContextImpl.java
@@ -129,6 +129,7 @@ public record SpecContextImpl(List<FabricModJson> modDependencies, List<FabricMo
 
 		return settings -> {
 			final Configuration configuration = settings.getSourceConfiguration().get().copyRecursive();
+			configuration.setCanBeConsumed(false);
 			configuration.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
 			return configuration.resolve().stream().map(File::toPath);
 		};


### PR DESCRIPTION
This prevents info-level log warnings from mod remapping from flooding the console. See [`DefaultConfiguration.logIfImproperConfiguration`](https://github.com/gradle/gradle/blob/0b7ae1afeef44c648872fe1be9639c95d99e0840/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java#L1742).

This PR targets 1.2 as it's still the recommended version.