### PR TITLE
Sort extra manifest attributes

### DIFF
--- a/src/test/groovy/net/fabricmc/loom/test/integration/ReproducibleBuildTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/ReproducibleBuildTest.groovy
@@ -55,13 +55,13 @@ class ReproducibleBuildTest extends Specification implements GradleProjectTestTr
 
 		where:
 		version              | modHash                               | sourceHash
-		DEFAULT_GRADLE      | "97240b42385adfaa1952e9c4ea942f71"    | [
-			"61438feb9bd548788bbc637637d202fc",
-			"185ad8396d89b726064682bf22572036"
+		DEFAULT_GRADLE      | "4bb8acb5e575a4080a8fe1282f8e1994"    | [
+			"8e8fac2a5e32fc872e6cf0f9ccc55cfd",
+			"ed331b6fae5677797a0104eba014e255"
 		]
-		PRE_RELEASE_GRADLE  | "97240b42385adfaa1952e9c4ea942f71"    | [
-			"61438feb9bd548788bbc637637d202fc",
-			"185ad8396d89b726064682bf22572036"
+		PRE_RELEASE_GRADLE  | "4bb8acb5e575a4080a8fe1282f8e1994"    | [
+			"8e8fac2a5e32fc872e6cf0f9ccc55cfd",
+			"ed331b6fae5677797a0104eba014e255"
 		]
 	}
 


### PR DESCRIPTION
This pull request fixes an issue where extra manifest attributes did not have a defined order by sorting them by their keys.

Previously, `MANIFEST.MF` could contain either of the following orders, inhibiting the reproducibility of builds:

```
Fabric-Loom-Split-Environment: true
Fabric-Loom-Client-Only-Entries: 
```
```
Fabric-Loom-Client-Only-Entries: 
Fabric-Loom-Split-Environment: true
```