### PR TITLE
Prepare for SelfResolvingDependency's removal & Update to Gradle 8.6

### DIFF
--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [8.3.0-jdk17]
+        version: [8.6.0-jdk17]
     runs-on: ubuntu-22.04
     container:
       image: gradle:${{ matrix.version }}
@@ -39,7 +39,7 @@ jobs:
 
     runs-on: ubuntu-22.04
     container:
-      image: gradle:8.3.0-jdk17
+      image: gradle:8.6.0-jdk17
       options: --user root
 
     steps:
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [8.3.0-jdk17]
+        version: [8.6.0-jdk17]
         test: ${{ fromJson(needs.prepare_test_matrix.outputs.matrix) }}
 
     runs-on: ubuntu-22.04

--- a/bootstrap/src/main/java/net/fabricmc/loom/bootstrap/LoomGradlePluginBootstrap.java
+++ b/bootstrap/src/main/java/net/fabricmc/loom/bootstrap/LoomGradlePluginBootstrap.java
@@ -14,7 +14,7 @@ import org.gradle.util.GradleVersion;
  */
 @SuppressWarnings("unused")
 public class LoomGradlePluginBootstrap implements Plugin<PluginAware> {
-	private static final String MIN_SUPPORTED_GRADLE_VERSION = "8.3";
+	private static final String MIN_SUPPORTED_GRADLE_VERSION = "8.6";
 	private static final int MIN_SUPPORTED_MAJOR_JAVA_VERSION = 17;
 	private static final int MIN_SUPPORTED_MAJOR_IDEA_VERSION = 2021;
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.9.0"
+kotlin = "1.9.20"
 asm = "9.6"
 commons-io = "2.15.1"
 gson = "2.10.1"
@@ -11,7 +11,7 @@ access-widener = "2.1.0"
 mapping-io = "0.5.1"
 lorenz-tiny = "4.0.2"
 mercury = "0.4.1"
-kotlinx-metadata = "0.8.0"
+kotlinx-metadata = "0.9.0"
 
 # Plugins
 spotless = "6.20.0"

--- a/gradle/test.libs.versions.toml
+++ b/gradle/test.libs.versions.toml
@@ -6,7 +6,7 @@ mockito = "5.8.0"
 java-debug = "0.50.0"
 mixin = "0.11.4+mixin.0.8.5"
 
-gradle-nightly = "8.7-20240104001326+0000"
+gradle-nightly = "8.7-20240202001338+0000"
 fabric-loader = "0.15.3"
 fabric-installer = "1.0.0"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -25,6 +25,7 @@
 package net.fabricmc.loom;
 
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
 
 import org.gradle.api.Project;
@@ -38,12 +39,14 @@ import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.configuration.InstallerData;
 import net.fabricmc.loom.configuration.LoomDependencyManager;
 import net.fabricmc.loom.configuration.accesswidener.AccessWidenerFile;
+import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsFactory;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.library.LibraryProcessorManager;
 import net.fabricmc.loom.configuration.providers.minecraft.mapped.IntermediaryMinecraftProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.mapped.NamedMinecraftProvider;
 import net.fabricmc.loom.extension.LoomFiles;
+import net.fabricmc.loom.extension.LoomProblemReporter;
 import net.fabricmc.loom.extension.MixinExtension;
 import net.fabricmc.loom.extension.RemapperExtensionHolder;
 import net.fabricmc.loom.util.download.DownloadBuilder;
@@ -118,4 +121,8 @@ public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 	ListProperty<LibraryProcessorManager.LibraryProcessorFactory> getLibraryProcessors();
 
 	ListProperty<RemapperExtensionHolder> getRemapperExtensions();
+
+	Collection<LayeredMappingsFactory> getLayeredMappingFactories();
+
+	LoomProblemReporter getProblemReporter();
 }

--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -53,6 +53,7 @@ import net.fabricmc.loom.configuration.accesswidener.AccessWidenerJarProcessor;
 import net.fabricmc.loom.configuration.ifaceinject.InterfaceInjectionProcessor;
 import net.fabricmc.loom.configuration.processors.MinecraftJarProcessorManager;
 import net.fabricmc.loom.configuration.processors.ModJavadocProcessor;
