### PR TITLE
Allow disabling RunConfig appending project path

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/FabricApiExtension.java
+++ b/src/main/java/net/fabricmc/loom/configuration/FabricApiExtension.java
@@ -28,7 +28,9 @@ import java.io.File;
 import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Inject;
 import javax.xml.parsers.DocumentBuilder;
@@ -117,7 +119,9 @@ public abstract class FabricApiExtension {
 		if (settings.getAddToResources().get()) {
 			mainSourceSet.resources(files -> {
 				// Add the src/main/generated to the main sourceset's resources.
-				files.getSrcDirs().add(outputDirectory);
+				Set<File> srcDirs = new HashSet<>(files.getSrcDirs());
+				srcDirs.add(outputDirectory);
+				files.setSrcDirs(srcDirs);
 			});
 		}
 

--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
@@ -111,8 +111,11 @@ public class RunConfig {
 		return e;
 	}
 
-	private static void populate(Project project, LoomGradleExtension extension, RunConfig runConfig, String environment) {
-		runConfig.configName += extension.isRootProject() ? "" : " (" + project.getPath() + ")";
+	private static void populate(Project project, LoomGradleExtension extension, RunConfig runConfig, String environment, boolean appendProjectPath) {
+		if (appendProjectPath && !extension.isRootProject()) {
+			runConfig.configName += " (" + project.getPath() + ")";
+		}
+
 		runConfig.eclipseProjectName = project.getExtensions().getByType(EclipseModel.class).getProject().getName();
 
 		runConfig.mainClass = "net.fabricmc.devlaunchinjector.Main";
@@ -167,9 +170,10 @@ public class RunConfig {
 			runDir = "run";
 		}
 
+		boolean appendProjectPath = settings.getAppendProjectPathToConfigName();
 		RunConfig runConfig = new RunConfig();
 		runConfig.configName = configName;
-		populate(project, extension, runConfig, environment);
+		populate(project, extension, runConfig, environment, appendProjectPath);
 		runConfig.ideaModuleName = IdeaUtils.getIdeaModuleName(new SourceSetReference(sourceSet, project));
 		runConfig.runDirIdeaUrl = "file://$PROJECT_DIR$/" + runDir;
 		runConfig.runDir = runDir;

--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
@@ -67,8 +67,19 @@ public class RunConfigSettings implements Named {
 	 * The full name of the run configuration, i.e. 'Minecraft Client'.
 	 *
 	 * <p>By default this is determined from the base name.
+	 *
+	 * <p>Note: unless the project is the root project (or {@link #appendProjectPathToConfigName} is disabled),
+	 * the project path will be appended automatically, e.g. 'Minecraft Client (:some:project)'.
 	 */
 	private String configName;
+
+	/**
+	 * Whether to append the project path to the {@link #configName} when {@code project} isn't the root project.
+	 *
+	 * <p>Warning: could produce ambiguous run config names if disabled, unless used carefully in conjunction with
+	 * {@link #configName}.
+	 */
+	private boolean appendProjectPathToConfigName;
 
 	/**
 	 * The default main class of the run configuration.
@@ -117,6 +128,7 @@ public class RunConfigSettings implements Named {
 	public RunConfigSettings(Project project, String name) {
 		this.name = name;
 		this.project = project;
+		this.appendProjectPathToConfigName = true;
 		this.extension = LoomGradleExtension.get(project);
 		this.ideConfigGenerated = extension.isRootProject();
 		this.mainClass = project.getObjects().property(String.class).convention(project.provider(() -> {
@@ -172,6 +184,14 @@ public class RunConfigSettings implements Named {
 
 	public void setConfigName(String name) {
 		this.configName = name;
+	}
+
+	public boolean getAppendProjectPathToConfigName() {
+		return appendProjectPathToConfigName;
+	}
+
+	public void setAppendProjectPathToConfigName(boolean append) {
+		appendProjectPathToConfigName = append;
 	}
 
 	public String getDefaultMainClass() {


### PR DESCRIPTION
I'd like to have more control over run config names in sub-projects, for example something like:

```gradle
allprojects {
  loom {
    runs {
      client {
        configName "Run ${project.path.replaceAll ':', ' '}"
        appendProjectPathToConfigName false
      }
      remove server
    }
  }
}
```

This PR adds that capability.

All tests passed when running `:check` locally.

I'd like to have introduced a test for both the default & modified behavior, however I'm a bit lost in your test suite and didn't want to spend much time on this PR without knowing how it'd be received.

If someone more knowledgeable would like to write a test or guide me through the process that'd be appreciated.