### PR TITLE
Introduce SemVer version parsing to included mods/libraries

### DIFF
--- a/src/main/java/net/fabricmc/loom/build/nesting/IncludedJarFactory.java
+++ b/src/main/java/net/fabricmc/loom/build/nesting/IncludedJarFactory.java
@@ -63,8 +63,8 @@ import net.fabricmc.loom.util.fmj.FabricModJsonFactory;
 public final class IncludedJarFactory {
 	private final Project project;
 	private static final Logger LOGGER = LoggerFactory.getLogger(IncludedJarFactory.class);
-	private static final String semverRegex = "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$";
-	private static final Pattern pattern = Pattern.compile(semverRegex);
+	private static final String SEMVER_REGEX = "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$";
+	private static final Pattern SEMVER_PATTERN = Pattern.compile(SEMVER_REGEX);
 
 	public IncludedJarFactory(Project project) {
 		this.project = project;
@@ -244,7 +244,7 @@ public final class IncludedJarFactory {
 	}
 
 	private static boolean validSemVer(String version) {
-		Matcher matcher = pattern.matcher(version);
+		Matcher matcher = SEMVER_PATTERN.matcher(version);
 		return matcher.find();
 	}
 }

--- a/src/main/java/net/fabricmc/loom/build/nesting/IncludedJarFactory.java
+++ b/src/main/java/net/fabricmc/loom/build/nesting/IncludedJarFactory.java
@@ -31,6 +31,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.google.common.collect.Sets;
 import com.google.common.hash.Hashing;
@@ -49,6 +51,8 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.LoomGradlePlugin;
@@ -58,6 +62,9 @@ import net.fabricmc.loom.util.fmj.FabricModJsonFactory;
 
 public final class IncludedJarFactory {
 	private final Project project;
+	private static final Logger LOGGER = LoggerFactory.getLogger(IncludedJarFactory.class);
+	private static final String semverRegex = "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$";
+	private static final Pattern pattern = Pattern.compile(semverRegex);
 
 	public IncludedJarFactory(Project project) {
 		this.project = project;
@@ -190,7 +197,8 @@ public final class IncludedJarFactory {
 		jsonObject.addProperty("schemaVersion", 1);
 
 		jsonObject.addProperty("id", modId);
-		jsonObject.addProperty("version", metadata.version());
+		String version = getVersion(metadata);
+		jsonObject.addProperty("version", version);
 		jsonObject.addProperty("name", metadata.name());
 
 		JsonObject custom = new JsonObject();
@@ -209,5 +217,34 @@ public final class IncludedJarFactory {
 				return "_" + classifier;
 			}
 		}
+
+		@Override
+		public String toString() {
+			return group + ":" + name + ":" + version + classifier();
+		}
+	}
+
+	private static String getVersion(Metadata metadata) {
+		String version = metadata.version();
+
+		if (validSemVer(version)) {
+			return version;
+		}
+
+		if (version.endsWith(".Final") || version.endsWith(".final")) {
+			String trimmedVersion = version.substring(0, version.length() - 6);
+
+			if (validSemVer(trimmedVersion)) {
+				return trimmedVersion;
+			}
+		}
+
+		LOGGER.warn("({}) is not valid semver for dependency {}", version, metadata);
+		return version;
+	}
+
+	private static boolean validSemVer(String version) {
+		Matcher matcher = pattern.matcher(version);
+		return matcher.find();
 	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/integration/SemVerParsingTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/SemVerParsingTest.groovy
@@ -25,10 +25,10 @@
 package net.fabricmc.loom.test.integration
 
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import net.fabricmc.loom.build.nesting.IncludedJarFactory
 import net.fabricmc.loom.test.util.GradleProjectTestTrait
-import spock.lang.Unroll
 
 class SemVerParsingTest extends Specification implements GradleProjectTestTrait {
 	@Unroll

--- a/src/test/groovy/net/fabricmc/loom/test/integration/SemVerParsingTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/SemVerParsingTest.groovy
@@ -1,0 +1,80 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2024 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.integration
+
+import spock.lang.Specification
+
+import net.fabricmc.loom.build.nesting.IncludedJarFactory
+import net.fabricmc.loom.test.util.GradleProjectTestTrait
+import spock.lang.Unroll
+
+class SemVerParsingTest extends Specification implements GradleProjectTestTrait {
+	@Unroll
+	def "test valid Semantic Versioning strings"() {
+		given:
+		IncludedJarFactory includedJarFactory = new IncludedJarFactory(null)
+
+		expect:
+		includedJarFactory.validSemVer(version) == true
+
+		where:
+		version                   | _
+		"1.0.0"                   | _
+		"2.5.3"                   | _
+		"3.0.0-beta.2"            | _
+		"4.2.1-alpha+001"         | _
+		"5.0.0-rc.1+build.1"      | _
+	}
+
+	@Unroll
+	def "test non-Semantic Versioning strings"() {
+		given:
+		IncludedJarFactory includedJarFactory = new IncludedJarFactory(null)
+
+		expect:
+		includedJarFactory.validSemVer(version) == false
+
+		where:
+		version                   | _
+		"1.0"                     | _
+		"3.0.0.Beta1-120922-126"  | _
+		"3.0.2.Final"             | _
+		"4.2.1.4.RELEASE"         | _
+	}
+
+	@Unroll
+	def "test '.Final' suffixed SemVer"() {
+		given:
+		IncludedJarFactory includedJarFactory = new IncludedJarFactory(null)
+
+		expect:
+		includedJarFactory.getVersion(metadata) == expectedVersion
+
+		where:
+		metadata                                                               | expectedVersion
+		new IncludedJarFactory.Metadata("group", "name", "1.0.0.Final", null)  | "1.0.0"
+		new IncludedJarFactory.Metadata("group", "name", "2.5.3.final", null)  | "2.5.3"
+	}
+}


### PR DESCRIPTION
This ensures that JiJ'ing libraries is much easier. For example, currently, it's common to see warnings such as these at the start of a fabric server:

```
[22:59:17] [main/INFO]: Loading Minecraft 1.20.4 with Fabric Loader 0.15.3
[22:59:17] [ForkJoinPool-1-worker-12/WARN]: Mod org_cloudburstmc_nbt uses the version 3.0.2.Final which isn't compatible with Loader's extended semantic version format (Could not parse version number component 'Final'!), SemVer is recommended for reliably evaluating dependencies and prioritizing newer version
[22:59:18] [ForkJoinPool-1-worker-16/WARN]: Mod io_netty_netty-codec-haproxy uses the version 4.1.103.Final which isn't compatible with Loader's extended semantic version format (Could not parse version number component 'Final'!), SemVer is recommended for reliably evaluating dependencies and prioritizing newer version
[22:59:18] [ForkJoinPool-1-worker-7/WARN]: Mod io_netty_netty-codec-dns uses the version 4.1.103.Final which isn't compatible with Loader's extended semantic version format (Could not parse version number component 'Final'!), SemVer is recommended for reliably evaluating dependencies and prioritizing newer version
```

With this PR, Loom warns about dependencies that do not follow SemVer versioning:
```
> Configure project :
Fabric Loom: 1.6.local
Download https://repo.opencollab.dev/main/org/cloudburstmc/protocol/common/3.0.0.Beta1-SNAPSHOT/maven-metadata.xml, took 252 ms
Download https://repo.opencollab.dev/main/org/cloudburstmc/math/immutable/2.0-SNAPSHOT/maven-metadata.xml, took 45 ms
(3.0.0.Beta1-20240313.120922-126) is not valid semver for dependency org.cloudburstmc.protocol:bedrock-codec:3.0.0.Beta1-20240313.120922-126
```

Further, `.Final` suffixes are stripped as these are common for various libraries, such as netty's. This should, hopefully, reduce the number of such warnings and potentially raise awareness for modders that their libraries do not follow SemVer versioning.

Ideally, Loom could deal with other versioning issues/outliers, such as:
- `3.0.0.Beta1-20240226.201527-124`
- `1.0.0.CR1-20231206.145325-12`
- commit-pinned versions
- various other issues.