### PR TITLE
Composite builds support for nested jars

### DIFF
--- a/src/test/groovy/net/fabricmc/loom/test/integration/CompositeBuildTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/CompositeBuildTest.groovy
@@ -1,0 +1,49 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2018-2021 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.integration
+
+import net.fabricmc.loom.test.util.GradleProjectTestTrait
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static net.fabricmc.loom.test.LoomTestConstants.STANDARD_TEST_VERSIONS
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class CompositeBuildTest extends Specification implements GradleProjectTestTrait {
+	@Unroll
+	def "build (gradle #version)"() {
+		setup:
+		def gradle = gradleProject(project: "composite-build", version: version)
+
+		when:
+		def result = gradle.run(task: "build")
+
+		then:
+		result.task(":build").outcome == SUCCESS
+
+		where:
+		version << STANDARD_TEST_VERSIONS
+	}
+}

--- a/src/test/resources/projects/composite-build/build.gradle
+++ b/src/test/resources/projects/composite-build/build.gradle
@@ -1,0 +1,84 @@
+plugins {
+	id 'fabric-loom'
+	id 'maven-publish'
+}
+
+version = loom.modVersion
+group = project.maven_group
+
+repositories {
+	// Add repositories to retrieve artifacts from in here.
+	// You should only use this when depending on other mods because
+	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
+	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
+	// for more information about repositories.
+}
+
+dependencies {
+	// To change the versions see the gradle.properties file
+	minecraft "com.mojang:minecraft:${project.minecraft_version}"
+	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+
+	// Fabric API. This is technically optional, but you probably want it anyway.
+	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+
+	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
+	// You may need to force-disable transitiveness on them.
+
+	// Includes included build
+	include "external:external"
+}
+
+base {
+	archivesName = project.archives_base_name
+}
+
+tasks.withType(JavaCompile).configureEach {
+	// ensure that the encoding is set to UTF-8, no matter what the system default is
+	// this fixes some edge cases with special characters not displaying correctly
+	// see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
+	// If Javadoc is generated, this must be specified in that task too.
+	it.options.encoding = "UTF-8"
+
+	// The Minecraft launcher currently installs Java 8 for users, so your mod probably wants to target Java 8 too
+	// JDK 9 introduced a new way of specifying this that will make sure no newer classes or methods are used.
+	// We'll use that if it's available, but otherwise we'll use the older option.
+	def targetVersion = 8
+	if (JavaVersion.current().isJava9Compatible()) {
+		it.options.release = targetVersion
+	}
+}
+
+java {
+	// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
+	// if it is present.
+	// If you remove this line, sources will not be generated.
+	withSourcesJar()
+
+	sourceCompatibility = JavaVersion.VERSION_1_8
+	targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+jar {
+	from("LICENSE") {
+		rename { "${it}_${base.archivesName.get()}"}
+	}
+}
+
+// configure the maven publication
+publishing {
+	publications {
+		mavenJava(MavenPublication) {
+			from components.java
+		}
+	}
+
+	// See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
+	repositories {
+		// Add repositories to publish to here.
+		// Notice: This block does NOT have the same function as the block in the top level.
+		// The repositories here will be used for publishing your artifact, not for
+		// retrieving dependencies.
+	}
+}

--- a/src/test/resources/projects/composite-build/external/build.gradle
+++ b/src/test/resources/projects/composite-build/external/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+	id 'java'
+}
+
+group = 'external'
+version = '0.0.1-SNAPSHOT'
+
+repositories {
+	mavenCentral()
+}
+
+tasks.withType(JavaCompile).configureEach {
+	it.options.encoding = "UTF-8"
+
+	def targetVersion = 8
+	if (JavaVersion.current().isJava9Compatible()) {
+		it.options.release = targetVersion
+	}
+}
+
+dependencies {
+}

--- a/src/test/resources/projects/composite-build/external/src/java/external/SomeExternalClass.java
+++ b/src/test/resources/projects/composite-build/external/src/java/external/SomeExternalClass.java
@@ -1,0 +1,4 @@
+package external;
+
+public class SomeExternalClass {
+}

