### PR TITLE
Skip remapping in `AbstractRemapJarTask`s when source and target namespaces match

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/AbstractRemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractRemapJarTask.java
@@ -173,6 +173,18 @@ public abstract class AbstractRemapJarTask extends Jar {
 		Property<String> getSourceNamespace();
 		Property<String> getTargetNamespace();
 
+		/**
+		 * Checks whether {@link #getSourceNamespace()} and {@link #getTargetNamespace()}
+		 * have the same value. When this is {@code true}, the user does not intend for any
+		 * remapping to occur. They are using the task for its other features, such as adding
+		 * namespace to the manifest, nesting jars, reproducible builds, etc.
+		 *
+		 * @return whether the source and target namespaces match
+		 */
+		default boolean namespacesMatch() {
+			return this.getSourceNamespace().get().equals(this.getTargetNamespace().get());
+		}
+
 		Property<Boolean> getArchivePreserveFileTimestamps();
 		Property<Boolean> getArchiveReproducibleFileOrder();
 		Property<ZipEntryCompression> getEntryCompression();

--- a/src/test/groovy/net/fabricmc/loom/test/integration/SimpleProjectTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/SimpleProjectTest.groovy
@@ -54,6 +54,10 @@ class SimpleProjectTest extends Specification implements GradleProjectTestTrait 
 		gradle.getOutputZipEntry("fabric-example-mod-1.0.0.jar", "META-INF/MANIFEST.MF").contains("Fabric-Loom-Version: 0.0.0+unknown")
 		gradle.getOutputZipEntry("fabric-example-mod-1.0.0-sources.jar", "net/fabricmc/example/mixin/ExampleMixin.java").contains("class_442") // Very basic test to ensure sources got remapped
 
+		// test same-namespace remapJar tasks
+		gradle.getOutputZipEntry("fabric-example-mod-1.0.0-no-remap.jar", "META-INF/MANIFEST.MF").contains("Fabric-Loom-Version: 0.0.0+unknown")
+		gradle.getOutputZipEntry("fabric-example-mod-1.0.0-no-remap-sources.jar", "net/fabricmc/example/mixin/ExampleMixin.java").contains("TitleScreen.class") // Very basic test to ensure sources did not get remapped :)
+
 		serverResult.successful()
 		serverResult.output.contains("Hello simple Fabric mod") // A check to ensure our mod init was actually called
 		where:

--- a/src/test/resources/projects/simple/build.gradle
+++ b/src/test/resources/projects/simple/build.gradle
@@ -86,3 +86,18 @@ publishing {
 		// retrieving dependencies.
 	}
 }
+
+// test same-namespace remapJar tasks
+def noRemap = tasks.register('sameNamespaceRemapJar', net.fabricmc.loom.task.RemapJarTask) {
+	sourceNamespace = net.fabricmc.loom.api.mappings.layered.MappingsNamespace.INTERMEDIARY.toString()
+	inputFile = jar.archiveFile
+	archiveClassifier = "no-remap"
+}
+def noRemapSource = tasks.register('sameNamespaceRemapSourcesJar', net.fabricmc.loom.task.RemapSourcesJarTask) {
+	sourceNamespace = net.fabricmc.loom.api.mappings.layered.MappingsNamespace.INTERMEDIARY.toString()
+	inputFile = sourcesJar.archiveFile
+	archiveClassifier = "no-remap-sources"
+}
+tasks.assemble {
+	dependsOn(noRemap, noRemapSource)
+}


### PR DESCRIPTION
The "remap jar" tasks have much more functionality than simply remapping jars at this point, such as adding namespace metadata, nesting jars, ensuring reproducible builds, etc. Some custom build logic may want to take advantage of these features without the full overhead of no-op remapping with TinyRemapper/Mercury.