### PR TITLE
Run tests against 8.3-rc1 and 8.4 nightlys

### DIFF
--- a/src/test/groovy/net/fabricmc/loom/test/LoomTestConstants.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/LoomTestConstants.groovy
@@ -24,14 +24,12 @@
 
 package net.fabricmc.loom.test
 
-import org.gradle.util.GradleVersion
-
 class LoomTestConstants {
-	private final static String NIGHTLY_VERSION = "8.3-20230702222859+0000"
+	private final static String NIGHTLY_VERSION = "8.4-20230721222403+0000"
 	private final static boolean NIGHTLY_EXISTS = nightlyExists(NIGHTLY_VERSION)
 
 	// Test against the version of Gradle being used to build loom
-	public final static String DEFAULT_GRADLE = GradleVersion.current().getVersion()
+	public final static String DEFAULT_GRADLE = "8.3-rc-1"
 	// Tests that depend specifically on the nightly will run on the current version when the nightly is not available.
 	public final static String PRE_RELEASE_GRADLE = NIGHTLY_EXISTS ? NIGHTLY_VERSION : DEFAULT_GRADLE
 	// Randomly sorted to ensure that all versions can run with a clean gradle home.


### PR DESCRIPTION
PR just to let the test run against the upcoming Gradle releses