### PR TITLE
Fix and test writing uncompressed entries to zip files.

### DIFF
--- a/src/main/java/net/fabricmc/loom/util/ZipReprocessorUtil.java
+++ b/src/main/java/net/fabricmc/loom/util/ZipReprocessorUtil.java
@@ -32,6 +32,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.Calendar;
 import java.util.Comparator;
 import java.util.GregorianCalendar;
+import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
@@ -122,7 +123,12 @@ public class ZipReprocessorUtil {
 					}
 
 					newEntry.setMethod(zipEntryCompressionMethod(zipEntryCompression));
-					copyZipEntry(zipOutputStream, newEntry, zipFile.getInputStream(entry));
+
+					if (zipEntryCompression == ZipEntryCompression.STORED) {
+						copyUncompressedZipEntry(zipOutputStream, newEntry, zipFile.getInputStream(entry));
+					} else {
+						copyZipEntry(zipOutputStream, newEntry, zipFile.getInputStream(entry));
+					}
 				}
 			}
 		}
@@ -173,6 +179,23 @@ public class ZipReprocessorUtil {
 			zipOutputStream.write(buf, 0, length);
 		}
 
+		zipOutputStream.closeEntry();
+	}
+
+	private static void copyUncompressedZipEntry(ZipOutputStream zipOutputStream, ZipEntry entry, InputStream inputStream) throws IOException {
+		// We need to read the entire input stream to calculate the CRC32 checksum and the size of the entry.
+		final byte[] data = inputStream.readAllBytes();
+
+		entry.setMethod(ZipEntry.STORED);
+		entry.setSize(data.length);
+		entry.setCompressedSize(data.length);
+
+		final CRC32 crc = new CRC32();
+		crc.update(data);
+		entry.setCrc(crc.getValue());
+
+		zipOutputStream.putNextEntry(entry);
+		zipOutputStream.write(data, 0, data.length);
 		zipOutputStream.closeEntry();
 	}
 

--- a/src/main/java/net/fabricmc/loom/util/ZipReprocessorUtil.java
+++ b/src/main/java/net/fabricmc/loom/util/ZipReprocessorUtil.java
@@ -186,13 +186,11 @@ public class ZipReprocessorUtil {
 		// We need to read the entire input stream to calculate the CRC32 checksum and the size of the entry.
 		final byte[] data = inputStream.readAllBytes();
 
-		entry.setMethod(ZipEntry.STORED);
-		entry.setSize(data.length);
-		entry.setCompressedSize(data.length);
-
-		final CRC32 crc = new CRC32();
+		var crc = new CRC32();
 		crc.update(data);
 		entry.setCrc(crc.getValue());
+		entry.setSize(data.length);
+		entry.setCompressedSize(data.length);
 
 		zipOutputStream.putNextEntry(entry);
 		zipOutputStream.write(data, 0, data.length);

--- a/src/test/groovy/net/fabricmc/loom/test/unit/ZipUtilsTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/ZipUtilsTest.groovy
@@ -29,6 +29,7 @@ import java.nio.file.Files
 import java.time.ZoneId
 
 import com.google.gson.JsonObject
+import org.gradle.api.tasks.bundling.ZipEntryCompression
 import spock.lang.Specification
 
 import net.fabricmc.loom.util.Checksum
@@ -239,5 +240,22 @@ class ZipUtilsTest extends Specification {
 		}
 		then:
 		thrown FileSystemUtil.UnrecoverableZipException
+	}
+
+	def "reprocess uncompressed"() {
+		given:
+		// Create a reproducible input zip
+		def dir = Files.createTempDirectory("loom-zip-test")
+		def zip = Files.createTempFile("loom-zip-test", ".zip")
+		def fileInside = dir.resolve("text.txt")
+		Files.writeString(fileInside, "hello world")
+		ZipUtils.pack(dir, zip)
+
+		when:
+		ZipReprocessorUtil.reprocessZip(zip, true, false, ZipEntryCompression.STORED)
+
+		then:
+		ZipUtils.unpack(zip, "text.txt") == "hello world".bytes
+		Checksum.sha1Hex(zip) == "e699fa52a520553241aac798f72255ac0a912b05"
 	}
 }


### PR DESCRIPTION
Closes #1138

Unfortunately I dont think there is a way to do this without copying the entire content into memory first, so any large files may cause memory pressure.