### PR TITLE
Always remap changing deps

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactRef.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactRef.java
@@ -52,9 +52,11 @@ public interface ArtifactRef {
 
 	@Nullable String classifier();
 
+	boolean changing();
+
 	void applyToConfiguration(Project project, Configuration configuration);
 
-	record ResolvedArtifactRef(ResolvedArtifact artifact, @Nullable Path sources) implements ArtifactRef {
+	record ResolvedArtifactRef(ResolvedArtifact artifact, @Nullable Path sources, boolean changing) implements ArtifactRef {
 		@Override
 		public Path path() {
 			return artifact.getFile().toPath();
@@ -99,6 +101,11 @@ public interface ArtifactRef {
 		@Override
 		public @Nullable String classifier() {
 			return null;
+		}
+
+		@Override
+		public boolean changing() {
+			return false;
 		}
 
 		@Override

--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SimpleModDependency.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SimpleModDependency.java
@@ -48,7 +48,7 @@ public final class SimpleModDependency extends ModDependency {
 
 	@Override
 	public boolean isCacheInvalid(Project project, @Nullable String variant) {
-		return !maven.exists(variant);
+		return getInputArtifact().changing() || !maven.exists(variant);
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SplitModDependency.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SplitModDependency.java
@@ -59,6 +59,10 @@ public final class SplitModDependency extends ModDependency {
 
 	@Override
 	public boolean isCacheInvalid(Project project, @Nullable String variant) {
+		if (getInputArtifact().changing()) {
+			return true;
+		}
+
 		boolean exists = switch (target) {
 		case COMMON_ONLY -> getCommonMaven().exists(variant);
 		case CLIENT_ONLY -> getClientMaven().exists(variant);

--- a/src/test/resources/projects/localFileDependency/build.gradle
+++ b/src/test/resources/projects/localFileDependency/build.gradle
@@ -31,6 +31,11 @@ dependencies {
 	modImplementation fileTree("myFileTree") // an entire file tree
 	modImplementation name: "test-data-e" // a flatDir dependency
 
+	// Test changing
+	modImplementation("net.fabricmc:fabric-loom-native-support:1.0.0") {
+		changing = true
+	}
+
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.
 }


### PR DESCRIPTION
Is there a better way to know if a ResolvedArtifact is changing?

TODO:
- Check snapshots, specially specific versions
- Maybe check the file hash, so we dont always remap?