### PR TITLE
Improve locking strategy for concurrent loom executions

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -296,7 +296,7 @@ public abstract class CompileConfiguration implements Runnable {
 				return LockResult.ACQUIRED_ALREADY_OWNED;
 			}
 
-			logger.lifecycle("Lock file \"{}\" is currently held by pid '{}'.", lockFile, lockingProcessId);
+			logger.lifecycle("\"{}\" is currently held by pid '{}'.", lockFile, lockingProcessId);
 
 			if (ProcessHandle.of(lockingProcessId).isEmpty()) {
 				logger.lifecycle("Locking process does not exist, assuming abrupt termination and deleting lock file.");


### PR DESCRIPTION
This does **not** allow building a project concurrently, and that is not a goal of this change. The goal of this change is to prevent the loom cache from being invalidated when IntelliJ syncs the project on its own during a user-requested Gradle run.