### PR TITLE
Exclude all *.existing.json files from jar

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/FabricApiExtension.java
+++ b/src/main/java/net/fabricmc/loom/configuration/FabricApiExtension.java
@@ -127,7 +127,7 @@ public abstract class FabricApiExtension {
 		// Exclude the cache dir from the output jar to ensure reproducibility.
 		taskContainer.getByName(JavaPlugin.JAR_TASK_NAME, task -> {
 			Jar jar = (Jar) task;
-			jar.exclude(".cache/**");
+			jar.exclude(".cache/**", "**/*.existing.json");
 		});
 
 		taskContainer.getByName(LifecycleBasePlugin.CLEAN_TASK_NAME, task -> {


### PR DESCRIPTION
Kinda a extension of excluding .cache files from the jar but excludes the .existing.json files that some use for lang datagen from the jar as they cannot be used by the game 