--- a/src/test/resources/projects/composite-build/gradle.properties
+++ b/src/test/resources/projects/composite-build/gradle.properties
@@ -1,0 +1,16 @@
+# Done to increase the memory available to gradle.
+org.gradle.jvmargs=-Xmx1G
+
+# Fabric Properties
+	# check these on https://fabricmc.net/use
+	minecraft_version=1.16.5
+	yarn_mappings=1.16.5+build.5
+	loader_version=0.11.2
+
+# Mod Properties
+	maven_group = com.example
+	archives_base_name = fabric-example-mod
+
+# Dependencies
+	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
+	fabric_version=0.31.0+1.16

--- a/src/test/resources/projects/composite-build/settings.gradle
+++ b/src/test/resources/projects/composite-build/settings.gradle
@@ -1,0 +1,7 @@
+rootProject.name = "fabric-example-mod"
+
+includeBuild('external') {
+	dependencySubstitution {
+		substitute module('external:external') using project(':')
+	}
+}

--- a/src/test/resources/projects/composite-build/src/main/java/net/fabricmc/example/ExampleMod.java
+++ b/src/test/resources/projects/composite-build/src/main/java/net/fabricmc/example/ExampleMod.java
@@ -1,0 +1,17 @@
+package net.fabricmc.example;
+
+import net.fabricmc.api.ModInitializer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class ExampleMod implements ModInitializer {
+	public static final Logger LOGGER = LogManager.getLogger("modid");
+
+	/**
+	 * @see net.fabricmc.example
+	 */
+	@Override
+	public void onInitialize() {
+		LOGGER.info("Hello simple Fabric mod!");
+	}
+}

--- a/src/test/resources/projects/composite-build/src/main/java/net/fabricmc/example/mixin/ExampleMixin.java
+++ b/src/test/resources/projects/composite-build/src/main/java/net/fabricmc/example/mixin/ExampleMixin.java
@@ -1,0 +1,15 @@
+package net.fabricmc.example.mixin;
+
+import net.minecraft.client.gui.screen.TitleScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TitleScreen.class)
+public class ExampleMixin {
+	@Inject(at = @At("HEAD"), method = "init()V")
+	private void init(CallbackInfo info) {
+		System.out.println("This line is printed by an example mod mixin!");
+	}
+}

--- a/src/test/resources/projects/composite-build/src/main/resources/fabric.mod.json
+++ b/src/test/resources/projects/composite-build/src/main/resources/fabric.mod.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": 1,
+  "id": "modid",
+  "version": "1.0.0",
+
+  "name": "Example Mod",
+  "description": "This is an example description! Tell everyone what your mod is about!",
+  "authors": [
+    "Me!"
+  ],
+  "contact": {
+    "homepage": "https://fabricmc.net/",
+    "sources": "https://github.com/FabricMC/fabric-example-mod"
+  },
+
+  "license": "CC0-1.0",
+
+  "environment": "*",
+  "entrypoints": {
+    "main": [
+      "net.fabricmc.example.ExampleMod"
+    ]
+  },
+  "mixins": [
+    "modid.mixins.json"
+  ],
+
+  "depends": {
+    "fabricloader": ">=0.7.4",
+    "fabric": "*",
+    "minecraft": "1.16.x"
+  },
+  "suggests": {
+    "another-mod": "*"
+  }
+}

--- a/src/test/resources/projects/composite-build/src/main/resources/modid.mixins.json
+++ b/src/test/resources/projects/composite-build/src/main/resources/modid.mixins.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "net.fabricmc.example.mixin",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+  ],
+  "client": [
+    "ExampleMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
Resolves #975 

This delays dependency resolution for nested jars until it is actually needed because dependencies substituted from included builds doesn't actually resolve during configuration phase. 

This also adds `nestedConfigurations` for `RemapJar`, allowing custom configurations to be used for inclusion. 
Note that this still retains the behavior of not adding transitive dependencies as nested jars.