### PR TITLE
Don't resolve source artifacts in CI

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
@@ -257,6 +257,10 @@ public class ModConfigurationRemapper {
 
 	@Nullable
 	public static Path findSources(Project project, ResolvedArtifact artifact) {
+		if (isCIBuild()) {
+			return null;
+		}
+
 		final DependencyHandler dependencies = project.getDependencies();
 
 		@SuppressWarnings("unchecked") ArtifactResolutionQuery query = dependencies.createArtifactResolutionQuery()


### PR DESCRIPTION
We don't remap them anyway, so the dependencies already effectively have no source artifact in CI.