### PR TITLE
Use last 16 chars for checksum

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactRef.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactRef.java
@@ -80,7 +80,7 @@ public interface ArtifactRef {
 		public void applyToConfiguration(Project project, Configuration configuration) {
 			final DependencyHandler dependencies = project.getDependencies();
 
-			Dependency dep = dependencies.module(artifact.getModuleVersion() + (artifact.getClassifier() == null ? "" : ':' + artifact.getClassifier())); // the owning module of the artifact
+			Dependency dep = dependencies.create(artifact.getModuleVersion() + (artifact.getClassifier() == null ? "" : ':' + artifact.getClassifier())); // the owning module of the artifact
 
 			if (dep instanceof ModuleDependency moduleDependency) {
 				moduleDependency.setTransitive(false);

--- a/src/main/java/net/fabricmc/loom/task/MigrateMappingsTask.java
+++ b/src/main/java/net/fabricmc/loom/task/MigrateMappingsTask.java
@@ -143,10 +143,10 @@ public abstract class MigrateMappingsTask extends AbstractLoomTask {
 			project.getLogger().info("Could not locate mappings, presuming V2 Yarn");
 
 			try {
-				files = project.getConfigurations().detachedConfiguration(project.getDependencies().module(ImmutableMap.of("group", "net.fabricmc", "name", "yarn", "version", mappings, "classifier", "v2"))).resolve();
+				files = project.getConfigurations().detachedConfiguration(project.getDependencies().create(ImmutableMap.of("group", "net.fabricmc", "name", "yarn", "version", mappings, "classifier", "v2"))).resolve();
 			} catch (GradleException ignored2) {
 				project.getLogger().info("Could not locate mappings, presuming V1 Yarn");
-				files = project.getConfigurations().detachedConfiguration(project.getDependencies().module(ImmutableMap.of("group", "net.fabricmc", "name", "yarn", "version", mappings))).resolve();
+				files = project.getConfigurations().detachedConfiguration(project.getDependencies().create(ImmutableMap.of("group", "net.fabricmc", "name", "yarn", "version", mappings))).resolve();
 			}
 		}
 

--- a/src/main/java/net/fabricmc/loom/util/Checksum.java
+++ b/src/main/java/net/fabricmc/loom/util/Checksum.java
@@ -96,6 +96,7 @@ public class Checksum {
 
 	public static String projectHash(Project project) {
 		String str = project.getProjectDir().getAbsolutePath() + ":" + project.getPath();
-		return toHex(str.getBytes(StandardCharsets.UTF_8)).substring(0, 16);
+		String hex = toHex(str.getBytes(StandardCharsets.UTF_8));
+		return hex.substring(hex.length() - 16);
 	}
 }

--- a/src/main/java/net/fabricmc/loom/util/Checksum.java
+++ b/src/main/java/net/fabricmc/loom/util/Checksum.java
@@ -96,7 +96,7 @@ public class Checksum {
 
 	public static String projectHash(Project project) {
 		String str = project.getProjectDir().getAbsolutePath() + ":" + project.getPath();
-		String hex = toHex(str.getBytes(StandardCharsets.UTF_8));
+		String hex = sha1Hex(str.getBytes(StandardCharsets.UTF_8));
 		return hex.substring(hex.length() - 16);
 	}
 }


### PR DESCRIPTION
This makes it to use the last 16 chars for the checksum used to create a lock.
Currently it uses the first 16 chars which makes structures like
```
Foo/bar/project_1
            .../project_2
```

have the same lock file.

This is of interest due to #929 (and the advantages are outlined there too).

