### PR TITLE
Fix and test record access flags in 23w31a.

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/RecordAccessFixerApplyVisitor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/RecordAccessFixerApplyVisitor.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2021 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.configuration.providers.minecraft;
+
+import org.jetbrains.annotations.VisibleForTesting;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Opcodes;
+
+import net.fabricmc.loom.util.Constants;
+import net.fabricmc.tinyremapper.TinyRemapper;
+import net.fabricmc.tinyremapper.api.TrClass;
+
+/**
+ * Fixes: <a href="https://bugs.mojang.com/browse/MC-264564">MC-264564</a>.
+ */
+public final class RecordAccessFixerApplyVisitor implements TinyRemapper.ApplyVisitorProvider {
+	public static RecordAccessFixerApplyVisitor INSTANCE = new RecordAccessFixerApplyVisitor();
+
+	private static final String RECORD_SUPER_NAME = "java/lang/Record";
+
+	private RecordAccessFixerApplyVisitor() {
+	}
+
+	@Override
+	public ClassVisitor insertApplyVisitor(TrClass cls, ClassVisitor next) {
+		return new Visitor(Constants.ASM_VERSION, next);
+	}
+
+	@VisibleForTesting
+	public static class Visitor extends ClassVisitor {
+		public Visitor(int api, ClassVisitor classVisitor) {
+			super(api, classVisitor);
+		}
+
+		@Override
+		public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+			if (RECORD_SUPER_NAME.equals(superName)) {
+				// Any class that extends the record class should also have the record access flag.
+				access |= Opcodes.ACC_RECORD;
+			}
+
+			super.visit(version, access, name, signature, superName, interfaces);
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/AbstractMappedMinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/AbstractMappedMinecraftProvider.java
@@ -46,6 +46,7 @@ import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftJar;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftSourceSets;
+import net.fabricmc.loom.configuration.providers.minecraft.RecordAccessFixerApplyVisitor;
 import net.fabricmc.loom.configuration.providers.minecraft.SignatureFixerApplyVisitor;
 import net.fabricmc.loom.extension.LoomFiles;
 import net.fabricmc.loom.util.SidedClassVisitor;
@@ -191,6 +192,7 @@ public abstract class AbstractMappedMinecraftProvider<M extends MinecraftProvide
 		final Map<String, String> remappedSignatures = SignatureFixerApplyVisitor.getRemappedSignatures(getTargetNamespace() == MappingsNamespace.INTERMEDIARY, mappingConfiguration, getProject(), configContext.serviceManager(), toM);
 		TinyRemapper remapper = TinyRemapperHelper.getTinyRemapper(getProject(), configContext.serviceManager(), fromM, toM, true, (builder) -> {
 			builder.extraPostApplyVisitor(new SignatureFixerApplyVisitor(remappedSignatures));
+			builder.extraPostApplyVisitor(RecordAccessFixerApplyVisitor.INSTANCE);
 			configureRemapper(remappedJars, builder);
 		});
 

--- a/src/test/groovy/net/fabricmc/loom/test/integration/BytecodeFixesTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/BytecodeFixesTest.groovy
@@ -33,9 +33,9 @@ import static net.fabricmc.loom.test.LoomTestConstants.STANDARD_TEST_VERSIONS
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 // Basic test to just ensure it builds.
-class SignatureFixesTest extends Specification implements GradleProjectTestTrait {
+class BytecodeFixesTest extends Specification implements GradleProjectTestTrait {
 	@Unroll
-	def "build (gradle #version)"() {
+	def "signature fixes (gradle #version)"() {
 		setup:
 		def gradle = gradleProject(project: "minimalBase", version: version)
 
@@ -43,6 +43,28 @@ class SignatureFixesTest extends Specification implements GradleProjectTestTrait
                 dependencies {
                     minecraft "com.mojang:minecraft:1.18-pre1"
                     mappings "net.fabricmc:yarn:1.18-pre1+build.14:v2"
+                }
+            '''
+
+		when:
+		def result = gradle.run(task: "build")
+
+		then:
+		result.task(":build").outcome == SUCCESS
+
+		where:
+		version << STANDARD_TEST_VERSIONS
+	}
+
+	@Unroll
+	def "record access fixes (gradle #version)"() {
+		setup:
+		def gradle = gradleProject(project: "minimalBase", version: version)
+
+		gradle.buildGradle << '''
+                dependencies {
+                    minecraft "com.mojang:minecraft:23w31a"
+                    mappings loom.officialMojangMappings()
                 }
             '''
 

--- a/src/test/groovy/net/fabricmc/loom/test/unit/providers/RecordAccessFixerApplyVisitorTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/providers/RecordAccessFixerApplyVisitorTest.groovy
@@ -1,0 +1,91 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2023 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit.providers
+
+import java.nio.file.Path
+
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.ClassNode
+import spock.lang.Specification
+
+import net.fabricmc.loom.configuration.providers.minecraft.RecordAccessFixerApplyVisitor
+import net.fabricmc.loom.test.LoomTestConstants
+import net.fabricmc.loom.util.Constants
+import net.fabricmc.loom.util.ZipUtils
+
+class RecordAccessFixerApplyVisitorTest extends Specification {
+	private static final String MC_JAR_URL = "https://piston-data.mojang.com/v1/objects/ca51bf36913a7333c055096a52a3a96fbdb11813/client.jar"
+
+	def "fix record attributes"() {
+		when:
+		def mcJar = downloadJarIfNotExists(MC_JAR_URL, "23w31a.jar")
+
+		// Broken class in 23w31a
+		def adk = asClassNode(ZipUtils.unpack(mcJar, "adk.class"))
+
+		def fixed = new ClassNode()
+		adk.accept(new RecordAccessFixerApplyVisitor.Visitor(Constants.ASM_VERSION, fixed))
+
+		if (false) {
+			// Export classes for testing.
+			new File("adk.class").bytes = ZipUtils.unpack(mcJar, "adk.class")
+			new File("adk.fixed.class").bytes = classNodeToBytes(fixed)
+		}
+
+		then:
+		!isRecord(adk)
+		isRecord(fixed)
+	}
+
+	private static ClassNode asClassNode(byte[] byteArray) {
+		def classNode = new ClassNode()
+		def classReader = new ClassReader(byteArray)
+		classReader.accept(classNode, 0)
+		return classNode
+	}
+
+	private static byte[] classNodeToBytes(ClassNode classNode) {
+		def classWriter = new ClassWriter(ClassWriter.COMPUTE_FRAMES)
+		classNode.accept(classWriter)
+		return classWriter.toByteArray()
+	}
+
+	private static boolean isRecord(ClassNode classNode) {
+		return (classNode.access & Opcodes.ACC_RECORD) != 0
+	}
+
+	private static Path downloadJarIfNotExists(String url, String name) {
+		def dst = new File(LoomTestConstants.TEST_DIR, name)
+
+		if (!dst.exists()) {
+			dst.parentFile.mkdirs()
+			dst << new URL(url).newInputStream()
+		}
+
+		return dst.toPath()
+	}
+}


### PR DESCRIPTION
This fixes empty records not having the correct record attribute, without this some decompilers fail to decompile the class as a record.

Fixes: https://bugs.mojang.com/browse/MC-264564