### PR TITLE
Update Loom native

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ mapping-io = "0.5.1"
 lorenz-tiny = "4.0.2"
 mercury = "0.4.1"
 kotlinx-metadata = "0.9.0"
-loom-native = "0.1.0"
+loom-native = "0.1.1"
 
 # Plugins
 spotless = "6.25.0"


### PR DESCRIPTION
This removes the Gradle module metadata, specifying that fabric-loom-native depends on Java 17, this was causing Gradle to bail out with its unhelpful outdated Java message. Loom has its own error message that is easier for users to understand.