+import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsFactory;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftJarConfiguration;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
@@ -147,6 +148,9 @@ public abstract class CompileConfiguration implements Runnable {
 		final MinecraftProvider minecraftProvider = jarConfiguration.getMinecraftProviderFunction().apply(configContext);
 		extension.setMinecraftProvider(minecraftProvider);
 		minecraftProvider.provide();
+
+		// Created any layered mapping files.
+		LayeredMappingsFactory.afterEvaluate(configContext);
 
 		final DependencyInfo mappingsDep = DependencyInfo.create(getProject(), Configurations.MAPPINGS);
 		final MappingConfiguration mappingConfiguration = MappingConfiguration.create(getProject(), configContext.serviceManager(), mappingsDep, minecraftProvider);

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactRef.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactRef.java
@@ -80,7 +80,7 @@ public interface ArtifactRef {
 		public void applyToConfiguration(Project project, Configuration configuration) {
 			final DependencyHandler dependencies = project.getDependencies();
 
-			Dependency dep = dependencies.module(artifact.getModuleVersion() + (artifact.getClassifier() == null ? "" : ':' + artifact.getClassifier())); // the owning module of the artifact
+			Dependency dep = dependencies.create(artifact.getModuleVersion() + (artifact.getClassifier() == null ? "" : ':' + artifact.getClassifier())); // the owning module of the artifact
 
 			if (dep instanceof ModuleDependency moduleDependency) {
 				moduleDependency.setTransitive(false);

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingSpecBuilderImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingSpecBuilderImpl.java
@@ -85,4 +85,10 @@ public class LayeredMappingSpecBuilderImpl implements LayeredMappingSpecBuilder 
 
 		return new LayeredMappingSpec(Collections.unmodifiableList(builtLayers));
 	}
+
+	public static LayeredMappingSpec buildOfficialMojangMappings() {
+		var builder = new LayeredMappingSpecBuilderImpl();
+		builder.officialMojangMappings();
+		return builder.build();
+	}
 }

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2021-2022 FabricMC
+ * Copyright (c) 2021-2024 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,8 @@ package net.fabricmc.loom.extension;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.gradle.api.Action;
@@ -59,10 +61,9 @@ import net.fabricmc.loom.api.remapping.RemapperParameters;
 import net.fabricmc.loom.configuration.RemapConfigurations;
 import net.fabricmc.loom.configuration.ide.RunConfigSettings;
 import net.fabricmc.loom.configuration.processors.JarProcessor;
-import net.fabricmc.loom.configuration.providers.mappings.GradleMappingContext;
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingSpec;
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingSpecBuilderImpl;
-import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsDependency;
+import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsFactory;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftJarConfiguration;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftSourceSets;
 import net.fabricmc.loom.task.GenerateSourcesTask;
@@ -101,6 +102,8 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 
 	// A common mistake with layered mappings is to call the wrong `officialMojangMappings` method, use this to keep track of when we are building a layered mapping spec.
 	protected final ThreadLocal<Boolean> layeredSpecBuilderScope = ThreadLocal.withInitial(() -> false);
+
+	protected final Map<LayeredMappingSpec, LayeredMappingsFactory> layeredMappingsDependencyMap = new HashMap<>();
 
 	protected LoomGradleExtensionApiImpl(Project project, LoomFiles directories) {
 		this.jarProcessors = project.getObjects().listProperty(JarProcessor.class)
@@ -216,8 +219,10 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 		action.execute(builder);
 		layeredSpecBuilderScope.set(false);
 
-		LayeredMappingSpec builtSpec = builder.build();
-		return new LayeredMappingsDependency(getProject(), new GradleMappingContext(getProject(), builtSpec.getVersion().replace("+", "_").replace(".", "_")), builtSpec, builtSpec.getVersion());
+		final LayeredMappingSpec builtSpec = builder.build();
+		// TODO maybe throw if we are too late?
+		final LayeredMappingsFactory layeredMappingsFactory = layeredMappingsDependencyMap.computeIfAbsent(builtSpec, LayeredMappingsFactory::new);
+		return layeredMappingsFactory.createDependency(getProject());
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2021 FabricMC
+ * Copyright (c) 2021-2024 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,6 +27,8 @@ package net.fabricmc.loom.extension;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -43,6 +45,7 @@ import net.fabricmc.loom.configuration.InstallerData;
 import net.fabricmc.loom.configuration.LoomDependencyManager;
 import net.fabricmc.loom.configuration.accesswidener.AccessWidenerFile;
 import net.fabricmc.loom.configuration.providers.mappings.IntermediaryMappingsProvider;
+import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsFactory;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.library.LibraryProcessorManager;
@@ -70,6 +73,7 @@ public class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl implemen
 	private boolean refreshDeps;
 	private Provider<Boolean> multiProjectOptimisation;
 	private final ListProperty<LibraryProcessorManager.LibraryProcessorFactory> libraryProcessorFactories;
+	private final LoomProblemReporter problemReporter;
 
 	public LoomGradleExtensionImpl(Project project, LoomFiles files) {
 		super(project, files);
@@ -97,6 +101,8 @@ public class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl implemen
 		if (refreshDeps) {
 			project.getLogger().lifecycle("Refresh dependencies is in use, loom will be significantly slower.");
 		}
+
+		problemReporter = project.getObjects().newInstance(LoomProblemReporter.class);
 	}
 
 	@Override
@@ -253,11 +259,21 @@ public class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl implemen
 	}
 
 	@Override
+	public Collection<LayeredMappingsFactory> getLayeredMappingFactories() {
+		return Collections.unmodifiableCollection(layeredMappingsDependencyMap.values());
+	}
+
+	@Override
 	protected <T extends IntermediateMappingsProvider> void configureIntermediateMappingsProviderInternal(T provider) {
 		provider.getMinecraftVersion().set(getProject().provider(() -> getMinecraftProvider().minecraftVersion()));
 		provider.getMinecraftVersion().disallowChanges();
 
 		provider.getDownloader().set(this::download);
 		provider.getDownloader().disallowChanges();
+	}
+
+	@Override
+	public LoomProblemReporter getProblemReporter() {
+		return problemReporter;
 	}
 }

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
@@ -260,6 +260,7 @@ public class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl implemen
 
 	@Override
 	public Collection<LayeredMappingsFactory> getLayeredMappingFactories() {
+		hasEvaluatedLayeredMappings = true;
 		return Collections.unmodifiableCollection(layeredMappingsDependencyMap.values());
 	}
 

--- a/src/main/java/net/fabricmc/loom/extension/LoomProblemReporter.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomProblemReporter.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2024 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.extension;
+
+import javax.inject.Inject;
+
+import org.gradle.api.problems.ProblemReporter;
+import org.gradle.api.problems.Problems;
+import org.gradle.api.problems.Severity;
+
+public abstract class LoomProblemReporter {
+	private final ProblemReporter problemReporter;
+
+	@Inject
+	public LoomProblemReporter(Problems problems) {
+		this.problemReporter = problems.forNamespace("net.fabricmc.loom");
+	}
+
+	public void reportSelfResolvingDependencyUsage() {
+		problemReporter.reporting(spec -> spec
+				.label("SelfResolvingDependency is deprecated")
+				.details("SelfResolvingDependency has been deprecated for removal in Gradle 9")
+				.solution("Please replace usages of SelfResolvingDependency")
+				.documentedAt("https://github.com/gradle/gradle/pull/27420")
+				.severity(Severity.WARNING)
+				.stackLocation()
+		);
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/MigrateMappingsTask.java
+++ b/src/main/java/net/fabricmc/loom/task/MigrateMappingsTask.java
@@ -26,8 +26,10 @@ package net.fabricmc.loom.task;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
@@ -50,8 +52,8 @@ import org.gradle.work.DisableCachingByDefault;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
-import net.fabricmc.loom.api.mappings.layered.spec.LayeredMappingSpecBuilder;
-import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsDependency;
+import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingSpecBuilderImpl;
+import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsFactory;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
 import net.fabricmc.loom.util.FileSystemUtil;
 import net.fabricmc.loom.util.SourceRemapper;
@@ -133,8 +135,8 @@ public abstract class MigrateMappingsTask extends AbstractLoomTask {
 					throw new UnsupportedOperationException("Migrating Mojang mappings is currently only supported for the specified minecraft version");
 				}
 
-				LayeredMappingsDependency dep = (LayeredMappingsDependency) getExtension().layered(LayeredMappingSpecBuilder::officialMojangMappings);
-				files = dep.resolve();
+				LayeredMappingsFactory dep = new LayeredMappingsFactory(LayeredMappingSpecBuilderImpl.buildOfficialMojangMappings());
+				files = Collections.singleton(dep.resolve(getProject()).toFile());
 			} else {
 				Dependency dependency = project.getDependencies().create(mappings);
 				files = project.getConfigurations().detachedConfiguration(dependency).resolve();
@@ -143,11 +145,13 @@ public abstract class MigrateMappingsTask extends AbstractLoomTask {
 			project.getLogger().info("Could not locate mappings, presuming V2 Yarn");
 
 			try {
-				files = project.getConfigurations().detachedConfiguration(project.getDependencies().module(ImmutableMap.of("group", "net.fabricmc", "name", "yarn", "version", mappings, "classifier", "v2"))).resolve();
+				files = project.getConfigurations().detachedConfiguration(project.getDependencies().create(ImmutableMap.of("group", "net.fabricmc", "name", "yarn", "version", mappings, "classifier", "v2"))).resolve();
 			} catch (GradleException ignored2) {
 				project.getLogger().info("Could not locate mappings, presuming V1 Yarn");
-				files = project.getConfigurations().detachedConfiguration(project.getDependencies().module(ImmutableMap.of("group", "net.fabricmc", "name", "yarn", "version", mappings))).resolve();
+				files = project.getConfigurations().detachedConfiguration(project.getDependencies().create(ImmutableMap.of("group", "net.fabricmc", "name", "yarn", "version", mappings))).resolve();
 			}
+		} catch (IOException e) {
+			throw new UncheckedIOException("Failed to resolve mappings", e);
 		}
 
 		if (files.isEmpty()) {

--- a/src/main/java/net/fabricmc/loom/util/gradle/SelfResolvingDependencyUtils.java
+++ b/src/main/java/net/fabricmc/loom/util/gradle/SelfResolvingDependencyUtils.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2024 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util.gradle;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.FileCollectionDependency;
+
+// SelfResolvingDependency is deprecated for removal, use reflection to ensure backwards compat.
+@Deprecated
+public class SelfResolvingDependencyUtils {
+	// Set this system prop to disable SRD support before Gradle does.
+	public static final boolean DISABLE_SRD_SUPPORT = System.getProperty("fabric.loom.disable.srd") != null;
+
+	private static final String SELF_RESOLVING_DEPENDENCY_CLASS_NAME = "org.gradle.api.artifacts.SelfResolvingDependency";
+	@Nullable
+	private static final Class<?> SELF_RESOLVING_DEPENDENCY_CLASS = getSelfResolvingDependencyOrNull();
+	@Nullable
+	private static final Method RESOLVE_METHOD = getResolveMethod(SELF_RESOLVING_DEPENDENCY_CLASS);
+
+	/**
+	 * @return true when dependency is a SelfResolvingDependency but NOT a FileCollectionDependency.
+	 */
+	public static boolean isExplicitSRD(Dependency dependency) {
+		// FileCollectionDependency is usually the replacement for SelfResolvingDependency
+		if (dependency instanceof FileCollectionDependency) {
+			return false;
+		}
+
+		return isSRD(dependency);
+	}
+
+	private static boolean isSRD(Dependency dependency) {
+		if (SELF_RESOLVING_DEPENDENCY_CLASS == null) {
+			return false;
+		}
+
+		return dependency.getClass().isAssignableFrom(SELF_RESOLVING_DEPENDENCY_CLASS);
+	}
+
+	public static Set<File> resolve(Dependency dependency) {
+		if (!isSRD(dependency)) {
+			throw new IllegalStateException("dependency is not a SelfResolvingDependency");
+		}
+
+		try {
+			return (Set<File>) RESOLVE_METHOD.invoke(dependency);
+		} catch (IllegalAccessException | InvocationTargetException e) {
+			throw new RuntimeException("Failed to resolve SelfResolvingDependency", e);
+		}
+	}
+
+	@Nullable
+	private static Class<?> getSelfResolvingDependencyOrNull() {
+		if (DISABLE_SRD_SUPPORT) {
+			// Lets pretend SRD doesnt exist.
+			return null;
+		}
+
+		try {
+			return Class.forName(SELF_RESOLVING_DEPENDENCY_CLASS_NAME);
+		} catch (ClassNotFoundException e) {
+			// Gradle 9+
+			return null;
+		}
+	}
+
+	@Nullable
+	private static Method getResolveMethod(Class<?> clazz) {
+		if (clazz == null) {
+			// Gradle 9+
+			return null;
+		}
+
+		try {
+			var method = clazz.getDeclaredMethod("resolve");
+			method.setAccessible(true);
+			return method;
+		} catch (NoSuchMethodException e) {
+			throw new IllegalStateException("Failed to get SelfResolvingDependency.resolve() method", e);
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/gradle/SelfResolvingDependencyUtils.java
+++ b/src/main/java/net/fabricmc/loom/util/gradle/SelfResolvingDependencyUtils.java
@@ -33,6 +33,7 @@ import javax.annotation.Nullable;
 
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.FileCollectionDependency;
+import org.gradle.api.artifacts.ProjectDependency;
 
 // SelfResolvingDependency is deprecated for removal, use reflection to ensure backwards compat.
 @Deprecated
@@ -52,6 +53,8 @@ public class SelfResolvingDependencyUtils {
 	public static boolean isExplicitSRD(Dependency dependency) {
 		// FileCollectionDependency is usually the replacement for SelfResolvingDependency
 		if (dependency instanceof FileCollectionDependency) {
+			return false;
+		} else if (dependency instanceof ProjectDependency) {
 			return false;
 		}
 

--- a/src/test/groovy/net/fabricmc/loom/test/integration/KotlinTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/KotlinTest.groovy
@@ -40,7 +40,7 @@ class KotlinTest extends Specification implements GradleProjectTestTrait {
 		def gradle = gradleProject(project: "kotlin", version: version)
 		def server = ServerRunner.create(gradle.projectDir, "1.16.5")
 				.withMod(gradle.getOutputFile("fabric-example-mod-0.0.1.jar"))
-				.downloadMod(ServerRunner.FABRIC_LANG_KOTLIN, "fabric-language-kotlin-1.8.7+kotlin.1.7.22.jar")
+				.downloadMod(ServerRunner.FABRIC_LANG_KOTLIN, "fabric-language-kotlin-1.10.17+kotlin.1.9.22.jar")
 
 		when:
 		def result = gradle.run(tasks: [

--- a/src/test/resources/projects/kotlin/build.gradle.kts
+++ b/src/test/resources/projects/kotlin/build.gradle.kts
@@ -1,8 +1,10 @@
 import java.util.Properties
+import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 
 plugins {
-	kotlin("jvm") version "1.7.22"
-	kotlin("plugin.serialization") version "1.7.22"
+	kotlin("jvm") version "1.9.22"
+	kotlin("plugin.serialization") version "1.9.22"
 	id("fabric-loom")
 	`maven-publish`
 }
@@ -12,6 +14,17 @@ java {
 	targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+tasks {
+	withType<JavaCompile> {
+		options.release.set(8)
+	}
+	withType<KotlinCompile<KotlinJvmOptions>> {
+		kotlinOptions {
+			jvmTarget = "1.8"
+		}
+	}
+}
+
 group = "com.example"
 version = "0.0.1"
 
@@ -19,7 +32,7 @@ dependencies {
 	minecraft(group = "com.mojang", name = "minecraft", version = "1.16.5")
 	mappings(group = "net.fabricmc", name = "yarn", version = "1.16.5+build.5", classifier = "v2")
 	modImplementation("net.fabricmc:fabric-loader:0.12.12")
-	modImplementation(group = "net.fabricmc", name = "fabric-language-kotlin", version = "1.8.7+kotlin.1.7.22")
+	modImplementation(group = "net.fabricmc", name = "fabric-language-kotlin", version = "1.10.17+kotlin.1.9.22")
 }
 
 publishing {


### PR DESCRIPTION
Layred mappings no longer use SelfResolvingDependency, and are now created during afterEvalute and placed into the global loom maven. This matches how remapped mods are handled, there may be other ways to handle this.

Any use of SelfResolvingDependency though the API has been supported via reflection, and will break when updating to Gradle 9. The new Gradle Problem API has been used to log a warning if SelfResolvingDependency is used. 

Fixes #1022 