### PR TITLE
Fix crash in DownloadAssetsTask when there is no client run config.

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/DownloadAssetsTask.java
+++ b/src/main/java/net/fabricmc/loom/task/DownloadAssetsTask.java
@@ -27,7 +27,6 @@ package net.fabricmc.loom.task;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Objects;
 
 import javax.inject.Inject;
 
@@ -92,8 +91,9 @@ public abstract class DownloadAssetsTask extends AbstractLoomTask {
 			getLegacyResourcesDirectory().set(new File(assetsDir, "/legacy/" + versionInfo.id()));
 		} else {
 			// pre-1.6 resources
-			RunConfigSettings client = Objects.requireNonNull(getExtension().getRunConfigs().findByName("client"), "Could not find client run config");
-			getLegacyResourcesDirectory().set(new File(getProject().getProjectDir(), client.getRunDir() + "/resources"));
+			RunConfigSettings client = getExtension().getRunConfigs().findByName("client");
+			String runDir = client != null ? client.getRunDir() : "run";
+			getLegacyResourcesDirectory().set(new File(getProject().getProjectDir(), runDir + "/resources"));
 		}
 
 		getResourcesBaseUrl().set(MirrorUtil.getResourcesBase(getProject()));

--- a/src/test/groovy/net/fabricmc/loom/test/integration/RunConfigTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/RunConfigTest.groovy
@@ -115,7 +115,7 @@ class RunConfigTest extends Specification implements GradleProjectTestTrait {
                     mappings "net.fabricmc:yarn:1.18.1+build.18:v2"
                     modImplementation "net.fabricmc:fabric-loader:0.12.12"
                 }
-                
+
                 loom {
     				runs.clear()
 				}

--- a/src/test/groovy/net/fabricmc/loom/test/integration/RunConfigTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/RunConfigTest.groovy
@@ -102,4 +102,32 @@ class RunConfigTest extends Specification implements GradleProjectTestTrait {
 		where:
 		version << STANDARD_TEST_VERSIONS
 	}
+
+	// Test that the download assets task doesnt depend on a client run existing.
+	@Unroll
+	def "cleared runs (gradle #version)"() {
+		setup:
+		def gradle = gradleProject(project: "minimalBase", version: version)
+
+		gradle.buildGradle << '''
+                dependencies {
+                    minecraft "com.mojang:minecraft:1.18.1"
+                    mappings "net.fabricmc:yarn:1.18.1+build.18:v2"
+                    modImplementation "net.fabricmc:fabric-loader:0.12.12"
+                }
+                
+                loom {
+    				runs.clear()
+				}
+            '''
+
+		when:
+		def result = gradle.run(tasks: ["downloadAssets"])
+
+		then:
+		result.task(":downloadAssets").outcome == SUCCESS
+
+		where:
+		version << STANDARD_TEST_VERSIONS
+	}
 }


### PR DESCRIPTION
This code is only used for pre 1.6 resources, and had existing limitations.