### PR TITLE
Remove jackson

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,6 @@ dependencies {
 	// libraries
 	implementation libs.commons.io
 	implementation libs.gson
-	implementation libs.jackson
 	implementation libs.guava
 	implementation libs.bundles.asm
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,6 @@ kotlin = "1.9.0"
 asm = "9.6"
 commons-io = "2.15.0"
 gson = "2.10.1"
-jackson = "2.16.0"
 guava = "33.0.0-jre"
 
 stitch = "0.6.2"
@@ -31,7 +30,6 @@ asm-util = { module = "org.ow2.asm:asm-util", version.ref = "asm" }
 
 commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
-jackson = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 
 fabric-stitch = { module = "net.fabricmc:stitch", version.ref = "stitch" }

--- a/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
@@ -27,8 +27,6 @@ package net.fabricmc.loom;
 import java.util.List;
 import java.util.Objects;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -52,7 +50,6 @@ import net.fabricmc.loom.util.LibraryLocationLogger;
 
 public class LoomGradlePlugin implements BootstrappedPlugin {
 	public static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
-	public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 	public static final String LOOM_VERSION = Objects.requireNonNullElse(LoomGradlePlugin.class.getPackage().getImplementationVersion(), "0.0.0+unknown");
 
 	/**

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsDependency.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsDependency.java
@@ -118,7 +118,7 @@ public class LayeredMappingsDependency implements SelfResolvingDependency, FileC
 			return;
 		}
 
-		byte[] data = LoomGradlePlugin.OBJECT_MAPPER.writeValueAsString(signatureFixes).getBytes(StandardCharsets.UTF_8);
+		byte[] data = LoomGradlePlugin.GSON.toJson(signatureFixes).getBytes(StandardCharsets.UTF_8);
 
 		ZipUtils.add(mappingsFile, "extras/record_signatures.json", data);
 	}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
@@ -235,7 +235,7 @@ public class MappingConfiguration {
 
 		try (Reader reader = Files.newBufferedReader(recordSignaturesJsonPath, StandardCharsets.UTF_8)) {
 			//noinspection unchecked
-			signatureFixes = LoomGradlePlugin.OBJECT_MAPPER.readValue(reader, Map.class);
+			signatureFixes = LoomGradlePlugin.GSON.fromJson(reader, Map.class);
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/unpick/UnpickLayer.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/unpick/UnpickLayer.java
@@ -46,15 +46,15 @@ public interface UnpickLayer {
 			final Metadata metadata;
 
 			try (Reader reader = Files.newBufferedReader(metadataPath, StandardCharsets.UTF_8)) {
-				metadata = LoomGradlePlugin.OBJECT_MAPPER.readValue(reader, Metadata.class);
+				metadata = LoomGradlePlugin.GSON.fromJson(reader, Metadata.class);
 			}
 
 			return new UnpickData(metadata, definitions);
 		}
 
 		public record Metadata(int version, String unpickGroup, String unpickVersion) {
-			public String asJson() throws IOException {
-				return LoomGradlePlugin.OBJECT_MAPPER.writeValueAsString(this);
+			public String asJson() {
+				return LoomGradlePlugin.GSON.toJson(this);
 			}
 		}
 	}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
@@ -115,7 +115,7 @@ public final class MinecraftMetadataProvider {
 		}
 
 		final String versionManifest = builder.downloadString(cacheFile);
-		return LoomGradlePlugin.OBJECT_MAPPER.readValue(versionManifest, ManifestVersion.class);
+		return LoomGradlePlugin.GSON.fromJson(versionManifest, ManifestVersion.class);
 	}
 
 	private MinecraftVersionMeta readVersionMeta() throws IOException {
@@ -128,7 +128,7 @@ public final class MinecraftMetadataProvider {
 		}
 
 		final String json = builder.downloadString(options.minecraftMetadataPath());
-		return LoomGradlePlugin.OBJECT_MAPPER.readValue(json, MinecraftVersionMeta.class);
+		return LoomGradlePlugin.GSON.fromJson(json, MinecraftVersionMeta.class);
 	}
 
 	public record Options(String minecraftVersion,

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/assets/AssetIndex.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/assets/AssetIndex.java
@@ -28,10 +28,10 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.SerializedName;
 
 @SuppressWarnings("unused")
-public record AssetIndex(Map<String, Entry> objects, boolean virtual, @JsonProperty("map_to_resources") boolean mapToResources) {
+public record AssetIndex(Map<String, Entry> objects, boolean virtual, @SerializedName("map_to_resources") boolean mapToResources) {
 	public AssetIndex() {
 		this(new LinkedHashMap<>(), false, false);
 	}

--- a/src/main/java/net/fabricmc/loom/task/DownloadAssetsTask.java
+++ b/src/main/java/net/fabricmc/loom/task/DownloadAssetsTask.java
@@ -122,7 +122,7 @@ public abstract class DownloadAssetsTask extends AbstractLoomTask {
 				.sha1(assetIndex.sha1())
 				.downloadString(indexFile.toPath());
 
-		return LoomGradlePlugin.OBJECT_MAPPER.readValue(json, AssetIndex.class);
+		return LoomGradlePlugin.GSON.fromJson(json, AssetIndex.class);
 	}
 
 	private Path getAssetsPath(AssetIndex.Object object, AssetIndex index) {

--- a/src/main/java/net/fabricmc/loom/util/LibraryLocationLogger.java
+++ b/src/main/java/net/fabricmc/loom/util/LibraryLocationLogger.java
@@ -26,7 +26,6 @@ package net.fabricmc.loom.util;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
 import kotlinx.metadata.jvm.KotlinClassMetadata;
@@ -53,7 +52,6 @@ public final class LibraryLocationLogger {
 			ClassRemapper.class,
 			ClassNode.class,
 			ASMifier.class,
-			ObjectMapper.class,
 			Gson.class,
 			Preconditions.class,
 			FileUtils.class

--- a/src/main/java/net/fabricmc/loom/util/ZipUtils.java
+++ b/src/main/java/net/fabricmc/loom/util/ZipUtils.java
@@ -123,7 +123,7 @@ public class ZipUtils {
 
 	public static <T> T unpackJackson(Path zip, String path, Class<T> clazz) throws IOException {
 		final byte[] bytes = unpack(zip, path);
-		return LoomGradlePlugin.OBJECT_MAPPER.readValue(new String(bytes, StandardCharsets.UTF_8), clazz);
+		return LoomGradlePlugin.GSON.fromJson(new String(bytes, StandardCharsets.UTF_8), clazz);
 	}
 
 	public static void pack(Path from, Path zip) throws IOException {

--- a/src/test/groovy/net/fabricmc/loom/test/benchmark/SimpleBenchmark.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/benchmark/SimpleBenchmark.groovy
@@ -39,9 +39,6 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 @Singleton
 class SimpleBenchmark implements GradleProjectTestTrait {
 	def run(File dir) {
-		// Forces loom to refresh files
-		System.setProperty("loom.refresh", "true")
-
 		def gradle = gradleProject(
 				project: "minimalBase",
 				version: LoomTestConstants.PRE_RELEASE_GRADLE,

--- a/src/test/groovy/net/fabricmc/loom/test/unit/library/LibraryContextTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/library/LibraryContextTest.groovy
@@ -131,7 +131,7 @@ class LibraryContextTest extends Specification {
 					}
 				  ]
 				}"""
-		def context = new LibraryContext(MinecraftTestUtils.OBJECT_MAPPER.readValue(metaJson, MinecraftVersionMeta.class), JavaVersion.VERSION_17)
+		def context = new LibraryContext(MinecraftTestUtils.GSON.fromJson(metaJson, MinecraftVersionMeta.class), JavaVersion.VERSION_17)
 
 		then:
 		context.supportsJava19OrLater() == supportsJava19OrLater

--- a/src/test/groovy/net/fabricmc/loom/test/util/MinecraftTestUtils.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/util/MinecraftTestUtils.groovy
@@ -26,8 +26,8 @@ package net.fabricmc.loom.test.util
 
 import java.time.Duration
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
 
 import net.fabricmc.loom.configuration.providers.minecraft.ManifestVersion
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftVersionMeta
@@ -37,15 +37,15 @@ import net.fabricmc.loom.util.download.Download
 
 class MinecraftTestUtils {
 	private static final File TEST_DIR = new File(LoomTestConstants.TEST_DIR, "minecraft")
-	public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+	public static final Gson GSON = new GsonBuilder().create()
 
 	static MinecraftVersionMeta getVersionMeta(String id) {
 		def versionManifest = download(Constants.VERSION_MANIFESTS, "version_manifest.json")
-		def manifest = OBJECT_MAPPER.readValue(versionManifest, ManifestVersion.class)
+		def manifest = GSON.fromJson(versionManifest, ManifestVersion.class)
 		def version = manifest.versions().find { it.id == id }
 
 		def metaJson = download(version.url, "${id}.json")
-		OBJECT_MAPPER.readValue(metaJson, MinecraftVersionMeta.class)
+		GSON.fromJson(metaJson, MinecraftVersionMeta.class)
 	}
 
 	static String download(String url, String name) {


### PR DESCRIPTION
Jackson was orignaly added as it supported records meanwhile GSON did not. Now that GSON supports records I dont think there is a reason to use Jackson.

Doing this saves a tiny bit of time downloading jackson and creating the ObjectMapper instance.