### PR TITLE
Add JADX decompiler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,8 @@ def brokenConfigurations = [
 	"commonDecompilerRuntimeClasspath",
 	"fernflowerRuntimeClasspath",
 	"cfrRuntimeClasspath",
-	"vineflowerRuntimeClasspath"
+	"vineflowerRuntimeClasspath",
+	"jadxRuntimeClasspath",
 ]
 
 configurations.configureEach {
@@ -109,6 +110,11 @@ sourceSets {
 			srcDir("src/decompilers/vineflower")
 		}
 	}
+	jadx {
+		java {
+			srcDir("src/decompilers/jadx")
+		}
+	}
 }
 
 dependencies {
@@ -147,14 +153,24 @@ dependencies {
 	vineflowerCompileOnly runtimeLibs.vineflower
 	vineflowerCompileOnly libs.fabric.mapping.io
 
+	jadxCompileOnly dependencies.create(runtimeLibs.jadx.core.get()) {
+		exclude group: 'com.android.tools.build', module: 'aapt2-proto'
+	}
+	jadxCompileOnly dependencies.create(runtimeLibs.jadx.java.get()) {
+		exclude group: 'io.github.skylot', module: 'raung-disasm'
+	}
+	jadxCompileOnly libs.fabric.mapping.io
+
 	fernflowerApi sourceSets.commonDecompiler.output
 	cfrApi sourceSets.commonDecompiler.output
 	vineflowerApi sourceSets.commonDecompiler.output
+	jadxApi sourceSets.commonDecompiler.output
 
 	implementation sourceSets.commonDecompiler.output
 	implementation sourceSets.fernflower.output
 	implementation sourceSets.cfr.output
 	implementation sourceSets.vineflower.output
+	implementation sourceSets.jadx.output
 
 	// source code remapping
 	implementation libs.fabric.mercury
@@ -198,6 +214,7 @@ jar {
 	from sourceSets.cfr.output.classesDirs
 	from sourceSets.fernflower.output.classesDirs
 	from sourceSets.vineflower.output.classesDirs
+	from sourceSets.jadx.output.classesDirs
 }
 
 base {

--- a/gradle/runtime.libs.versions.toml
+++ b/gradle/runtime.libs.versions.toml
@@ -3,6 +3,7 @@
 fernflower = "2.0.0"
 cfr = "0.2.2"
 vineflower = "1.9.3"
+jadx = "1.4.7"
 
 # Runtime depedencies
 mixin-compile-extensions = "0.6.0"
@@ -16,6 +17,9 @@ native-support = "1.0.1"
 fernflower = { module = "net.fabricmc:fabric-fernflower", version.ref = "fernflower" }
 cfr = { module = "net.fabricmc:cfr", version.ref = "cfr" }
 vineflower = { module = "org.vineflower:vineflower", version.ref = "vineflower" }
+jadx-core = { module = "io.github.skylot:jadx-core", version.ref = "jadx" }
+jadx-java = { module = "io.github.skylot:jadx-java-input", version.ref = "jadx" }
+
 
 # Runtime depedencies
 mixin-compile-extensions = { module = "net.fabricmc:fabric-mixin-compile-extensions", version.ref = "mixin-compile-extensions" }

--- a/src/decompilers/jadx/net/fabricmc/loom/decompilers/jadx/JarEntryWriter.java
+++ b/src/decompilers/jadx/net/fabricmc/loom/decompilers/jadx/JarEntryWriter.java
@@ -38,7 +38,7 @@ public class JarEntryWriter {
 	JarEntryWriter(JarOutputStream outputStream) {
 		this.outputStream = outputStream;
 	}
-	
+
 	synchronized void write(String filename, byte[] data) throws IOException {
 		String[] path = filename.split("/");
 		String pathPart = "";

--- a/src/decompilers/jadx/net/fabricmc/loom/decompilers/jadx/JarEntryWriter.java
+++ b/src/decompilers/jadx/net/fabricmc/loom/decompilers/jadx/JarEntryWriter.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2024 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package net.fabricmc.loom.decompilers.jadx;
 
 import java.io.IOException;

--- a/src/decompilers/jadx/net/fabricmc/loom/decompilers/jadx/JarEntryWriter.java
+++ b/src/decompilers/jadx/net/fabricmc/loom/decompilers/jadx/JarEntryWriter.java
@@ -1,0 +1,46 @@
+package net.fabricmc.loom.decompilers.jadx;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+public class JarEntryWriter {
+	private final Set<String> addedDirectories = new HashSet<>();
+	private final JarOutputStream outputStream;
+
+	JarEntryWriter(JarOutputStream outputStream) {
+		this.outputStream = outputStream;
+	}
+	
+	synchronized void write(String filename, byte[] data) throws IOException {
+		String[] path = filename.split("/");
+		String pathPart = "";
+
+		for (int i = 0; i < path.length - 1; i++) {
+			pathPart += path[i] + "/";
+
+			if (addedDirectories.add(pathPart)) {
+				JarEntry entry = new JarEntry(pathPart);
+				entry.setTime(new Date().getTime());
+
+				try {
+					outputStream.putNextEntry(entry);
+					outputStream.closeEntry();
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				}
+			}
+		}
+
+		JarEntry entry = new JarEntry(filename);
+		entry.setTime(new Date().getTime());
+		entry.setSize(data.length);
+
+		outputStream.putNextEntry(entry);
+		outputStream.write(data);
+		outputStream.closeEntry();
+	}
+}

--- a/src/decompilers/jadx/net/fabricmc/loom/decompilers/jadx/LoomJadxDecompiler.java
+++ b/src/decompilers/jadx/net/fabricmc/loom/decompilers/jadx/LoomJadxDecompiler.java
@@ -144,7 +144,7 @@ public final class LoomJadxDecompiler implements LoomInternalDecompiler {
 
 				// Write to JAR
 				String filename = clsMapping.getSrcName() + ".java";
-				
+
 				try {
 					byte[] code = codeInfo.getCodeStr().getBytes(StandardCharsets.UTF_8);
 					jarEntryWriter.write(filename, code);

--- a/src/decompilers/jadx/net/fabricmc/loom/decompilers/jadx/LoomJadxDecompiler.java
+++ b/src/decompilers/jadx/net/fabricmc/loom/decompilers/jadx/LoomJadxDecompiler.java
@@ -182,7 +182,7 @@ public final class LoomJadxDecompiler implements LoomInternalDecompiler {
 		for (JavaField fld : cls.getFields()) {
 			FieldMapping fldMapping = clsMapping.getField(fld.getFieldNode().getName(), TypeGen.signature(fld.getType()));
 
-			if ((comment = emptyToNull(fldMapping.getComment())) != null) {
+			if (fldMapping != null && (comment = emptyToNull(fldMapping.getComment())) != null) {
 				fld.getFieldNode().addAttr(AType.CODE_COMMENTS, comment);
 			}
 		}
@@ -192,7 +192,7 @@ public final class LoomJadxDecompiler implements LoomInternalDecompiler {
 			String mthName = mthInfo.getName();
 			MethodMapping mthMapping = clsMapping.getMethod(mthName, mthInfo.getShortId().substring(mthName.length()));
 
-			if ((comment = emptyToNull(mthMapping.getComment())) != null) {
+			if (mthMapping != null && (comment = emptyToNull(mthMapping.getComment())) != null) {
 				mth.getMethodNode().addAttr(AType.CODE_COMMENTS, comment);
 			}
 		}
@@ -203,6 +203,6 @@ public final class LoomJadxDecompiler implements LoomInternalDecompiler {
 	}
 
 	public static String emptyToNull(String string) {
-		return string.isEmpty() ? null : string;
+		return string == null || string.isEmpty() ? null : string;
 	}
 }

--- a/src/decompilers/jadx/net/fabricmc/loom/decompilers/jadx/LoomJadxDecompiler.java
+++ b/src/decompilers/jadx/net/fabricmc/loom/decompilers/jadx/LoomJadxDecompiler.java
@@ -85,16 +85,13 @@ public final class LoomJadxDecompiler implements LoomInternalDecompiler {
 		JadxArgs jadxArgs = getJadxArgs();
 		jadxArgs.setThreadsCount(context.numberOfThreads());
 
-		List<Path> inputs = new ArrayList<>(context.libraries());
-		inputs.add(context.compiledJar());
-
 		Manifest manifest = new Manifest();
 		manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
 
 		try (JadxDecompiler jadx = new JadxDecompiler(jadxArgs);
 				JarOutputStream jarOutputStream = new JarOutputStream(Files.newOutputStream(context.sourcesDestination()), manifest);
 				Writer lineMapWriter = Files.newBufferedWriter(context.linemapDestination(), StandardCharsets.UTF_8)) {
-			jadx.addCustomLoad(JavaInputPlugin.loadClassFiles(inputs));
+			jadx.addCustomLoad(JavaInputPlugin.loadClassFiles(List.of(context.compiledJar())));
 			jadx.load();
 
 			MappingTree tree = readMappings(context.javaDocs().toFile());

--- a/src/decompilers/jadx/net/fabricmc/loom/decompilers/jadx/LoomJadxDecompiler.java
+++ b/src/decompilers/jadx/net/fabricmc/loom/decompilers/jadx/LoomJadxDecompiler.java
@@ -105,9 +105,10 @@ public final class LoomJadxDecompiler implements LoomInternalDecompiler {
 					continue;
 				}
 
+				String clsName = internalNameOf(cls.getClassNode());
+
 				// Add Javadocs
-				ClassMapping clsMapping = tree.getClass(internalNameOf(cls.getClassNode()));
-				addJavadocs(cls, clsMapping);
+				addJavadocs(cls, tree.getClass(clsName));
 
 				// Decompile
 				ICodeInfo codeInfo = cls.getCodeInfo();
@@ -122,7 +123,7 @@ public final class LoomJadxDecompiler implements LoomInternalDecompiler {
 				}
 
 				// Write to JAR
-				String filename = clsMapping.getSrcName() + ".java";
+				String filename = clsName + ".java";
 
 				try {
 					byte[] code = codeInfo.getCodeStr().getBytes(StandardCharsets.UTF_8);
@@ -146,7 +147,7 @@ public final class LoomJadxDecompiler implements LoomInternalDecompiler {
 					builder.append("\t").append(src).append("\t").append(dst).append("\n");
 				}
 
-				lineMapWriter.write(String.format(Locale.ENGLISH, "%s\t%d\t%d\n", clsMapping.getSrcName(), maxLine, maxLineDest));
+				lineMapWriter.write(String.format(Locale.ENGLISH, "%s\t%d\t%d\n", clsName, maxLine, maxLineDest));
 				lineMapWriter.write(builder.toString());
 				lineMapWriter.write("\n");
 			}

--- a/src/decompilers/jadx/net/fabricmc/loom/decompilers/jadx/LoomJadxDecompiler.java
+++ b/src/decompilers/jadx/net/fabricmc/loom/decompilers/jadx/LoomJadxDecompiler.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2021 FabricMC
+ * Copyright (c) 2024 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/decompilers/jadx/net/fabricmc/loom/decompilers/jadx/LoomJadxDecompiler.java
+++ b/src/decompilers/jadx/net/fabricmc/loom/decompilers/jadx/LoomJadxDecompiler.java
@@ -1,0 +1,198 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2021 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.decompilers.jadx;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.jar.Attributes;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+
+import jadx.api.CommentsLevel;
+import jadx.api.ICodeInfo;
+import jadx.api.JadxArgs;
+import jadx.api.JadxDecompiler;
+import jadx.api.JavaClass;
+import jadx.api.JavaField;
+import jadx.api.JavaMethod;
+import jadx.api.impl.NoOpCodeCache;
+import jadx.core.codegen.TypeGen;
+import jadx.core.dex.attributes.AFlag;
+import jadx.core.dex.attributes.AType;
+import jadx.core.dex.info.MethodInfo;
+import jadx.core.dex.nodes.ClassNode;
+import jadx.plugins.input.java.JavaInputPlugin;
+
+import net.fabricmc.loom.decompilers.LoomInternalDecompiler;
+import net.fabricmc.mappingio.MappingReader;
+import net.fabricmc.mappingio.adapter.MappingSourceNsSwitch;
+import net.fabricmc.mappingio.tree.MappingTree;
+import net.fabricmc.mappingio.tree.MappingTree.ClassMapping;
+import net.fabricmc.mappingio.tree.MappingTree.FieldMapping;
+import net.fabricmc.mappingio.tree.MappingTree.MethodMapping;
+import net.fabricmc.mappingio.tree.MemoryMappingTree;
+
+public final class LoomJadxDecompiler implements LoomInternalDecompiler {
+	private static JadxArgs getJadxArgs() {
+		JadxArgs jadxArgs = new JadxArgs();
+		jadxArgs.setCodeCache(NoOpCodeCache.INSTANCE);
+		jadxArgs.setShowInconsistentCode(true);
+		// jadxArgs.setInlineAnonymousClasses(false);
+		// jadxArgs.setInlineMethods(false);
+		jadxArgs.setSkipResources(true);
+		jadxArgs.setRenameValid(false);
+		jadxArgs.setRespectBytecodeAccModifiers(true);
+		jadxArgs.setCommentsLevel(CommentsLevel.WARN);
+
+		return jadxArgs;
+	}
+
+	@Override
+	public void decompile(LoomInternalDecompiler.Context context) {
+		JadxArgs jadxArgs = getJadxArgs();
+		jadxArgs.setThreadsCount(context.numberOfThreads());
+
+		List<Path> inputs = new ArrayList<>(context.libraries());
+		inputs.add(context.compiledJar());
+
+		Manifest manifest = new Manifest();
+		manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+
+		try (JadxDecompiler jadx = new JadxDecompiler(jadxArgs);
+				JarOutputStream jarOutputStream = new JarOutputStream(Files.newOutputStream(context.sourcesDestination()), manifest);
+				Writer lineMapWriter = Files.newBufferedWriter(context.linemapDestination(), StandardCharsets.UTF_8)) {
+			jadx.addCustomLoad(JavaInputPlugin.loadClassFiles(inputs));
+			jadx.load();
+
+			String comment;
+			MappingTree tree = readMappings(context.javaDocs().toFile());
+			JarEntryWriter jarEntryWriter = new JarEntryWriter(jarOutputStream);
+
+			for (JavaClass cls : jadx.getClasses()) {
+				if (cls.getClassNode().contains(AFlag.DONT_GENERATE)) {
+					continue;
+				}
+
+				// Add Javadocs
+				ClassMapping clsMapping = tree.getClass(internalNameOf(cls.getClassNode()));
+
+				if ((comment = emptyToNull(clsMapping.getComment())) != null) {
+					cls.getClassNode().addAttr(AType.CODE_COMMENTS, comment);
+				}
+
+				for (JavaField fld : cls.getFields()) {
+					FieldMapping fldMapping = clsMapping.getField(fld.getFieldNode().getName(), TypeGen.signature(fld.getType()));
+
+					if ((comment = emptyToNull(fldMapping.getComment())) != null) {
+						fld.getFieldNode().addAttr(AType.CODE_COMMENTS, comment);
+					}
+				}
+
+				for (JavaMethod mth : cls.getMethods()) {
+					MethodInfo mthInfo = mth.getMethodNode().getMethodInfo();
+					String mthName = mthInfo.getName();
+					MethodMapping mthMapping = clsMapping.getMethod(mthName, mthInfo.getShortId().substring(mthName.length()));
+
+					if ((comment = emptyToNull(mthMapping.getComment())) != null) {
+						mth.getMethodNode().addAttr(AType.CODE_COMMENTS, comment);
+					}
+				}
+
+				// Decompile
+				ICodeInfo codeInfo = cls.getCodeInfo();
+
+				if (codeInfo == null) {
+					context.logger().error("Code not generated for class " + cls.getFullName());
+					continue;
+				}
+
+				if (codeInfo == ICodeInfo.EMPTY) {
+					continue;
+				}
+
+				// Write to JAR
+				String filename = clsMapping.getSrcName() + ".java";
+				
+				try {
+					byte[] code = codeInfo.getCodeStr().getBytes(StandardCharsets.UTF_8);
+					jarEntryWriter.write(filename, code);
+				} catch (IOException e) {
+					throw new RuntimeException("Unable to create archive: " + filename, e);
+				}
+
+				// Write line map
+				int maxLine = 0;
+				int maxLineDest = 0;
+				StringBuilder builder = new StringBuilder();
+
+				for (Map.Entry<Integer, Integer> mappingEntry : cls.getCodeInfo().getCodeMetadata().getLineMapping().entrySet()) {
+					final int src = mappingEntry.getKey();
+					final int dst = mappingEntry.getValue();
+
+					maxLine = Math.max(maxLine, src);
+					maxLineDest = Math.max(maxLineDest, dst);
+
+					builder.append("\t").append(src).append("\t").append(dst).append("\n");
+				}
+
+				lineMapWriter.write(String.format(Locale.ENGLISH, "%s\t%d\t%d\n", clsMapping.getSrcName(), maxLine, maxLineDest));
+				lineMapWriter.write(builder.toString());
+				lineMapWriter.write("\n");
+			}
+		} catch (IOException e) {
+			throw new UncheckedIOException("Failed to decompile", e);
+		}
+	}
+
+	private MappingTree readMappings(File input) {
+		try (BufferedReader reader = Files.newBufferedReader(input.toPath())) {
+			MemoryMappingTree mappingTree = new MemoryMappingTree();
+			MappingSourceNsSwitch nsSwitch = new MappingSourceNsSwitch(mappingTree, "named");
+			MappingReader.read(reader, nsSwitch);
+
+			return mappingTree;
+		} catch (IOException e) {
+			throw new RuntimeException("Failed to read mappings", e);
+		}
+	}
+
+	private String internalNameOf(ClassNode cls) {
+		return cls.getClassInfo().makeRawFullName().replace('.', '/');
+	}
+
+	public static String emptyToNull(String string) {
+		return string.isEmpty() ? null : string;
+	}
+}

--- a/src/decompilers/jadx/net/fabricmc/loom/decompilers/jadx/LoomJadxDecompiler.java
+++ b/src/decompilers/jadx/net/fabricmc/loom/decompilers/jadx/LoomJadxDecompiler.java
@@ -31,8 +31,6 @@ import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;

--- a/src/test/groovy/net/fabricmc/loom/test/integration/DecompileTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/DecompileTest.groovy
@@ -49,6 +49,7 @@ class DecompileTest extends Specification implements GradleProjectTestTrait {
 		'fernflower'	| "genSourcesWithFernFlower"		| PRE_RELEASE_GRADLE
 		'cfr' 			| "genSourcesWithCfr"				| PRE_RELEASE_GRADLE
 		'vineflower' 	| "genSourcesWithVineflower"		| PRE_RELEASE_GRADLE
+		'jadx'		 	| "genSourcesWithJadx"				| PRE_RELEASE_GRADLE
 	}
 
 	@Unroll


### PR DESCRIPTION
Adds support for the [JADX](https://github.com/skylot/jadx) decompiler.

Version 1.4.7 doesn't support properly attaching Javadocs, the best I could do is adding normal comments (with `//`). The latest  master branch fixes this, but I didn't want to depend on potentially unstable snapshot versions.

~~Running `genSourcesWithJadx` currently cashes due to some [transitive dependencies not being excluded](https://github.com/NebelNidas/fabric-loom/blob/3e8f50c02706760c4d56eccd2169124a42f023d8/src/main/java/net/fabricmc/loom/decompilers/DecompilerConfiguration.java#L59), but I've never worked with Gradle's Java API before, so I'm not sure how to do this. Which means I wasn't able to conduct proper tests yet, maybe I'll have to fix up some more stuff later down the road.~~