### PR TITLE
Use manifest name in cache file name instead of manifest URL hash

### DIFF
--- a/src/main/java/net/fabricmc/loom/api/manifest/VersionsManifestsAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/manifest/VersionsManifestsAPI.java
@@ -30,17 +30,21 @@ import org.jetbrains.annotations.ApiStatus;
 public interface VersionsManifestsAPI {
 	/**
 	 * Adds a URL to a versions manifest json with the default priority of {@code 0}.
+	 * @param name a string that uniquely identifies this versions manifest,
+	 *        to be used in cache file paths
 	 * @param url the String-representation of the URL to the manifest json
 	 */
-	default void add(String url) {
-		add(url, 0);
+	default void add(String name, String url) {
+		add(name, url, 0);
 	}
 
 	/**
 	 * Adds a URL to a versions manifest json with the given priority.
+	 * @param name a string that uniquely identifies this versions manifest,
+	 *             to be used in cache file paths
 	 * @param url the String-representation of the URL to the manifest json
 	 * @param priority the priority with which this URL gets sorted against other entries
 	 *        entries are sorted by priority, from lowest to highest
 	 */
-	void add(String url, int priority);
+	void add(String name, String url, int priority);
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
@@ -161,19 +161,13 @@ public final class MinecraftMetadataProvider {
 	}
 
 	private String getVersionMetaFileName() {
-		String base = "minecraft-info";
-
 		// custom version metadata
 		if (versionEntry.manifest == null) {
-			return base + Integer.toHexString(versionEntry.entry.url.hashCode()) + ".json";
+			return "minecraft_info_" + Integer.toHexString(versionEntry.entry.url.hashCode()) + ".json";
 		}
 
-		// custom versions manifest
-		if (!versionEntry.manifest.isBuiltIn()) {
-			return base + Integer.toHexString(versionEntry.manifest.url().hashCode()) + ".json";
-		}
-
-		return base + ".json";
+		// metadata url taken from versions manifest
+		return versionEntry.manifest.name() + "_minecraft_info.json";
 	}
 
 	public record Options(String minecraftVersion,

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -117,9 +117,9 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 				.empty();
 		this.log4jConfigs = project.files(directories.getDefaultLog4jConfigFile());
 		this.accessWidener = project.getObjects().fileProperty();
-		this.versionsManifests = new ManifestLocations("versions_manifest");
-		this.versionsManifests.addBuiltIn(-2, MirrorUtil.getVersionManifests(project), "versions_manifest");
-		this.versionsManifests.addBuiltIn(-1, MirrorUtil.getExperimentalVersions(project), "experimental_versions_manifest");
+		this.versionsManifests = new ManifestLocations();
+		this.versionsManifests.add("mojang", MirrorUtil.getVersionManifests(project), -2);
+		this.versionsManifests.add("fabric_experimental", MirrorUtil.getExperimentalVersions(project), -1);
 		this.customMetadata = project.getObjects().property(String.class);
 		this.knownIndyBsms = project.getObjects().setProperty(String.class).convention(Set.of(
 				"java/lang/invoke/StringConcatFactory",

--- a/src/test/groovy/net/fabricmc/loom/test/unit/providers/MinecraftMetadataProviderTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/providers/MinecraftMetadataProviderTest.groovy
@@ -153,9 +153,9 @@ class MinecraftMetadataProviderTest extends DownloadTest {
 	}
 
 	private MinecraftMetadataProvider.Options options(String version, String customUrl) {
-		ManifestLocations manifests = new ManifestLocations("versions_manifest")
-		manifests.addBuiltIn(0, "$PATH/versionManifest", "versions_manifest")
-		manifests.addBuiltIn(1, "$PATH/experimentalVersionManifest", "experimental_versions_manifest")
+		ManifestLocations manifests = new ManifestLocations()
+		manifests.add("test", "$PATH/versionManifest", 0)
+		manifests.add("test_experimental", "$PATH/experimentalVersionManifest", 1)
 
 		return new MinecraftMetadataProvider.Options(
 				version,


### PR DESCRIPTION
- Each manifest location now has a name, that must be unique. If multiple manifest locations are added with the same name, an exception is thrown.
- This name is used in the cache file names of the versions manifest and the version metadata. This will make the file names easier to read than the current solution, which is to add the manifest URL hash to the file name.