### PR TITLE
Check refmaps exist before adding them to mixin configs

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
@@ -310,13 +310,15 @@ public abstract class RemapJarTask extends AbstractRemapJarTask {
 			}
 
 			for (RemapParams.RefmapData refmapData : getParameters().getMixinData().get()) {
-				int transformed = ZipUtils.transformJson(JsonObject.class, outputFile, refmapData.mixinConfigs().stream().collect(Collectors.toMap(s -> s, s -> json -> {
-					if (!json.has("refmap")) {
-						json.addProperty("refmap", refmapData.refmapName());
-					}
+				if (ZipUtils.contains(outputFile, refmapData.refmapName())) {
+					int transformed = ZipUtils.transformJson(JsonObject.class, outputFile, refmapData.mixinConfigs().stream().collect(Collectors.toMap(s -> s, s -> json -> {
+						if (!json.has("refmap")) {
+							json.addProperty("refmap", refmapData.refmapName());
+						}
 
-					return json;
-				})));
+						return json;
+					})));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
reproduction for issue this solves:

1. build a mod with an empty mixin config (no mixins specified)
2. a refmap is not generated for that config
3. loom still adds a `refmap` field to the mixin config
4. warnings from mixin about not being able to find the refmap, at runtime

So I'm simply checking whether the refmap exists before adding it. This works in the example mod, I deleted the mixins from the common sourceset but not the client sourceset and it works accordingly.