### PR TITLE
Some minor peformance improvements.

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2021-2022 FabricMC
+ * Copyright (c) 2021-2024 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -124,12 +124,9 @@ public abstract class RemapJarTask extends AbstractRemapJarTask {
 		mustRunAfter(prepareJarTask);
 
 		getProject().getGradle().allprojects(project -> {
-			project.getTasks().configureEach(task -> {
-				if (task instanceof PrepareJarRemapTask otherTask) {
-					// Ensure that all remap jars run after all prepare tasks
-					mustRunAfter(otherTask);
-				}
-			});
+			project.getTasks()
+					.withType(PrepareJarRemapTask.class)
+					.configureEach(this::mustRunAfter);
 		});
 	}
 

--- a/src/test/groovy/net/fabricmc/loom/test/benchmark/FabricAPIBenchmark.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/benchmark/FabricAPIBenchmark.groovy
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2022 FabricMC
+ * Copyright (c) 2022-2024 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,11 +44,19 @@ class FabricAPIBenchmark implements GradleProjectTestTrait {
 				allowExistingRepo: true,
 
 				repo: "https://github.com/FabricMC/fabric.git",
-				commit: "2facd446984085376bd23245410ebf2dc0881b02",
+				commit: "efa5891941a32589207dc58c2e77183d599465b8",
 				patch: "fabric_api"
 				)
 
 		gradle.enableMultiProjectOptimisation()
+
+		if (!gradle.buildGradle.text.contains("loom.mixin.useLegacyMixinAp")) {
+			gradle.buildGradle << """
+				allprojects {
+					loom.mixin.useLegacyMixinAp = false
+				}
+				""".stripIndent()
+		}
 
 		def timeStart = new Date()
 


### PR DESCRIPTION
Decided to profile FAPIs configuration, with these changes its down to 8 seconds.

The main change is to update the last modified time when the etag matches a downloaded file. Previously if the version_metadata.json was over 24 hours old, it would always check the etag. Now it updates the last modified time on the file when the etag matches.

I only noticed this as I was testing with an older Gradle home that had the latest version_metadata, but was older than 24 hours, its no surprise this went under the radar.