### PR TITLE
Injected Interfaces Expansion => Generics Support

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
@@ -284,8 +284,8 @@ public abstract class InterfaceInjectionProcessor implements MinecraftJarProcess
 
 			// See JVMS: https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-4.html#jvms-ClassSignature
 			if (InjectedInterface.containsGenerics(injectedInterfaces) && signature == null) {
-				// Classes that are not using generics don't need signatures, so they are null
-				// So if the class is not using generics but that an injected interface is using them, we are creating the signature
+				// Classes that are not using generics don't need signatures, so their signatures are null
+				// If the class is not using generics but that an injected interface targeting the class is using them, we are creating the class signature
 				StringBuilder baseSignatureBuilder = new StringBuilder("L" + superName + ";");
 
 				for (String baseInterface : baseInterfaces) {

--- a/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
@@ -60,7 +60,7 @@ import net.fabricmc.loom.util.fmj.FabricModJson;
 import net.fabricmc.mappingio.tree.MappingTree;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
-public abstract class InterfaceInjectionProcessor implements MinecraftJarProcessor<InterfaceInjectionProcessor.Spec>, List<List<? extends Object>> {
+public abstract class InterfaceInjectionProcessor implements MinecraftJarProcessor<InterfaceInjectionProcessor.Spec> {
 	private static final Logger LOGGER = LoggerFactory.getLogger(InterfaceInjectionProcessor.class);
 
 	private final String name;

--- a/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
@@ -120,7 +120,6 @@ public abstract class InterfaceInjectionProcessor implements MinecraftJarProcess
 							tinyRemapper.get().getEnvironment().getRemapper()
 					))
 					.toList();
-
 			try {
 				ZipUtils.transform(jar, getTransformers(remappedInjectedInterfaces));
 			} catch (IOException e) {
@@ -236,9 +235,11 @@ public abstract class InterfaceInjectionProcessor implements MinecraftJarProcess
 				for (JsonElement ifaceElement : ifacesInfo) {
 					String ifaceInfo = ifaceElement.getAsString();
 
+					String name = ifaceInfo;
 					String generics = null;
 
 					if (ifaceInfo.contains("<") && ifaceInfo.contains(">")) {
+						name = ifaceInfo.substring(0, ifaceInfo.indexOf("<"));
 						generics = ifaceInfo.substring(ifaceInfo.indexOf("<"));
 
 						// First Generics Check, if there are generics, are them correctly written?
@@ -247,7 +248,7 @@ public abstract class InterfaceInjectionProcessor implements MinecraftJarProcess
 						reader.accept(checker);
 					}
 
-					result.add(new InjectedInterface(modId, className, ifaceElement.getAsString(), generics));
+					result.add(new InjectedInterface(modId, className, name, generics));
 				}
 			}
 
@@ -385,20 +386,20 @@ public abstract class InterfaceInjectionProcessor implements MinecraftJarProcess
 	}
 
 	private static class GenericsChecker extends SignatureVisitor {
-		private final List<String> typeVariables;
+		private final List<String> typeParameters;
 
 		private final List<InjectedInterface> injectedInterfaces;
 
 		GenericsChecker(int asmVersion, List<InjectedInterface> injectedInterfaces) {
 			super(asmVersion);
-			this.typeVariables = new ArrayList<>();
+			this.typeParameters = new ArrayList<>();
 			this.injectedInterfaces = injectedInterfaces;
 		}
 
 		@Override
-		public void visitTypeVariable(String name) {
-			this.typeVariables.add(name);
-			super.visitTypeVariable(name);
+		public void visitFormalTypeParameter(String name) {
+			this.typeParameters.add(name);
+			super.visitFormalTypeParameter(name);
 		}
 
 		@Override
@@ -410,7 +411,7 @@ public abstract class InterfaceInjectionProcessor implements MinecraftJarProcess
 							Constants.ASM_VERSION,
 							injectedInterface.className(),
 							injectedInterface.ifaceName(),
-							this.typeVariables
+							this.typeParameters
 					);
 					reader.accept(confirm);
 				}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/processor/InterfaceInjectionProcessorTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/processor/InterfaceInjectionProcessorTest.groovy
@@ -24,16 +24,6 @@
 
 package net.fabricmc.loom.test.unit.processor
 
-import net.fabricmc.loom.api.mappings.layered.MappingsNamespace
-import net.fabricmc.loom.test.unit.processor.classes.AdvancedGenericInterface
-import net.fabricmc.loom.test.unit.processor.classes.FirstGenericInterface
-import net.fabricmc.loom.test.unit.processor.classes.GenericInterface
-import net.fabricmc.loom.test.unit.processor.classes.SecondGenericInterface
-import net.fabricmc.loom.test.unit.processor.classes.SelfGenericInterface
-import net.fabricmc.loom.util.LazyCloseable
-import net.fabricmc.loom.util.TinyRemapperHelper
-import net.fabricmc.tinyremapper.TinyRemapper
-
 import java.nio.file.Path
 import java.util.function.Consumer
 
@@ -42,22 +32,31 @@ import com.google.gson.JsonObject
 import spock.lang.Specification
 import spock.lang.TempDir
 
+import net.fabricmc.loom.api.mappings.layered.MappingsNamespace
 import net.fabricmc.loom.api.processor.ProcessorContext
 import net.fabricmc.loom.api.processor.SpecContext
 import net.fabricmc.loom.configuration.ifaceinject.InterfaceInjectionProcessor
+import net.fabricmc.loom.test.unit.processor.classes.AdvancedGenericInterface
 import net.fabricmc.loom.test.unit.processor.classes.AdvancedGenericTargetClass
 import net.fabricmc.loom.test.unit.processor.classes.DoubleGenericTargetClass
+import net.fabricmc.loom.test.unit.processor.classes.FirstGenericInterface
+import net.fabricmc.loom.test.unit.processor.classes.GenericInterface
 import net.fabricmc.loom.test.unit.processor.classes.GenericTargetClass
 import net.fabricmc.loom.test.unit.processor.classes.PassingGenericTargetClass
+import net.fabricmc.loom.test.unit.processor.classes.SecondGenericInterface
+import net.fabricmc.loom.test.unit.processor.classes.SelfGenericInterface
 import net.fabricmc.loom.test.unit.processor.classes.SelfGenericTargetClass
 import net.fabricmc.loom.test.unit.processor.classes.SimpleInterface
 import net.fabricmc.loom.test.unit.processor.classes.SimpleTargetClass
 import net.fabricmc.loom.util.Constants
+import net.fabricmc.loom.util.LazyCloseable
 import net.fabricmc.loom.util.Pair
+import net.fabricmc.loom.util.TinyRemapperHelper
 import net.fabricmc.loom.util.ZipUtils
 import net.fabricmc.loom.util.fmj.FabricModJson
 import net.fabricmc.mappingio.MappingReader
 import net.fabricmc.mappingio.tree.MemoryMappingTree
+import net.fabricmc.tinyremapper.TinyRemapper
 
 class InterfaceInjectionProcessorTest extends Specification {
 	@TempDir
@@ -182,18 +181,13 @@ class InterfaceInjectionProcessorTest extends Specification {
 	}
 
 	static LazyCloseable<TinyRemapper> createRemapper(Path jar, MemoryMappingTree mappings) {
-		return new LazyCloseable<>(() -> {
+		return new LazyCloseable<>({
 			TinyRemapper.Builder builder = TinyRemapper.newRemapper()
-			builder.withMappings(TinyRemapperHelper.create(
-					mappings,
-					MappingsNamespace.INTERMEDIARY.toString(),
-					MappingsNamespace.NAMED.toString(),
-					false
-			))
+			builder.withMappings(TinyRemapperHelper.create(mappings, MappingsNamespace.INTERMEDIARY.toString(), MappingsNamespace.NAMED.toString(), false))
 			TinyRemapper tinyRemapper = builder.build()
 			tinyRemapper.readClassPath(jar)
 			return tinyRemapper
-		}, TinyRemapper::finish)
+		}, { tinyRemapper -> tinyRemapper.finish() })
 	}
 
 	// Load a class from a jar file and execute a closure with it
@@ -223,20 +217,20 @@ class InterfaceInjectionProcessorTest extends Specification {
 	}
 
 	private static final List<Class<?>> CLASSES_TO_PACKAGE = [
-			SimpleTargetClass.class,
-			SimpleTargetClass.Inner.class,
-			SimpleInterface.class,
-			GenericTargetClass.class,
-			PassingGenericTargetClass.class,
-			GenericInterface.class,
-			AdvancedGenericTargetClass.class,
-			AdvancedGenericTargetClass.Pair.class,
-			AdvancedGenericInterface.class,
-			DoubleGenericTargetClass.class,
-			FirstGenericInterface.class,
-			SecondGenericInterface.class,
-			SelfGenericTargetClass.class,
-			SelfGenericInterface.class
+		SimpleTargetClass.class,
+		SimpleTargetClass.Inner.class,
+		SimpleInterface.class,
+		GenericTargetClass.class,
+		PassingGenericTargetClass.class,
+		GenericInterface.class,
+		AdvancedGenericTargetClass.class,
+		AdvancedGenericTargetClass.Pair.class,
+		AdvancedGenericInterface.class,
+		DoubleGenericTargetClass.class,
+		FirstGenericInterface.class,
+		SecondGenericInterface.class,
+		SelfGenericTargetClass.class,
+		SelfGenericInterface.class
 	]
 
 	private static final String MAPPINGS = """

--- a/src/test/groovy/net/fabricmc/loom/test/unit/processor/InterfaceInjectionProcessorTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/processor/InterfaceInjectionProcessorTest.groovy
@@ -24,12 +24,6 @@
 
 package net.fabricmc.loom.test.unit.processor
 
-import net.fabricmc.loom.test.unit.processor.classes.AdvancedGenericTargetClass
-import net.fabricmc.loom.test.unit.processor.classes.DoubleGenericTargetClass
-import net.fabricmc.loom.test.unit.processor.classes.GenericTargetClass
-import net.fabricmc.loom.test.unit.processor.classes.PassingGenericTargetClass
-import net.fabricmc.loom.test.unit.processor.classes.SelfGenericTargetClass
-
 import java.nio.file.Path
 import java.util.function.Consumer
 
@@ -41,6 +35,11 @@ import spock.lang.TempDir
 import net.fabricmc.loom.api.processor.ProcessorContext
 import net.fabricmc.loom.api.processor.SpecContext
 import net.fabricmc.loom.configuration.ifaceinject.InterfaceInjectionProcessor
+import net.fabricmc.loom.test.unit.processor.classes.AdvancedGenericTargetClass
+import net.fabricmc.loom.test.unit.processor.classes.DoubleGenericTargetClass
+import net.fabricmc.loom.test.unit.processor.classes.GenericTargetClass
+import net.fabricmc.loom.test.unit.processor.classes.PassingGenericTargetClass
+import net.fabricmc.loom.test.unit.processor.classes.SelfGenericTargetClass
 import net.fabricmc.loom.test.unit.processor.classes.SimpleInterface
 import net.fabricmc.loom.test.unit.processor.classes.SimpleTargetClass
 import net.fabricmc.loom.util.Constants
@@ -95,35 +94,35 @@ class InterfaceInjectionProcessorTest extends Specification {
 		}
 
 		// Class using interface with generics
-		"class_3" | "net/fabricmc/loom/test/unit/processor/classes/GenericInterface<Ljava/lang/String;>" | GenericTargetClass.class { Class<?> loadedClass ->
+		"class_3" | "net/fabricmc/loom/test/unit/processor/classes/GenericInterface<Ljava/lang/String;>" | GenericTargetClass.class | { Class<?> loadedClass ->
 			loadedClass.interfaces.first().name == "net/fabricmc/loom/test/unit/processor/classes/GenericInterface"
 			loadedClass.constructors.first().newInstance().genericInjectedMethod() == null
 		}
 
 		// Class using generics and passing them to interface
-		"class_4" | "net/fabricmc/loom/test/unit/processor/classes/GenericInterface<TT;>" | PassingGenericTargetClass.class { Class<?> loadedClass ->
+		"class_4" | "net/fabricmc/loom/test/unit/processor/classes/GenericInterface<TT;>" | PassingGenericTargetClass.class | { Class<?> loadedClass ->
 			loadedClass.interfaces.first().name == "net/fabricmc/loom/test/unit/processor/classes/GenericInterface"
 			loadedClass.constructors.first().newInstance().genericInjectedMethod() == null
 		}
 
 		// Class having one injected interface with two generics, including one provided by the class
-		"class_5" | "net/fabricmc/loom/test/unit/processor/classes/AdvancedGenericInterface<Ljava/util/function/Predicate<TT;>;Ljava/lang/Integer;>" | AdvancedGenericTargetClass.class { Class<?> loadedClass ->
+		"class_5" | "net/fabricmc/loom/test/unit/processor/classes/AdvancedGenericInterface<Ljava/util/function/Predicate<TT;>;Ljava/lang/Integer;>" | AdvancedGenericTargetClass.class | { Class<?> loadedClass ->
 			loadedClass.interfaces.first().name == "net/fabricmc/loom/test/unit/processor/classes/AdvancedGenericInterface"
 			loadedClass.constructors.first().newInstance().advancedGenericInjectedMethod().getClass() == Pair.class
 		}
 
 		// Class having two injected interfaces with one generic for each of them, including one provided by the class
-		"class_6" | "net/fabricmc/loom/test/unit/processor/classes/FirstGenericInterface<Ljava/util/function/Predicate<TT;>;>" | DoubleGenericTargetClass.class { Class<?> loadedClass ->
+		"class_6" | "net/fabricmc/loom/test/unit/processor/classes/FirstGenericInterface<Ljava/util/function/Predicate<TT;>;>" | DoubleGenericTargetClass.class | { Class<?> loadedClass ->
 			loadedClass.interfaces.first().name == "net/fabricmc/loom/test/unit/processor/classes/FirstGenericInterface"
 			loadedClass.constructors.first().newInstance().firstGenericInjectedMethod() == null
 		}
-		"class_6" | "net/fabricmc/loom/test/unit/processor/classes/SecondGenericInterface<Ljava/lang/Integer;>" | DoubleGenericTargetClass.class { Class<?> loadedClass ->
+		"class_6" | "net/fabricmc/loom/test/unit/processor/classes/SecondGenericInterface<Ljava/lang/Integer;>" | DoubleGenericTargetClass.class | { Class<?> loadedClass ->
 			loadedClass.interfaces.last().name == "net/fabricmc/loom/test/unit/processor/classes/SecondGenericInterface"
 			loadedClass.constructors.last().newInstance().secondGenericInjectedMethod() == null
 		}
 
 		// Self Generic Types + Signature Remapping Check
-		"class_7" | "net/fabricmc/loom/test/unit/processor/classes/SelfGenericInterface<Lclass_7;>" | SelfGenericTargetClass.class { Class<?> loadedClass ->
+		"class_7" | "net/fabricmc/loom/test/unit/processor/classes/SelfGenericInterface<Lclass_7;>" | SelfGenericTargetClass.class | { Class<?> loadedClass ->
 			loadedClass.interfaces.first().name == "net/fabricmc/loom/test/unit/proessor/classes/SelfGenericInterface"
 			loadedClass.constructors.first().newInstance().selfGenericInjectedMethod() == null
 		}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/processor/InterfaceInjectionProcessorTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/processor/InterfaceInjectionProcessorTest.groovy
@@ -183,17 +183,17 @@ class InterfaceInjectionProcessorTest extends Specification {
 
 	static LazyCloseable<TinyRemapper> createRemapper(Path jar, MemoryMappingTree mappings) {
 		return new LazyCloseable<>(() -> {
-			TinyRemapper.Builder builder = TinyRemapper.newRemapper();
+			TinyRemapper.Builder builder = TinyRemapper.newRemapper()
 			builder.withMappings(TinyRemapperHelper.create(
 					mappings,
 					MappingsNamespace.INTERMEDIARY.toString(),
 					MappingsNamespace.NAMED.toString(),
 					false
-			));
-			TinyRemapper tinyRemapper = builder.build();
-			tinyRemapper.readClassPath(jar);
-			return tinyRemapper;
-		}, TinyRemapper::finish);
+			))
+			TinyRemapper tinyRemapper = builder.build()
+			tinyRemapper.readClassPath(jar)
+			return tinyRemapper
+		}, TinyRemapper::finish)
 	}
 
 	// Load a class from a jar file and execute a closure with it

--- a/src/test/groovy/net/fabricmc/loom/test/unit/processor/InterfaceInjectionProcessorTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/processor/InterfaceInjectionProcessorTest.groovy
@@ -24,6 +24,16 @@
 
 package net.fabricmc.loom.test.unit.processor
 
+import net.fabricmc.loom.api.mappings.layered.MappingsNamespace
+import net.fabricmc.loom.test.unit.processor.classes.AdvancedGenericInterface
+import net.fabricmc.loom.test.unit.processor.classes.FirstGenericInterface
+import net.fabricmc.loom.test.unit.processor.classes.GenericInterface
+import net.fabricmc.loom.test.unit.processor.classes.SecondGenericInterface
+import net.fabricmc.loom.test.unit.processor.classes.SelfGenericInterface
+import net.fabricmc.loom.util.LazyCloseable
+import net.fabricmc.loom.util.TinyRemapperHelper
+import net.fabricmc.tinyremapper.TinyRemapper
+
 import java.nio.file.Path
 import java.util.function.Consumer
 
@@ -69,6 +79,8 @@ class InterfaceInjectionProcessorTest extends Specification {
 		def jar = tempDir.resolve("test.jar")
 		packageJar(jar)
 
+		processorContext.createRemapper(MappingsNamespace.INTERMEDIARY, MappingsNamespace.NAMED) >> createRemapper(jar, processorContext.getMappings())
+
 		when:
 		def processor = new TestInterfaceInjectionProcessor()
 		def spec = processor.buildSpec(specContext)
@@ -108,21 +120,21 @@ class InterfaceInjectionProcessorTest extends Specification {
 		// Class having one injected interface with two generics, including one provided by the class
 		"class_5" | "net/fabricmc/loom/test/unit/processor/classes/AdvancedGenericInterface<Ljava/util/function/Predicate<TT;>;Ljava/lang/Integer;>" | AdvancedGenericTargetClass.class | { Class<?> loadedClass ->
 			loadedClass.interfaces.first().name == "net/fabricmc/loom/test/unit/processor/classes/AdvancedGenericInterface"
-			loadedClass.constructors.first().newInstance().advancedGenericInjectedMethod().getClass() == Pair.class
+			loadedClass.constructors.first().newInstance().advancedGenericInjectedMethod().getClass() == AdvancedGenericTargetClass.Pair.class
 		}
 
 		// Class having two injected interfaces with one generic for each of them, including one provided by the class
-		"class_6" | "net/fabricmc/loom/test/unit/processor/classes/FirstGenericInterface<Ljava/util/function/Predicate<TT;>;>" | DoubleGenericTargetClass.class | { Class<?> loadedClass ->
+		"class_7" | "net/fabricmc/loom/test/unit/processor/classes/FirstGenericInterface<Ljava/util/function/Predicate<TT;>;>" | DoubleGenericTargetClass.class | { Class<?> loadedClass ->
 			loadedClass.interfaces.first().name == "net/fabricmc/loom/test/unit/processor/classes/FirstGenericInterface"
 			loadedClass.constructors.first().newInstance().firstGenericInjectedMethod() == null
 		}
-		"class_6" | "net/fabricmc/loom/test/unit/processor/classes/SecondGenericInterface<Ljava/lang/Integer;>" | DoubleGenericTargetClass.class | { Class<?> loadedClass ->
+		"class_7" | "net/fabricmc/loom/test/unit/processor/classes/SecondGenericInterface<Ljava/lang/Integer;>" | DoubleGenericTargetClass.class | { Class<?> loadedClass ->
 			loadedClass.interfaces.last().name == "net/fabricmc/loom/test/unit/processor/classes/SecondGenericInterface"
 			loadedClass.constructors.last().newInstance().secondGenericInjectedMethod() == null
 		}
 
 		// Self Generic Types + Signature Remapping Check
-		"class_7" | "net/fabricmc/loom/test/unit/processor/classes/SelfGenericInterface<Lclass_7;>" | SelfGenericTargetClass.class | { Class<?> loadedClass ->
+		"class_8" | "net/fabricmc/loom/test/unit/processor/classes/SelfGenericInterface<Lclass_7;>" | SelfGenericTargetClass.class | { Class<?> loadedClass ->
 			loadedClass.interfaces.first().name == "net/fabricmc/loom/test/unit/proessor/classes/SelfGenericInterface"
 			loadedClass.constructors.first().newInstance().selfGenericInjectedMethod() == null
 		}
@@ -169,6 +181,21 @@ class InterfaceInjectionProcessorTest extends Specification {
 		return mappings
 	}
 
+	static LazyCloseable<TinyRemapper> createRemapper(Path jar, MemoryMappingTree mappings) {
+		return new LazyCloseable<>(() -> {
+			TinyRemapper.Builder builder = TinyRemapper.newRemapper();
+			builder.withMappings(TinyRemapperHelper.create(
+					mappings,
+					MappingsNamespace.INTERMEDIARY.toString(),
+					MappingsNamespace.NAMED.toString(),
+					false
+			));
+			TinyRemapper tinyRemapper = builder.build();
+			tinyRemapper.readClassPath(jar);
+			return tinyRemapper;
+		}, TinyRemapper::finish);
+	}
+
 	// Load a class from a jar file and execute a closure with it
 	static void withTargetClass(Path jar, Class<?> clazz, Consumer<Class<?>> closure) {
 		// Groovy is needed as the test classes are compiled with it
@@ -196,10 +223,22 @@ class InterfaceInjectionProcessorTest extends Specification {
 	}
 
 	private static final List<Class<?>> CLASSES_TO_PACKAGE = [
-		SimpleTargetClass.class,
-		SimpleTargetClass.Inner.class,
-		SimpleInterface.class
+			SimpleTargetClass.class,
+			SimpleTargetClass.Inner.class,
+			SimpleInterface.class,
+			GenericTargetClass.class,
+			PassingGenericTargetClass.class,
+			GenericInterface.class,
+			AdvancedGenericTargetClass.class,
+			AdvancedGenericTargetClass.Pair.class,
+			AdvancedGenericInterface.class,
+			DoubleGenericTargetClass.class,
+			FirstGenericInterface.class,
+			SecondGenericInterface.class,
+			SelfGenericTargetClass.class,
+			SelfGenericInterface.class
 	]
+
 	private static final String MAPPINGS = """
 tiny\t2\t0\tintermediary\tnamed
 c\tclass_1\tnet/fabricmc/loom/test/unit/processor/classes/SimpleTargetClass
@@ -207,7 +246,8 @@ c\tclass_1\$class_2\tnet/fabricmc/loom/test/unit/processor/classes/SimpleTargetC
 c\tclass_3\tnet/fabricmc/loom/test/unit/processor/classes/GenericTargetClass
 c\tclass_4\tnet/fabricmc/loom/test/unit/processor/classes/PassingGenericTargetClass
 c\tclass_5\tnet/fabricmc/loom/test/unit/processor/classes/AdvancedGenericTargetClass
-c\tclass_6\tnet/fabricmc/loom/test/unit/processor/classes/DoubleGenericTargetClass
-c\tclass_7\tnet/fabricmc/loom/test/unit/processor/classes/SelfGenericTargetClass
+c\tclass_5\$class_6\tnet/fabricmc/loom/test/unit/processor/classes/AdvancedGenericTargetClass\$Pair
+c\tclass_7\tnet/fabricmc/loom/test/unit/processor/classes/DoubleGenericTargetClass
+c\tclass_8\tnet/fabricmc/loom/test/unit/processor/classes/SelfGenericTargetClass
 """.trim()
 }

--- a/src/test/groovy/net/fabricmc/loom/test/unit/processor/InterfaceInjectionProcessorTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/processor/InterfaceInjectionProcessorTest.groovy
@@ -91,11 +91,13 @@ class InterfaceInjectionProcessorTest extends Specification {
 			loadedClass.constructors.first().newInstance().injectedMethod() == 123
 		}
 
+		// Class using interface with generics
 		"class_3" | "net/fabricmc/loom/test/unit/processor/classes/GenericInterface<Ljava/lang/String;>" | GenericTargetClass.class { Class<?> loadedClass ->
 			loadedClass.interfaces.first().name == "net/fabricmc/loom/test/unit/processor/classes/GenericInterface"
 			loadedClass.constructors.first().newInstance().genericInjectedMethod() == null
 		}
 
+		// Class using generics and passing them to interface
 		"class_4" | "net/fabricmc/loom/test/unit/processor/classes/GenericInterface<TT;>" | PassingGenericTargetClass.class { Class<?> loadedClass ->
 			loadedClass.interfaces.first().name == "net/fabricmc/loom/test/unit/processor/classes/GenericInterface"
 			loadedClass.constructors.first().newInstance().genericInjectedMethod() == null

--- a/src/test/groovy/net/fabricmc/loom/test/unit/processor/InterfaceInjectionProcessorTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/processor/InterfaceInjectionProcessorTest.groovy
@@ -24,8 +24,11 @@
 
 package net.fabricmc.loom.test.unit.processor
 
+import net.fabricmc.loom.test.unit.processor.classes.AdvancedGenericTargetClass
+import net.fabricmc.loom.test.unit.processor.classes.DoubleGenericTargetClass
 import net.fabricmc.loom.test.unit.processor.classes.GenericTargetClass
 import net.fabricmc.loom.test.unit.processor.classes.PassingGenericTargetClass
+import net.fabricmc.loom.test.unit.processor.classes.SelfGenericTargetClass
 
 import java.nio.file.Path
 import java.util.function.Consumer
@@ -101,6 +104,28 @@ class InterfaceInjectionProcessorTest extends Specification {
 		"class_4" | "net/fabricmc/loom/test/unit/processor/classes/GenericInterface<TT;>" | PassingGenericTargetClass.class { Class<?> loadedClass ->
 			loadedClass.interfaces.first().name == "net/fabricmc/loom/test/unit/processor/classes/GenericInterface"
 			loadedClass.constructors.first().newInstance().genericInjectedMethod() == null
+		}
+
+		// Class having one injected interface with two generics, including one provided by the class
+		"class_5" | "net/fabricmc/loom/test/unit/processor/classes/AdvancedGenericInterface<Ljava/util/function/Predicate<TT;>;Ljava/lang/Integer;>" | AdvancedGenericTargetClass.class { Class<?> loadedClass ->
+			loadedClass.interfaces.first().name == "net/fabricmc/loom/test/unit/processor/classes/AdvancedGenericInterface"
+			loadedClass.constructors.first().newInstance().advancedGenericInjectedMethod().getClass() == Pair.class
+		}
+
+		// Class having two injected interfaces with one generic for each of them, including one provided by the class
+		"class_6" | "net/fabricmc/loom/test/unit/processor/classes/FirstGenericInterface<Ljava/util/function/Predicate<TT;>;>" | DoubleGenericTargetClass.class { Class<?> loadedClass ->
+			loadedClass.interfaces.first().name == "net/fabricmc/loom/test/unit/processor/classes/FirstGenericInterface"
+			loadedClass.constructors.first().newInstance().firstGenericInjectedMethod() == null
+		}
+		"class_6" | "net/fabricmc/loom/test/unit/processor/classes/SecondGenericInterface<Ljava/lang/Integer;>" | DoubleGenericTargetClass.class { Class<?> loadedClass ->
+			loadedClass.interfaces.last().name == "net/fabricmc/loom/test/unit/processor/classes/SecondGenericInterface"
+			loadedClass.constructors.last().newInstance().secondGenericInjectedMethod() == null
+		}
+
+		// Self Generic Types + Signature Remapping Check
+		"class_7" | "net/fabricmc/loom/test/unit/processor/classes/SelfGenericInterface<Lclass_7;>" | SelfGenericTargetClass.class { Class<?> loadedClass ->
+			loadedClass.interfaces.first().name == "net/fabricmc/loom/test/unit/proessor/classes/SelfGenericInterface"
+			loadedClass.constructors.first().newInstance().selfGenericInjectedMethod() == null
 		}
 	}
 
@@ -182,5 +207,8 @@ c\tclass_1\tnet/fabricmc/loom/test/unit/processor/classes/SimpleTargetClass
 c\tclass_1\$class_2\tnet/fabricmc/loom/test/unit/processor/classes/SimpleTargetClass\$Inner
 c\tclass_3\tnet/fabricmc/loom/test/unit/processor/classes/GenericTargetClass
 c\tclass_4\tnet/fabricmc/loom/test/unit/processor/classes/PassingGenericTargetClass
+c\tclass_5\tnet/fabricmc/loom/test/unit/processor/classes/AdvancedGenericTargetClass
+c\tclass_6\tnet/fabricmc/loom/test/unit/processor/classes/DoubleGenericTargetClass
+c\tclass_7\tnet/fabricmc/loom/test/unit/processor/classes/SelfGenericTargetClass
 """.trim()
 }

--- a/src/test/groovy/net/fabricmc/loom/test/unit/processor/InterfaceInjectionProcessorTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/processor/InterfaceInjectionProcessorTest.groovy
@@ -24,6 +24,9 @@
 
 package net.fabricmc.loom.test.unit.processor
 
+import net.fabricmc.loom.test.unit.processor.classes.GenericTargetClass
+import net.fabricmc.loom.test.unit.processor.classes.PassingGenericTargetClass
+
 import java.nio.file.Path
 import java.util.function.Consumer
 
@@ -83,9 +86,19 @@ class InterfaceInjectionProcessorTest extends Specification {
 		}
 
 		// Inner class with a simple interface
-		"class_1\$class_2" | "net/fabricmc/loom/test/unit/processor/classes/SimpleInterface" |  SimpleTargetClass.Inner.class | { Class<?> loadedClass ->
+		"class_1\$class_2" | "net/fabricmc/loom/test/unit/processor/classes/SimpleInterface" | SimpleTargetClass.Inner.class | { Class<?> loadedClass ->
 			loadedClass.interfaces.first().name == "net/fabricmc/loom/test/unit/processor/classes/SimpleInterface"
 			loadedClass.constructors.first().newInstance().injectedMethod() == 123
+		}
+
+		"class_3" | "net/fabricmc/loom/test/unit/processor/classes/GenericInterface<Ljava/lang/String;>" | GenericTargetClass.class { Class<?> loadedClass ->
+			loadedClass.interfaces.first().name == "net/fabricmc/loom/test/unit/processor/classes/GenericInterface"
+			loadedClass.constructors.first().newInstance().genericInjectedMethod() == null
+		}
+
+		"class_4" | "net/fabricmc/loom/test/unit/processor/classes/GenericInterface<TT;>" | PassingGenericTargetClass.class { Class<?> loadedClass ->
+			loadedClass.interfaces.first().name == "net/fabricmc/loom/test/unit/processor/classes/GenericInterface"
+			loadedClass.constructors.first().newInstance().genericInjectedMethod() == null
 		}
 	}
 
@@ -165,5 +178,7 @@ class InterfaceInjectionProcessorTest extends Specification {
 tiny\t2\t0\tintermediary\tnamed
 c\tclass_1\tnet/fabricmc/loom/test/unit/processor/classes/SimpleTargetClass
 c\tclass_1\$class_2\tnet/fabricmc/loom/test/unit/processor/classes/SimpleTargetClass\$Inner
+c\tclass_3\tnet/fabricmc/loom/test/unit/processor/classes/GenericTargetClass
+c\tclass_4\tnet/fabricmc/loom/test/unit/processor/classes/PassingGenericTargetClass
 """.trim()
 }

--- a/src/test/java/net/fabricmc/loom/test/unit/processor/classes/AdvancedGenericInterface.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/processor/classes/AdvancedGenericInterface.java
@@ -24,5 +24,11 @@
 
 package net.fabricmc.loom.test.unit.processor.classes;
 
-public class GenericTargetClass {
+import net.fabricmc.loom.util.Pair;
+
+public interface AdvancedGenericInterface<F, S> {
+
+	default Pair<F, S> advancedGenericInjectedMethod() {
+		return new Pair<>(null, null);
+	}
 }

--- a/src/test/java/net/fabricmc/loom/test/unit/processor/classes/AdvancedGenericInterface.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/processor/classes/AdvancedGenericInterface.java
@@ -27,7 +27,6 @@ package net.fabricmc.loom.test.unit.processor.classes;
 import net.fabricmc.loom.util.Pair;
 
 public interface AdvancedGenericInterface<F, S> {
-
 	default Pair<F, S> advancedGenericInjectedMethod() {
 		return new Pair<>(null, null);
 	}

--- a/src/test/java/net/fabricmc/loom/test/unit/processor/classes/AdvancedGenericInterface.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/processor/classes/AdvancedGenericInterface.java
@@ -24,10 +24,8 @@
 
 package net.fabricmc.loom.test.unit.processor.classes;
 
-import net.fabricmc.loom.util.Pair;
-
 public interface AdvancedGenericInterface<F, S> {
-	default Pair<F, S> advancedGenericInjectedMethod() {
-		return new Pair<>(null, null);
+	default AdvancedGenericTargetClass.Pair<F, S> advancedGenericInjectedMethod() {
+		return new AdvancedGenericTargetClass.Pair<>(null, null);
 	}
 }

--- a/src/test/java/net/fabricmc/loom/test/unit/processor/classes/AdvancedGenericTargetClass.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/processor/classes/AdvancedGenericTargetClass.java
@@ -24,5 +24,5 @@
 
 package net.fabricmc.loom.test.unit.processor.classes;
 
-public class GenericTargetClass {
+public class AdvancedGenericTargetClass<T> {
 }

--- a/src/test/java/net/fabricmc/loom/test/unit/processor/classes/AdvancedGenericTargetClass.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/processor/classes/AdvancedGenericTargetClass.java
@@ -25,4 +25,8 @@
 package net.fabricmc.loom.test.unit.processor.classes;
 
 public class AdvancedGenericTargetClass<T> {
+	public static class Pair<F, S> {
+		Pair(F ignoredF, S ignoredS) {
+		}
+	}
 }

--- a/src/test/java/net/fabricmc/loom/test/unit/processor/classes/DoubleGenericTargetClass.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/processor/classes/DoubleGenericTargetClass.java
@@ -24,5 +24,5 @@
 
 package net.fabricmc.loom.test.unit.processor.classes;
 
-public class GenericTargetClass {
+public class DoubleGenericTargetClass<T> {
 }

--- a/src/test/java/net/fabricmc/loom/test/unit/processor/classes/FirstGenericInterface.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/processor/classes/FirstGenericInterface.java
@@ -24,5 +24,9 @@
 
 package net.fabricmc.loom.test.unit.processor.classes;
 
-public class GenericTargetClass {
+public interface FirstGenericInterface<T> {
+
+	default T firstGenericInjectedMethod() {
+		return null;
+	}
 }

--- a/src/test/java/net/fabricmc/loom/test/unit/processor/classes/FirstGenericInterface.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/processor/classes/FirstGenericInterface.java
@@ -25,7 +25,6 @@
 package net.fabricmc.loom.test.unit.processor.classes;
 
 public interface FirstGenericInterface<T> {
-
 	default T firstGenericInjectedMethod() {
 		return null;
 	}

--- a/src/test/java/net/fabricmc/loom/test/unit/processor/classes/GenericInterface.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/processor/classes/GenericInterface.java
@@ -1,0 +1,8 @@
+package net.fabricmc.loom.test.unit.processor.classes;
+
+public interface GenericInterface<T> {
+
+	default T genericInjectedMethod() {
+		return null;
+	}
+}

--- a/src/test/java/net/fabricmc/loom/test/unit/processor/classes/GenericInterface.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/processor/classes/GenericInterface.java
@@ -25,7 +25,6 @@
 package net.fabricmc.loom.test.unit.processor.classes;
 
 public interface GenericInterface<T> {
-
 	default T genericInjectedMethod() {
 		return null;
 	}

--- a/src/test/java/net/fabricmc/loom/test/unit/processor/classes/GenericInterface.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/processor/classes/GenericInterface.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2024 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package net.fabricmc.loom.test.unit.processor.classes;
 
 public interface GenericInterface<T> {

--- a/src/test/java/net/fabricmc/loom/test/unit/processor/classes/GenericTargetClass.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/processor/classes/GenericTargetClass.java
@@ -1,0 +1,4 @@
+package net.fabricmc.loom.test.unit.processor.classes;
+
+public class GenericTargetClass {
+}

--- a/src/test/java/net/fabricmc/loom/test/unit/processor/classes/PassingGenericTargetClass.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/processor/classes/PassingGenericTargetClass.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2024 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package net.fabricmc.loom.test.unit.processor.classes;
 
 public class PassingGenericTargetClass<T> {

--- a/src/test/java/net/fabricmc/loom/test/unit/processor/classes/PassingGenericTargetClass.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/processor/classes/PassingGenericTargetClass.java
@@ -1,0 +1,4 @@
+package net.fabricmc.loom.test.unit.processor.classes;
+
+public class PassingGenericTargetClass<T> {
+}

--- a/src/test/java/net/fabricmc/loom/test/unit/processor/classes/SecondGenericInterface.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/processor/classes/SecondGenericInterface.java
@@ -24,5 +24,9 @@
 
 package net.fabricmc.loom.test.unit.processor.classes;
 
-public class GenericTargetClass {
+public interface SecondGenericInterface<T> {
+
+	default T secondGenericInjectedMethod() {
+		return null;
+	}
 }

--- a/src/test/java/net/fabricmc/loom/test/unit/processor/classes/SecondGenericInterface.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/processor/classes/SecondGenericInterface.java
@@ -25,7 +25,6 @@
 package net.fabricmc.loom.test.unit.processor.classes;
 
 public interface SecondGenericInterface<T> {
-
 	default T secondGenericInjectedMethod() {
 		return null;
 	}

--- a/src/test/java/net/fabricmc/loom/test/unit/processor/classes/SelfGenericInterface.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/processor/classes/SelfGenericInterface.java
@@ -24,5 +24,9 @@
 
 package net.fabricmc.loom.test.unit.processor.classes;
 
-public class GenericTargetClass {
+public interface SelfGenericInterface<S extends SelfGenericInterface<S>> {
+
+	default S selfGenericInjectedMethod() {
+		return null;
+	}
 }

--- a/src/test/java/net/fabricmc/loom/test/unit/processor/classes/SelfGenericInterface.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/processor/classes/SelfGenericInterface.java
@@ -25,7 +25,6 @@
 package net.fabricmc.loom.test.unit.processor.classes;
 
 public interface SelfGenericInterface<S extends SelfGenericInterface<S>> {
-
 	default S selfGenericInjectedMethod() {
 		return null;
 	}

--- a/src/test/java/net/fabricmc/loom/test/unit/processor/classes/SelfGenericTargetClass.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/processor/classes/SelfGenericTargetClass.java
@@ -24,5 +24,5 @@
 
 package net.fabricmc.loom.test.unit.processor.classes;
 
-public class GenericTargetClass {
+public class SelfGenericTargetClass {
 }

--- a/src/test/resources/projects/interfaceInjection/src/main/java/ExampleMod.java
+++ b/src/test/resources/projects/interfaceInjection/src/main/java/ExampleMod.java
@@ -1,4 +1,5 @@
 import net.minecraft.block.Blocks;
+import net.minecraft.util.registry.Registry;
 
 import net.fabricmc.api.ModInitializer;
 
@@ -8,6 +9,6 @@ public class ExampleMod implements ModInitializer {
 		Blocks.AIR.newMethodThatDidNotExist();
 		Blocks.AIR.anotherNewMethodThatDidNotExist();
 		Blocks.AIR.typedMethodThatDidNotExist();
-		RegistryKeys.BLOCK.genericMethodThatDidNotExist();
+		Registry.BLOCK_KEY.genericMethodThatDidNotExist();
 	}
 }

--- a/src/test/resources/projects/interfaceInjection/src/main/java/ExampleMod.java
+++ b/src/test/resources/projects/interfaceInjection/src/main/java/ExampleMod.java
@@ -7,5 +7,7 @@ public class ExampleMod implements ModInitializer {
 	public void onInitialize() {
 		Blocks.AIR.newMethodThatDidNotExist();
 		Blocks.AIR.anotherNewMethodThatDidNotExist();
+		Blocks.AIR.typedMethodThatDidNotExist();
+		RegistryKeys.BLOCK.genericMethodThatDidNotExist();
 	}
 }

--- a/src/test/resources/projects/interfaceInjection/src/main/java/GenericInjectedInterface.java
+++ b/src/test/resources/projects/interfaceInjection/src/main/java/GenericInjectedInterface.java
@@ -1,0 +1,5 @@
+
+public interface GenericInjectedInterface<T> {
+	default T genericMethodThatDidNotExist() {
+	}
+}

--- a/src/test/resources/projects/interfaceInjection/src/main/java/GenericInjectedInterface.java
+++ b/src/test/resources/projects/interfaceInjection/src/main/java/GenericInjectedInterface.java
@@ -1,5 +1,6 @@
 
 public interface GenericInjectedInterface<T> {
 	default T genericMethodThatDidNotExist() {
+		return null;
 	}
 }

--- a/src/test/resources/projects/interfaceInjection/src/main/java/OwnInjectedInterface.java
+++ b/src/test/resources/projects/interfaceInjection/src/main/java/OwnInjectedInterface.java
@@ -1,5 +1,8 @@
 
-public interface OwnInjectedInterface {
+public interface OwnInjectedInterface<T> {
 	default void anotherNewMethodThatDidNotExist() {
+	}
+
+	default void typedMethodThatDidNotExist() {
 	}
 }

--- a/src/test/resources/projects/interfaceInjection/src/main/java/OwnInjectedInterface.java
+++ b/src/test/resources/projects/interfaceInjection/src/main/java/OwnInjectedInterface.java
@@ -3,6 +3,6 @@ public interface OwnInjectedInterface<T> {
 	default void anotherNewMethodThatDidNotExist() {
 	}
 
-	default void typedMethodThatDidNotExist() {
+	default T typedMethodThatDidNotExist() {
 	}
 }

--- a/src/test/resources/projects/interfaceInjection/src/main/java/OwnInjectedInterface.java
+++ b/src/test/resources/projects/interfaceInjection/src/main/java/OwnInjectedInterface.java
@@ -4,5 +4,6 @@ public interface OwnInjectedInterface<T> {
 	}
 
 	default T typedMethodThatDidNotExist() {
+		return null;
 	}
 }

--- a/src/test/resources/projects/interfaceInjection/src/main/java/WildcardInjectedInterface.java
+++ b/src/test/resources/projects/interfaceInjection/src/main/java/WildcardInjectedInterface.java
@@ -1,0 +1,5 @@
+
+public interface OwnInjectedInterface {
+	default void anotherNewMethodThatDidNotExist() {
+	}
+}

--- a/src/test/resources/projects/interfaceInjection/src/main/java/WildcardInjectedInterface.java
+++ b/src/test/resources/projects/interfaceInjection/src/main/java/WildcardInjectedInterface.java
@@ -1,5 +1,0 @@
-
-public interface OwnInjectedInterface {
-	default void anotherNewMethodThatDidNotExist() {
-	}
-}

--- a/src/test/resources/projects/interfaceInjection/src/main/resources/fabric.mod.json
+++ b/src/test/resources/projects/interfaceInjection/src/main/resources/fabric.mod.json
@@ -5,7 +5,12 @@
   "name": "Own Dummy Mod",
   "custom": {
     "loom:injected_interfaces": {
-      "net/minecraft/class_2248": ["OwnInjectedInterface"]
+      "net/minecraft/class_2248": [
+        "OwnInjectedInterface<Ljava/lang/String;>"
+      ],
+      "net/minecraft/class_5321": [
+        "GenericInjectedInterface<TT;>"
+      ]
     }
   }
 }


### PR DESCRIPTION
Before this pull request, modders were able to add injected interfaces in other classes, but they were not able to use generics for them. This pull request allows to specify the raw generics signature (which is a part of the [ClassSignature](https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-4.html#jvms-ClassSignature)) after the interface name in `fabric.mod.json`, solving the issue.

Examples:

Before:

```json
"net/minecraft/class_x": [
    "com/example/WithoutGenerics",
    "com/example/WithGenerics" // but we can't specify them
]
```

After:

```json
"net/minecraft/class_x": [
    "com/example/WithoutGenerics",
    "com/example/WithGenerics<Ljava/lang/String;>"
]
```

Fixes #597