### PR TITLE
[BACKPORT 1.1->1.4] Validate jar and fail if it was built with Loom 1.5 or later.

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactMetadata.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactMetadata.java
@@ -64,6 +64,12 @@ public record ArtifactMetadata(boolean isFabricMod, RemapRequirements remapRequi
 					// Support opting into and out of remapping with "Fabric-Loom-Remap" manifest entry
 					remapRequirements = Boolean.parseBoolean(value) ? RemapRequirements.OPT_IN : RemapRequirements.OPT_OUT;
 				}
+
+				// Check to see if the jar was built with a newer version of loom.
+				// This version of loom does not support the remap type value so throw an exception.
+				if (mainAttributes.getValue("Fabric-Loom-Mixin-Remap-Type") != null) {
+					throw new IllegalStateException("This version of loom does not support the mixin remap type value. Please update to the latest version of loom.");
+				}
 			}
 
 			final Path installerPath = fs.getPath(INSTALLER_PATH);


### PR DESCRIPTION
This should be backported to 1.1, 1.2, 1.3 and 1.4.