### PR TITLE
Use different cache files for custom manifest and metadata jsons

### DIFF
--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -142,7 +142,15 @@ public interface LoomGradleExtensionAPI {
 	@ApiStatus.Experimental
 	ManifestLocations getVersionsManifests();
 
-	Property<String> getCustomMinecraftManifest();
+	/**
+	 * @deprecated use {@linkplain #getCustomMinecraftMetadata} instead
+	 */
+	@Deprecated
+	default Property<String> getCustomMinecraftManifest() {
+		return getCustomMinecraftMetadata();
+	}
+
+	Property<String> getCustomMinecraftMetadata();
 
 	SetProperty<String> getKnownIndyBsms();
 

--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -134,16 +134,20 @@ public interface LoomGradleExtensionAPI {
 
 	InterfaceInjectionExtensionAPI getInterfaceInjection();
 
+	@ApiStatus.Experimental
 	default void versionsManifests(Action<VersionsManifestsAPI> action) {
 		action.execute(getVersionsManifests());
 	}
 
+	@ApiStatus.Experimental
 	ManifestLocations getVersionsManifests();
 
+	@ApiStatus.Experimental
 	default void experimentalVersionsManifests(Action<VersionsManifestsAPI> action) {
 		action.execute(getExperimentalVersionsManifests());
 	}
 
+	@ApiStatus.Experimental
 	ManifestLocations getExperimentalVersionsManifests();
 
 	Property<String> getCustomMinecraftManifest();

--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -43,6 +43,7 @@ import org.gradle.api.tasks.SourceSet;
 import org.jetbrains.annotations.ApiStatus;
 
 import net.fabricmc.loom.api.decompilers.DecompilerOptions;
+import net.fabricmc.loom.api.manifest.VersionsManifestsAPI;
 import net.fabricmc.loom.api.mappings.intermediate.IntermediateMappingsProvider;
 import net.fabricmc.loom.api.mappings.layered.spec.LayeredMappingSpecBuilder;
 import net.fabricmc.loom.api.processor.MinecraftJarProcessor;
@@ -51,6 +52,7 @@ import net.fabricmc.loom.api.remapping.RemapperParameters;
 import net.fabricmc.loom.configuration.ide.RunConfigSettings;
 import net.fabricmc.loom.configuration.processors.JarProcessor;
 import net.fabricmc.loom.configuration.providers.mappings.NoOpIntermediateMappingsProvider;
+import net.fabricmc.loom.configuration.providers.minecraft.ManifestLocations;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftJarConfiguration;
 import net.fabricmc.loom.task.GenerateSourcesTask;
 import net.fabricmc.loom.util.DeprecationHelper;
@@ -132,11 +134,19 @@ public interface LoomGradleExtensionAPI {
 
 	InterfaceInjectionExtensionAPI getInterfaceInjection();
 
+	default void versionsManifests(Action<VersionsManifestsAPI> action) {
+		action.execute(getVersionsManifests());
+	}
+
+	ManifestLocations getVersionsManifests();
+
+	default void experimentalVersionsManifests(Action<VersionsManifestsAPI> action) {
+		action.execute(getExperimentalVersionsManifests());
+	}
+
+	ManifestLocations getExperimentalVersionsManifests();
+
 	Property<String> getCustomMinecraftManifest();
-
-	Property<String> getCustomVersionsManifest();
-
-	Property<String> getCustomExperimentalVersionsManifest();
 
 	SetProperty<String> getKnownIndyBsms();
 

--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -142,14 +142,6 @@ public interface LoomGradleExtensionAPI {
 	@ApiStatus.Experimental
 	ManifestLocations getVersionsManifests();
 
-	@ApiStatus.Experimental
-	default void experimentalVersionsManifests(Action<VersionsManifestsAPI> action) {
-		action.execute(getExperimentalVersionsManifests());
-	}
-
-	@ApiStatus.Experimental
-	ManifestLocations getExperimentalVersionsManifests();
-
 	Property<String> getCustomMinecraftManifest();
 
 	SetProperty<String> getKnownIndyBsms();

--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -134,6 +134,10 @@ public interface LoomGradleExtensionAPI {
 
 	Property<String> getCustomMinecraftManifest();
 
+	Property<String> getCustomVersionsManifest();
+
+	Property<String> getCustomExperimentalVersionsManifest();
+
 	SetProperty<String> getKnownIndyBsms();
 
 	/**

--- a/src/main/java/net/fabricmc/loom/api/manifest/VersionsManifestsAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/manifest/VersionsManifestsAPI.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2016-2021 FabricMC
+ * Copyright (c) 2024 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,23 +22,24 @@
  * SOFTWARE.
  */
 
-package net.fabricmc.loom.configuration.providers.minecraft;
+package net.fabricmc.loom.api.manifest;
 
-import java.util.List;
-import java.util.Map;
+import org.jetbrains.annotations.ApiStatus;
 
-import org.jetbrains.annotations.Nullable;
-
-public record ManifestVersion(List<Versions> versions, Map<String, String> latest) {
-	public static class Versions {
-		public String id, url, sha1;
+@ApiStatus.Experimental
+public interface VersionsManifestsAPI {
+	/**
+	 * Adds a URL to a versions manifest json with the default priority of {@code 0}.
+	 * @param url the String-representation of the URL to the manifest json
+	 */
+	default void add(String url) {
+		add(url, 0);
 	}
 
-	@Nullable
-	public Versions getVersion(String id) {
-		return versions.stream()
-				.filter(versions -> versions.id.equalsIgnoreCase(id))
-				.findFirst()
-				.orElse(null);
-	}
+	/**
+	 * Adds a URL to a versions manifest json with the default priority of {@code 0}.
+	 * @param url the String-representation of the URL to the manifest json
+	 * @param priority the priority with which this URL gets sorted against other entries
+	 */
+	void add(String url, int priority);
 }

--- a/src/main/java/net/fabricmc/loom/api/manifest/VersionsManifestsAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/manifest/VersionsManifestsAPI.java
@@ -40,6 +40,7 @@ public interface VersionsManifestsAPI {
 	 * Adds a URL to a versions manifest json with the default priority of {@code 0}.
 	 * @param url the String-representation of the URL to the manifest json
 	 * @param priority the priority with which this URL gets sorted against other entries
+	 *        entries are sorted by priority, from lowest to highest
 	 */
 	void add(String url, int priority);
 }

--- a/src/main/java/net/fabricmc/loom/api/manifest/VersionsManifestsAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/manifest/VersionsManifestsAPI.java
@@ -37,7 +37,7 @@ public interface VersionsManifestsAPI {
 	}
 
 	/**
-	 * Adds a URL to a versions manifest json with the default priority of {@code 0}.
+	 * Adds a URL to a versions manifest json with the given priority.
 	 * @param url the String-representation of the URL to the manifest json
 	 * @param priority the priority with which this URL gets sorted against other entries
 	 *        entries are sorted by priority, from lowest to highest

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/ManifestLocations.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/ManifestLocations.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2024 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.configuration.providers.minecraft;
+
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.PriorityQueue;
+import java.util.Queue;
+
+import net.fabricmc.loom.api.manifest.VersionsManifestsAPI;
+import net.fabricmc.loom.configuration.providers.minecraft.ManifestLocations.ManifestLocation;
+
+public class ManifestLocations implements VersionsManifestsAPI, Iterable<ManifestLocation> {
+	private static final String FILE_EXTENSION = ".json";
+	private final Queue<ManifestLocation> locations = new PriorityQueue<>();
+	private final String baseCacheFileName;
+
+	public ManifestLocations(String builtInUrl, String baseCacheFileName) {
+		this.locations.add(new ManifestLocation(true, 0, builtInUrl));
+		this.baseCacheFileName = baseCacheFileName;
+	}
+
+	@Override
+	public void add(String url, int priority) {
+		locations.add(new ManifestLocation(false, priority, url));
+	}
+
+	@Override
+	public Iterator<ManifestLocation> iterator() {
+		return locations.iterator();
+	}
+
+	public class ManifestLocation implements Comparable<ManifestLocation> {
+		private final boolean builtIn;
+		private final int priority;
+		private final String url;
+
+		private ManifestLocation(boolean builtIn, int priority, String url) {
+			this.builtIn = builtIn;
+			this.priority = priority;
+			this.url = url;
+		}
+
+		public boolean isBuiltIn() {
+			return builtIn;
+		}
+
+		public String url() {
+			return url;
+		}
+
+		public Path cacheFile(Path dir) {
+			String fileName = !builtIn
+					? baseCacheFileName + "-" + url.hashCode() + FILE_EXTENSION
+					: baseCacheFileName + FILE_EXTENSION;
+			return dir.resolve(fileName);
+		}
+
+		@Override
+		public int compareTo(ManifestLocation o) {
+			return Integer.compare(priority, o.priority);
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/ManifestLocations.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/ManifestLocations.java
@@ -35,16 +35,19 @@ import net.fabricmc.loom.configuration.providers.minecraft.ManifestLocations.Man
 public class ManifestLocations implements VersionsManifestsAPI, Iterable<ManifestLocation> {
 	private static final String FILE_EXTENSION = ".json";
 	private final Queue<ManifestLocation> locations = new PriorityQueue<>();
-	private final String baseCacheFileName;
+	private final String baseFileName;
 
-	public ManifestLocations(String builtInUrl, String baseCacheFileName) {
-		this.locations.add(new ManifestLocation(true, 0, builtInUrl));
-		this.baseCacheFileName = baseCacheFileName;
+	public ManifestLocations(String baseFileName) {
+		this.baseFileName = baseFileName;
+	}
+
+	public void addBuiltIn(int priority, String url, String fileName) {
+		locations.add(new ManifestLocation(priority, url, fileName));
 	}
 
 	@Override
 	public void add(String url, int priority) {
-		locations.add(new ManifestLocation(false, priority, url));
+		locations.add(new ManifestLocation(priority, url));
 	}
 
 	@Override
@@ -53,18 +56,22 @@ public class ManifestLocations implements VersionsManifestsAPI, Iterable<Manifes
 	}
 
 	public class ManifestLocation implements Comparable<ManifestLocation> {
-		private final boolean builtIn;
 		private final int priority;
 		private final String url;
+		private final String builtInFileName;
 
-		private ManifestLocation(boolean builtIn, int priority, String url) {
-			this.builtIn = builtIn;
+		private ManifestLocation(int priority, String url) {
+			this(priority, url, null);
+		}
+
+		private ManifestLocation(int priority, String url, String builtInFileName) {
 			this.priority = priority;
 			this.url = url;
+			this.builtInFileName = builtInFileName;
 		}
 
 		public boolean isBuiltIn() {
-			return builtIn;
+			return builtInFileName != null;
 		}
 
 		public String url() {
@@ -72,9 +79,9 @@ public class ManifestLocations implements VersionsManifestsAPI, Iterable<Manifes
 		}
 
 		public Path cacheFile(Path dir) {
-			String fileName = !builtIn
-					? baseCacheFileName + "-" + url.hashCode() + FILE_EXTENSION
-					: baseCacheFileName + FILE_EXTENSION;
+			String fileName = (builtInFileName == null)
+					? builtInFileName + FILE_EXTENSION
+					: baseFileName + "-" + url.hashCode() + FILE_EXTENSION;
 			return dir.resolve(fileName);
 		}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/ManifestLocations.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/ManifestLocations.java
@@ -81,7 +81,7 @@ public class ManifestLocations implements VersionsManifestsAPI, Iterable<Manifes
 		public Path cacheFile(Path dir) {
 			String fileName = (builtInFileName == null)
 					? builtInFileName + FILE_EXTENSION
-					: baseFileName + "-" + url.hashCode() + FILE_EXTENSION;
+					: baseFileName + "-" + Integer.toHexString(url.hashCode()) + FILE_EXTENSION;
 			return dir.resolve(fileName);
 		}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/ManifestLocations.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/ManifestLocations.java
@@ -79,7 +79,7 @@ public class ManifestLocations implements VersionsManifestsAPI, Iterable<Manifes
 		}
 
 		public Path cacheFile(Path dir) {
-			String fileName = (builtInFileName == null)
+			String fileName = (builtInFileName != null)
 					? builtInFileName + FILE_EXTENSION
 					: baseFileName + "-" + Integer.toHexString(url.hashCode()) + FILE_EXTENSION;
 			return dir.resolve(fileName);

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
@@ -169,29 +169,26 @@ public final class MinecraftMetadataProvider {
 			final Path userCache = extension.getFiles().getUserCache().toPath();
 			final Path workingDir = MinecraftProvider.minecraftWorkingDirectory(project, minecraftVersion).toPath();
 
-			final String manifestUrl = MirrorUtil.getVersionManifests(project);
-			final String expManifestUrl = MirrorUtil.getExperimentalVersions(project);
+			final Property<String> customManifestUrl = extension.getCustomVersionsManifest();
+			final Property<String> customExpManifestUrl = extension.getCustomExperimentalVersionsManifest();
 			final Property<String> customMetaUrl = extension.getCustomMinecraftManifest();
 
-			final boolean customManifest = !manifestUrl.equals(Constants.VERSION_MANIFESTS);
-			final boolean customExpManifest = !expManifestUrl.equals(Constants.EXPERIMENTAL_VERSIONS);
-
-			final Path manifestPath = customManifest
-					? userCache.resolve("version_manifest-" + manifestUrl.hashCode() + ".json")
+			final Path manifestPath = customManifestUrl.isPresent()
+					? userCache.resolve("version_manifest-" + customManifestUrl.get().hashCode() + ".json")
 					: userCache.resolve("version_manifest.json");
-			final Path expManifestPath = customExpManifest
-					? userCache.resolve("experimental_version_manifest-" + expManifestUrl.hashCode() + ".json")
+			final Path expManifestPath = customExpManifestUrl.isPresent()
+					? userCache.resolve("experimental_version_manifest-" + customExpManifestUrl.get().hashCode() + ".json")
 					: userCache.resolve("experimental_version_manifest.json");
 			final Path metadataPath = customMetaUrl.isPresent()
 					? workingDir.resolve("minecraft-info-" + customMetaUrl.get().hashCode() + ".json")
-					: customManifest || customExpManifest
-							? workingDir.resolve("minecraft-info-" + manifestUrl.hashCode() + ".json")
+					: customManifestUrl.isPresent() || customExpManifestUrl.isPresent()
+							? workingDir.resolve("minecraft-info-" + customManifestUrl.get().hashCode() + ".json")
 							: workingDir.resolve("minecraft-info.json");
 
 			return new Options(
 					minecraftVersion,
-					manifestUrl,
-					expManifestUrl,
+					customManifestUrl.getOrElse(MirrorUtil.getVersionManifests(project)),
+					customExpManifestUrl.getOrElse(MirrorUtil.getExperimentalVersions(project)),
 					customMetaUrl.getOrNull(),
 					manifestPath,
 					expManifestPath,

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
@@ -165,12 +165,12 @@ public final class MinecraftMetadataProvider {
 
 		// custom version metadata
 		if (versionEntry.manifest == null) {
-			return base + versionEntry.entry.url.hashCode() + ".json";
+			return base + Integer.toHexString(versionEntry.entry.url.hashCode()) + ".json";
 		}
 
 		// custom versions manifest
 		if (!versionEntry.manifest.isBuiltIn()) {
-			return base + versionEntry.manifest.url().hashCode() + ".json";
+			return base + Integer.toHexString(versionEntry.manifest.url().hashCode()) + ".json";
 		}
 
 		return base + ".json";

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
@@ -108,18 +108,8 @@ public final class MinecraftMetadataProvider {
 			suppliers.add(() -> getManifestEntry(location, false));
 		}
 
-		// Then try finding the experimental version with caching
-		for (ManifestLocation location : options.experimentalVersionsManifests()) {
-			suppliers.add(() -> getManifestEntry(location, false));
-		}
-
 		// Then force download Mojang's metadata to find the version
 		for (ManifestLocation location : options.versionsManifests()) {
-			suppliers.add(() -> getManifestEntry(location, true));
-		}
-
-		// Finally try a force downloaded experimental metadata.
-		for (ManifestLocation location : options.experimentalVersionsManifests()) {
 			suppliers.add(() -> getManifestEntry(location, true));
 		}
 
@@ -188,7 +178,6 @@ public final class MinecraftMetadataProvider {
 
 	public record Options(String minecraftVersion,
 					ManifestLocations versionsManifests,
-					ManifestLocations experimentalVersionsManifests,
 					@Nullable String customManifestUrl,
 					Path userCache,
 					Path workingDir) {
@@ -198,13 +187,11 @@ public final class MinecraftMetadataProvider {
 			final Path workingDir = MinecraftProvider.minecraftWorkingDirectory(project, minecraftVersion).toPath();
 
 			final ManifestLocations manifestLocations = extension.getVersionsManifests();
-			final ManifestLocations experimentalManifestLocations = extension.getExperimentalVersionsManifests();
 			final Property<String> customMetaUrl = extension.getCustomMinecraftManifest();
 
 			return new Options(
 					minecraftVersion,
 					manifestLocations,
-					experimentalManifestLocations,
 					customMetaUrl.getOrNull(),
 					userCache,
 					workingDir

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
@@ -108,7 +108,7 @@ public final class MinecraftMetadataProvider {
 			suppliers.add(() -> getManifestEntry(location, false));
 		}
 
-		// Then force download Mojang's metadata to find the version
+		// Then force download the manifest to find the version
 		for (ManifestLocation location : options.versionsManifests()) {
 			suppliers.add(() -> getManifestEntry(location, true));
 		}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
@@ -187,7 +187,7 @@ public final class MinecraftMetadataProvider {
 			final Path workingDir = MinecraftProvider.minecraftWorkingDirectory(project, minecraftVersion).toPath();
 
 			final ManifestLocations manifestLocations = extension.getVersionsManifests();
-			final Property<String> customMetaUrl = extension.getCustomMinecraftManifest();
+			final Property<String> customMetaUrl = extension.getCustomMinecraftMetadata();
 
 			return new Options(
 					minecraftVersion,

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
@@ -164,14 +164,26 @@ public final class MinecraftMetadataProvider {
 			builder.defaultCache();
 		}
 
-		final String fileName = versionEntry.manifest == null
-				? "minecraft-info-" + versionEntry.entry.url.hashCode() + ".json"
-				: !versionEntry.manifest.isBuiltIn()
-						? "minecraft-info-" + versionEntry.manifest.url().hashCode() + ".json"
-						: "minecraft-info.json";
+		final String fileName = getVersionMetaFileName();
 		final Path cacheFile = options.workingDir().resolve(fileName);
 		final String json = builder.downloadString(cacheFile);
 		return LoomGradlePlugin.GSON.fromJson(json, MinecraftVersionMeta.class);
+	}
+
+	private String getVersionMetaFileName() {
+		String base = "minecraft-info";
+
+		// custom version metadata
+		if (versionEntry.manifest == null) {
+			return base + versionEntry.entry.url.hashCode() + ".json";
+		}
+
+		// custom versions manifest
+		if (!versionEntry.manifest.isBuiltIn()) {
+			return base + versionEntry.manifest.url().hashCode() + ".json";
+		}
+
+		return base + ".json";
 	}
 
 	public record Options(String minecraftVersion,

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/VersionsManifest.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/VersionsManifest.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2023 FabricMC
+ * Copyright (c) 2016-2021 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,35 +22,23 @@
  * SOFTWARE.
  */
 
-package net.fabricmc.loom.test.util
+package net.fabricmc.loom.configuration.providers.minecraft;
 
-import java.time.Duration
+import java.util.List;
+import java.util.Map;
 
-import com.google.gson.Gson
-import com.google.gson.GsonBuilder
+import org.jetbrains.annotations.Nullable;
 
-import net.fabricmc.loom.configuration.providers.minecraft.MinecraftVersionMeta
-import net.fabricmc.loom.configuration.providers.minecraft.VersionsManifest
-import net.fabricmc.loom.test.LoomTestConstants
-import net.fabricmc.loom.util.Constants
-import net.fabricmc.loom.util.download.Download
-
-class MinecraftTestUtils {
-	private static final File TEST_DIR = new File(LoomTestConstants.TEST_DIR, "minecraft")
-	public static final Gson GSON = new GsonBuilder().create()
-
-	static MinecraftVersionMeta getVersionMeta(String id) {
-		def versionManifest = download(Constants.VERSION_MANIFESTS, "version_manifest.json")
-		def manifest = GSON.fromJson(versionManifest, VersionsManifest.class)
-		def version = manifest.versions().find { it.id == id }
-
-		def metaJson = download(version.url, "${id}.json")
-		GSON.fromJson(metaJson, MinecraftVersionMeta.class)
+public record VersionsManifest(List<Version> versions, Map<String, String> latest) {
+	public static class Version {
+		public String id, url, sha1;
 	}
 
-	static String download(String url, String name) {
-		Download.create(url)
-				.maxAge(Duration.ofDays(31))
-				.downloadString(new File(TEST_DIR, name).toPath())
+	@Nullable
+	public Version getVersion(String id) {
+		return versions.stream()
+				.filter(versions -> versions.id.equalsIgnoreCase(id))
+				.findFirst()
+				.orElse(null);
 	}
 }

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -84,6 +84,8 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	protected final ConfigurableFileCollection log4jConfigs;
 	protected final RegularFileProperty accessWidener;
 	protected final Property<String> customManifest;
+	protected final Property<String> customVersionsManifest;
+	protected final Property<String> customExperimentalVersionsManifest;
 	protected final SetProperty<String> knownIndyBsms;
 	protected final Property<Boolean> transitiveAccessWideners;
 	protected final Property<Boolean> modProvidedJavadoc;
@@ -115,6 +117,8 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 		this.log4jConfigs = project.files(directories.getDefaultLog4jConfigFile());
 		this.accessWidener = project.getObjects().fileProperty();
 		this.customManifest = project.getObjects().property(String.class);
+		this.customVersionsManifest = project.getObjects().property(String.class);
+		this.customExperimentalVersionsManifest = project.getObjects().property(String.class);
 		this.knownIndyBsms = project.getObjects().setProperty(String.class).convention(Set.of(
 				"java/lang/invoke/StringConcatFactory",
 				"java/lang/runtime/ObjectMethods",
@@ -256,6 +260,16 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	@Override
 	public Property<String> getCustomMinecraftManifest() {
 		return customManifest;
+	}
+
+	@Override
+	public Property<String> getCustomVersionsManifest() {
+		return customVersionsManifest;
+	}
+
+	@Override
+	public Property<String> getCustomExperimentalVersionsManifest() {
+		return customExperimentalVersionsManifest;
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -85,8 +85,8 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	protected final ListProperty<JarProcessor> jarProcessors;
 	protected final ConfigurableFileCollection log4jConfigs;
 	protected final RegularFileProperty accessWidener;
-	protected final Property<String> customManifest;
 	protected final ManifestLocations versionsManifests;
+	protected final Property<String> customMetadata;
 	protected final SetProperty<String> knownIndyBsms;
 	protected final Property<Boolean> transitiveAccessWideners;
 	protected final Property<Boolean> modProvidedJavadoc;
@@ -117,10 +117,10 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 				.empty();
 		this.log4jConfigs = project.files(directories.getDefaultLog4jConfigFile());
 		this.accessWidener = project.getObjects().fileProperty();
-		this.customManifest = project.getObjects().property(String.class);
 		this.versionsManifests = new ManifestLocations("versions_manifest");
 		this.versionsManifests.addBuiltIn(-2, MirrorUtil.getVersionManifests(project), "versions_manifest");
 		this.versionsManifests.addBuiltIn(-1, MirrorUtil.getExperimentalVersions(project), "experimental_versions_manifest");
+		this.customMetadata = project.getObjects().property(String.class);
 		this.knownIndyBsms = project.getObjects().setProperty(String.class).convention(Set.of(
 				"java/lang/invoke/StringConcatFactory",
 				"java/lang/runtime/ObjectMethods",
@@ -260,13 +260,13 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	}
 
 	@Override
-	public Property<String> getCustomMinecraftManifest() {
-		return customManifest;
+	public ManifestLocations getVersionsManifests() {
+		return versionsManifests;
 	}
 
 	@Override
-	public ManifestLocations getVersionsManifests() {
-		return versionsManifests;
+	public Property<String> getCustomMinecraftMetadata() {
+		return customMetadata;
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -66,10 +66,12 @@ import net.fabricmc.loom.configuration.processors.JarProcessor;
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingSpec;
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingSpecBuilderImpl;
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsFactory;
+import net.fabricmc.loom.configuration.providers.minecraft.ManifestLocations;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftJarConfiguration;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftSourceSets;
 import net.fabricmc.loom.task.GenerateSourcesTask;
 import net.fabricmc.loom.util.DeprecationHelper;
+import net.fabricmc.loom.util.MirrorUtil;
 import net.fabricmc.loom.util.fmj.FabricModJson;
 import net.fabricmc.loom.util.fmj.FabricModJsonFactory;
 import net.fabricmc.loom.util.gradle.SourceSetHelper;
@@ -84,8 +86,8 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	protected final ConfigurableFileCollection log4jConfigs;
 	protected final RegularFileProperty accessWidener;
 	protected final Property<String> customManifest;
-	protected final Property<String> customVersionsManifest;
-	protected final Property<String> customExperimentalVersionsManifest;
+	protected final ManifestLocations versionsManifests;
+	protected final ManifestLocations experimentalVersionsManifests;
 	protected final SetProperty<String> knownIndyBsms;
 	protected final Property<Boolean> transitiveAccessWideners;
 	protected final Property<Boolean> modProvidedJavadoc;
@@ -117,8 +119,8 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 		this.log4jConfigs = project.files(directories.getDefaultLog4jConfigFile());
 		this.accessWidener = project.getObjects().fileProperty();
 		this.customManifest = project.getObjects().property(String.class);
-		this.customVersionsManifest = project.getObjects().property(String.class);
-		this.customExperimentalVersionsManifest = project.getObjects().property(String.class);
+		this.versionsManifests = new ManifestLocations(MirrorUtil.getVersionManifests(project), "versions_manifest");
+		this.experimentalVersionsManifests = new ManifestLocations(MirrorUtil.getExperimentalVersions(project), "experimental_versions_manifest");
 		this.knownIndyBsms = project.getObjects().setProperty(String.class).convention(Set.of(
 				"java/lang/invoke/StringConcatFactory",
 				"java/lang/runtime/ObjectMethods",
@@ -263,13 +265,13 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	}
 
 	@Override
-	public Property<String> getCustomVersionsManifest() {
-		return customVersionsManifest;
+	public ManifestLocations getVersionsManifests() {
+		return versionsManifests;
 	}
 
 	@Override
-	public Property<String> getCustomExperimentalVersionsManifest() {
-		return customExperimentalVersionsManifest;
+	public ManifestLocations getExperimentalVersionsManifests() {
+		return experimentalVersionsManifests;
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -119,8 +119,8 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 		this.accessWidener = project.getObjects().fileProperty();
 		this.customManifest = project.getObjects().property(String.class);
 		this.versionsManifests = new ManifestLocations("versions_manifest");
-		this.versionsManifests.addBuiltIn(0, MirrorUtil.getVersionManifests(project), "versions_manifest");
-		this.versionsManifests.addBuiltIn(1, MirrorUtil.getExperimentalVersions(project), "experimental_versions_manifest");
+		this.versionsManifests.addBuiltIn(-2, MirrorUtil.getVersionManifests(project), "versions_manifest");
+		this.versionsManifests.addBuiltIn(-1, MirrorUtil.getExperimentalVersions(project), "experimental_versions_manifest");
 		this.knownIndyBsms = project.getObjects().setProperty(String.class).convention(Set.of(
 				"java/lang/invoke/StringConcatFactory",
 				"java/lang/runtime/ObjectMethods",

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -87,7 +87,6 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	protected final RegularFileProperty accessWidener;
 	protected final Property<String> customManifest;
 	protected final ManifestLocations versionsManifests;
-	protected final ManifestLocations experimentalVersionsManifests;
 	protected final SetProperty<String> knownIndyBsms;
 	protected final Property<Boolean> transitiveAccessWideners;
 	protected final Property<Boolean> modProvidedJavadoc;
@@ -119,8 +118,9 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 		this.log4jConfigs = project.files(directories.getDefaultLog4jConfigFile());
 		this.accessWidener = project.getObjects().fileProperty();
 		this.customManifest = project.getObjects().property(String.class);
-		this.versionsManifests = new ManifestLocations(MirrorUtil.getVersionManifests(project), "versions_manifest");
-		this.experimentalVersionsManifests = new ManifestLocations(MirrorUtil.getExperimentalVersions(project), "experimental_versions_manifest");
+		this.versionsManifests = new ManifestLocations("versions_manifest");
+		this.versionsManifests.addBuiltIn(0, MirrorUtil.getVersionManifests(project), "versions_manifest");
+		this.versionsManifests.addBuiltIn(1, MirrorUtil.getExperimentalVersions(project), "experimental_versions_manifest");
 		this.knownIndyBsms = project.getObjects().setProperty(String.class).convention(Set.of(
 				"java/lang/invoke/StringConcatFactory",
 				"java/lang/runtime/ObjectMethods",
@@ -267,11 +267,6 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	@Override
 	public ManifestLocations getVersionsManifests() {
 		return versionsManifests;
-	}
-
-	@Override
-	public ManifestLocations getExperimentalVersionsManifests() {
-		return experimentalVersionsManifests;
 	}
 
 	@Override

--- a/src/test/groovy/net/fabricmc/loom/test/unit/providers/MinecraftMetadataProviderTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/providers/MinecraftMetadataProviderTest.groovy
@@ -29,6 +29,7 @@ import java.nio.file.Path
 
 import org.intellij.lang.annotations.Language
 
+import net.fabricmc.loom.configuration.providers.minecraft.ManifestLocations
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftMetadataProvider
 import net.fabricmc.loom.test.LoomTestConstants
 import net.fabricmc.loom.test.unit.download.DownloadTest
@@ -154,12 +155,11 @@ class MinecraftMetadataProviderTest extends DownloadTest {
 	private MinecraftMetadataProvider.Options options(String version, String customUrl) {
 		return new MinecraftMetadataProvider.Options(
 				version,
-				"$PATH/versionManifest",
-				"$PATH/experimentalVersionManifest",
+				new ManifestLocations("$PATH/versionManifest", "versions_manifest"),
+				new ManifestLocations("$PATH/experimentalVersionManifest", "experimental_versions_manifest"),
 				customUrl,
-				testDir.resolve("version_manifest.json"),
-				testDir.resolve("experimental_version_manifest.json"),
-				testDir.resolve("${version}.json")
+				testDir,
+				testDir
 				)
 	}
 

--- a/src/test/groovy/net/fabricmc/loom/test/unit/providers/MinecraftMetadataProviderTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/providers/MinecraftMetadataProviderTest.groovy
@@ -153,10 +153,13 @@ class MinecraftMetadataProviderTest extends DownloadTest {
 	}
 
 	private MinecraftMetadataProvider.Options options(String version, String customUrl) {
+		ManifestLocations manifests = new ManifestLocations("versions_manifest")
+		manifests.addBuiltIn(0, "$PATH/versionManifest", "versions_manifest")
+		manifests.addBuiltIn(1, "$PATH/experimentalVersionManifest", "experimental_versions_manifest")
+
 		return new MinecraftMetadataProvider.Options(
 				version,
-				new ManifestLocations("$PATH/versionManifest", "versions_manifest"),
-				new ManifestLocations("$PATH/experimentalVersionManifest", "experimental_versions_manifest"),
+				manifests,
 				customUrl,
 				testDir,
 				testDir


### PR DESCRIPTION
This PR serves to replace #1069 and resolve the issues discussed within it a different way.

- A new API is added where plugins can provide custom versions manifests. All versions manifests (including the built in ones) are sorted in a priority queue so mods can choose let their custom manifests act either as a fallback or to override the built in manifests.
- The manifest cache file name gets a hash suffix if a custom versions manifest URL is given through this new API. The hash is computed by calling `hashCode` on the manifest URL string and converting that to hex.
- The Minecraft metadata cache file name gets a hash suffix if a custom metadata URL is given (through the `customMinecraftManifest` property in the Loom extension API) or if the versions manifest is custom. The hash is computed by calling `hashCode` on the custom metadata URL string if it is present, or else by calling `hashCode` on the manifest URL string, and converting that to hex.