### PR TITLE
Downloader: Protect against partially downloaded files.

### DIFF
--- a/src/main/java/net/fabricmc/loom/util/download/Download.java
+++ b/src/main/java/net/fabricmc/loom/util/download/Download.java
@@ -96,7 +96,7 @@ public final class Download {
 	}
 
 	private HttpRequest.Builder requestBuilder() {
-		return  HttpRequest.newBuilder(url)
+		return HttpRequest.newBuilder(url)
 				.timeout(TIMEOUT)
 				.version(httpVersion)
 				.GET();

--- a/src/main/java/net/fabricmc/loom/util/download/Download.java
+++ b/src/main/java/net/fabricmc/loom/util/download/Download.java
@@ -62,9 +62,11 @@ import net.fabricmc.loom.util.Checksum;
 public final class Download {
 	private static final String E_TAG = "ETag";
 	private static final Logger LOGGER = LoggerFactory.getLogger(Download.class);
+	private static final Duration TIMEOUT = Duration.ofMinutes(1);
 	private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
 			.followRedirects(HttpClient.Redirect.ALWAYS)
 			.proxy(ProxySelector.getDefault())
+			.connectTimeout(TIMEOUT)
 			.build();
 
 	public static DownloadBuilder create(String url) throws URISyntaxException {
@@ -93,17 +95,20 @@ public final class Download {
 		this.downloadAttempt = downloadAttempt;
 	}
 
-	private HttpRequest getRequest() {
-		return HttpRequest.newBuilder(url)
+	private HttpRequest.Builder requestBuilder() {
+		return  HttpRequest.newBuilder(url)
+				.timeout(TIMEOUT)
 				.version(httpVersion)
-				.GET()
+				.GET();
+	}
+
+	private HttpRequest getRequest() {
+		return requestBuilder()
 				.build();
 	}
 
 	private HttpRequest getETagRequest(String etag) {
-		return HttpRequest.newBuilder(url)
-				.version(httpVersion)
-				.GET()
+		return requestBuilder()
 				.header("If-None-Match", etag)
 				.build();
 	}


### PR DESCRIPTION
Seen one or two users on [Discord](https://discord.com/channels/507304429255393322/592749519171616796/1154450470404882432) reporting loom only downloading parts of the file, I think this is quite rare. This change should protect against failed or cancled downloads by ensuring that the output file only exists in its final state.

1. Download the file initially to a `<filename>.part` file
2. Once the file has been fully written, create a hard link to the destination file.
3. And then remove the part file, this ensures that the output file only exists in fully populated state.