### PR TITLE
Raspberry Pi support

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
@@ -310,7 +310,7 @@ public class RunConfigSettings implements Named {
 		defaultMainClass(Constants.Knot.KNOT_CLIENT);
 
 		if (Platform.CURRENT.isRaspberryPi()) {
-			getProject().getLogger().lifecycle("Raspberry Pi detected, setting MESA_GL_VERSION_OVERRIDE=4.3");
+			getProject().getLogger().info("Raspberry Pi detected, setting MESA_GL_VERSION_OVERRIDE=4.3");
 			environmentVariable("MESA_GL_VERSION_OVERRIDE", "4.3");
 		}
 	}

--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
@@ -308,6 +308,11 @@ public class RunConfigSettings implements Named {
 		startFirstThread();
 		environment("client");
 		defaultMainClass(Constants.Knot.KNOT_CLIENT);
+
+		if (Platform.CURRENT.isRaspberryPi()) {
+			getProject().getLogger().lifecycle("Raspberry Pi detected, setting MESA_GL_VERSION_OVERRIDE=4.3");
+			environmentVariable("MESA_GL_VERSION_OVERRIDE", "4.3");
+		}
 	}
 
 	/**

--- a/src/main/java/net/fabricmc/loom/util/Platform.java
+++ b/src/main/java/net/fabricmc/loom/util/Platform.java
@@ -56,4 +56,6 @@ public interface Platform {
 	Architecture getArchitecture();
 
 	boolean supportsUnixDomainSockets();
+
+	boolean isRaspberryPi();
 }

--- a/src/test/groovy/net/fabricmc/loom/test/util/PlatformTestUtils.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/util/PlatformTestUtils.groovy
@@ -58,6 +58,11 @@ class PlatformTestUtils implements Platform  {
 		supportsUnixDomainSockets
 	}
 
+	@Override
+	boolean isRaspberryPi() {
+		return false
+	}
+
 	@Immutable
 	static class TestArchitecture implements Architecture {
 		boolean is64Bit


### PR DESCRIPTION
I recently got a Raspberry Pi 5, first thing I did was to try and run Minecraft on it. Turns it out its actually playable, once you set the `MESA_GL_VERSION_OVERRIDE=4.3` env var. Loom already handles adding the linux arm64 natives, so why not set this env var for a flawless experience on a Pi5.

I have limited this to debian bookworm (Raspbian) as its the easyist thing for me to test with.