### PR TITLE
Filter out realms connection error message from debug log

### DIFF
--- a/src/main/resources/log4j2.fabric.xml
+++ b/src/main/resources/log4j2.fabric.xml
@@ -4,8 +4,12 @@
 
 		<!--	System out	-->
 		<Console name="SysOut" target="SYSTEM_OUT">
-			<!-- Filter out the authentication error when starting in development -->
-			<RegexFilter regex="^Failed to verify authentication|^Couldn't connect to realms$" onMatch="DENY" onMismatch="ACCEPT"/>
+			<!-- Filter out the authentication errors when starting in development -->
+			<Filters>
+				<RegexFilter regex="^Failed to verify authentication$" onMatch="DENY" onMismatch="NEUTRAL"/>
+				<RegexFilter regex="^Failed to fetch user properties$" onMatch="DENY" onMismatch="NEUTRAL"/>
+				<RegexFilter regex="^Couldn't connect to realms$" onMatch="DENY" onMismatch="NEUTRAL"/>
+			</Filters>
 			<PatternLayout>
 				<LoggerNamePatternSelector defaultPattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(%logger{1})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}" disableAnsi="${sys:fabric.log.disableAnsi:-true}">
 					<!-- Dont show the logger name for minecraft classes-->

--- a/src/main/resources/log4j2.fabric.xml
+++ b/src/main/resources/log4j2.fabric.xml
@@ -5,7 +5,7 @@
 		<!--	System out	-->
 		<Console name="SysOut" target="SYSTEM_OUT">
 			<!-- Filter out the authentication error when starting in development -->
-			<RegexFilter regex="^Failed to verify authentication$" onMatch="DENY" onMismatch="ACCEPT"/>
+			<RegexFilter regex="^Failed to verify authentication|^Couldn't connect to realms$" onMatch="DENY" onMismatch="ACCEPT"/>
 			<PatternLayout>
 				<LoggerNamePatternSelector defaultPattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(%logger{1})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}" disableAnsi="${sys:fabric.log.disableAnsi:-true}">
 					<!-- Dont show the logger name for minecraft classes-->


### PR DESCRIPTION
Filter out realms connection error exception message from debug log. Using another `<RegexFilter>` did not work, hence the current regex.

![img](https://github.com/FabricMC/fabric-loom/assets/121529979/7d1f7fc3-bb67-4c95-a3eb-f10fce729075)

There are two log entries related to not being able to connect to Realms. Only the log entry related to the exception, `Couldn't connect to realms` is removed.

Sample log attached.

[log.txt](https://github.com/FabricMC/fabric-loom/files/13442639/log.txt)