### PR TITLE
Only validate loom version when mixins are to be remapped with TinyRemapper

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactMetadata.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactMetadata.java
@@ -81,7 +81,7 @@ public record ArtifactMetadata(boolean isFabricMod, RemapRequirements remapRequi
 					}
 				}
 
-				if (loomVersion != null && refmapRemapType != MixinRemapType.STATIC) {
+				if (loomVersion != null && refmapRemapType == MixinRemapType.STATIC) {
 					validateLoomVersion(loomVersion, currentLoomVersion);
 				}
 

--- a/src/test/groovy/net/fabricmc/loom/test/unit/ArtifactMetadataTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/ArtifactMetadataTest.groovy
@@ -117,8 +117,8 @@ class ArtifactMetadataTest extends Specification {
 		MIXIN       | ["hello.json": "{}"]       // None Mod jar
 		MIXIN       | ["fabric.mod.json": "{}"]  // Fabric mod without manfiest file
 		MIXIN       | ["fabric.mod.json": "{}", "META-INF/MANIFEST.MF": manifest("Fabric-Loom-Remap", "true")]              // Fabric mod without remap type entry
-		MIXIN       | ["fabric.mod.json": "{}", "META-INF/MANIFEST.MF": manifest("Fabric-Loom-Mixin-Remap-Type", "mixin")] 	// Fabric mod with remap type entry "mixin"
-		STATIC      | ["fabric.mod.json": "{}", "META-INF/MANIFEST.MF": manifest("Fabric-Loom-Mixin-Remap-Type", "static")]	// Fabric mod with remap type entry "static"
+		MIXIN       | ["fabric.mod.json": "{}", "META-INF/MANIFEST.MF": manifest("Fabric-Loom-Mixin-Remap-Type", "mixin")]  // Fabric mod with remap type entry "mixin"
+		STATIC      | ["fabric.mod.json": "{}", "META-INF/MANIFEST.MF": manifest("Fabric-Loom-Mixin-Remap-Type", "static")] // Fabric mod with remap type entry "static"
 	}
 
 	// Test that a mod with the same or older version of loom can be read

--- a/src/test/groovy/net/fabricmc/loom/test/unit/ArtifactMetadataTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/ArtifactMetadataTest.groovy
@@ -124,7 +124,7 @@ class ArtifactMetadataTest extends Specification {
 	// Test that a mod with the same or older version of loom can be read
 	def "Valid loom version"() {
 		given:
-		def zip = createModWithRemapType(modLoomVersion, "mixin")
+		def zip = createModWithRemapType(modLoomVersion, "static")
 		when:
 		def metadata = createMetadata(zip, loomVersion)
 		then:

--- a/src/test/groovy/net/fabricmc/loom/test/unit/ArtifactMetadataTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/ArtifactMetadataTest.groovy
@@ -116,14 +116,15 @@ class ArtifactMetadataTest extends Specification {
 		type | entries
 		MIXIN       | ["hello.json": "{}"] 												// None Mod jar
 		MIXIN       | ["fabric.mod.json": "{}"] 										// Fabric mod without manfiest file
-		MIXIN       | ["fabric.mod.json": "{}", "META-INF/MANIFEST.MF": manifest("Fabric-Loom-Mixin-Remap-Type", "mixin")] 	// Fabric mod without remap type entry
-		STATIC  	| ["fabric.mod.json": "{}", "META-INF/MANIFEST.MF": manifest("Fabric-Loom-Mixin-Remap-Type", "static")]	// Fabric mod opt-in
+		MIXIN       | ["fabric.mod.json": "{}", "META-INF/MANIFEST.MF": manifest("Fabric-Loom-Remap", "true")]              // Fabric mod without remap type entry
+		MIXIN       | ["fabric.mod.json": "{}", "META-INF/MANIFEST.MF": manifest("Fabric-Loom-Mixin-Remap-Type", "mixin")] 	// Fabric mod with remap type entry "mixin"
+		STATIC  	| ["fabric.mod.json": "{}", "META-INF/MANIFEST.MF": manifest("Fabric-Loom-Mixin-Remap-Type", "static")]	// Fabric mod with remap type entry "static"
 	}
 
 	// Test that a mod with the same or older version of loom can be read
 	def "Valid loom version"() {
 		given:
-		def zip = createMod(modLoomVersion, "mixin")
+		def zip = createModWithRemapType(modLoomVersion, "mixin")
 		when:
 		def metadata = createMetadata(zip, loomVersion)
 		then:
@@ -144,7 +145,7 @@ class ArtifactMetadataTest extends Specification {
 	// Test that a mod with the same or older version of loom can be read
 	def "Invalid loom version"() {
 		given:
-		def zip = createMod(modLoomVersion, "mixin")
+		def zip = createModWithRemapType(modLoomVersion, "mixin")
 		when:
 		def metadata = createMetadata(zip, loomVersion)
 		then:
@@ -158,9 +159,35 @@ class ArtifactMetadataTest extends Specification {
 		"1.4"       | "2.4"
 	}
 
-	def "Accepts all Loom versions"() {
+	def "Accepts all Loom versions for remap 'false'"() {
 		given:
-		def zip = createMod(modLoomVersion, "static")
+		def zip = createModWithRemap(modLoomVersion, false)
+		when:
+		def metadata = createMetadata(zip, loomVersion)
+		then:
+		metadata != null
+		where:
+		loomVersion | modLoomVersion
+		// Valid
+		"1.4"       | "1.0.1"
+		"1.4"       | "1.0.99"
+		"1.4"       | "1.4"
+		"1.4"       | "1.4.0"
+		"1.4"       | "1.4.1"
+		"1.4"       | "1.4.99"
+		"1.4"       | "1.4.local"
+		"1.5"		| "1.4.99"
+		"2.0"		| "1.4.99"
+		// Usually invalid
+		"1.4"       | "1.5"
+		"1.4"       | "1.5.00"
+		"1.4"       | "2.0"
+		"1.4"       | "2.4"
+	}
+
+	def "Accepts all Loom versions for remap 'true'"() {
+		given:
+		def zip = createModWithRemap(modLoomVersion, true)
 		when:
 		def metadata = createMetadata(zip, loomVersion)
 		then:
@@ -201,8 +228,12 @@ class ArtifactMetadataTest extends Specification {
 		] | ["META-INF/MANIFEST.MF": manifest("Fabric-Loom-Known-Indy-BSMS", "com/example/Class,com/example/Another")] // two bsms
 	}
 
-	private static Path createMod(String loomVersion, String remapType) {
+	private static Path createModWithRemapType(String loomVersion, String remapType) {
 		return createZip(["fabric.mod.json": "{}", "META-INF/MANIFEST.MF": manifest(["Fabric-Loom-Version": loomVersion, "Fabric-Loom-Mixin-Remap-Type": remapType])])
+	}
+
+	private static Path createModWithRemap(String loomVersion, boolean remap) {
+		return createZip(["fabric.mod.json": "{}", "META-INF/MANIFEST.MF": manifest(["Fabric-Loom-Version": loomVersion, "Fabric-Loom-Mixin-Remap": remap ? "true" : "false"])])
 	}
 
 	private static ArtifactMetadata createMetadata(Path zip, String loomVersion = "1.4") {

--- a/src/test/groovy/net/fabricmc/loom/test/unit/ArtifactMetadataTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/ArtifactMetadataTest.groovy
@@ -114,11 +114,11 @@ class ArtifactMetadataTest extends Specification {
 		result == type
 		where:
 		type | entries
-		MIXIN       | ["hello.json": "{}"] 												// None Mod jar
-		MIXIN       | ["fabric.mod.json": "{}"] 										// Fabric mod without manfiest file
+		MIXIN       | ["hello.json": "{}"]       // None Mod jar
+		MIXIN       | ["fabric.mod.json": "{}"]  // Fabric mod without manfiest file
 		MIXIN       | ["fabric.mod.json": "{}", "META-INF/MANIFEST.MF": manifest("Fabric-Loom-Remap", "true")]              // Fabric mod without remap type entry
 		MIXIN       | ["fabric.mod.json": "{}", "META-INF/MANIFEST.MF": manifest("Fabric-Loom-Mixin-Remap-Type", "mixin")] 	// Fabric mod with remap type entry "mixin"
-		STATIC  	| ["fabric.mod.json": "{}", "META-INF/MANIFEST.MF": manifest("Fabric-Loom-Mixin-Remap-Type", "static")]	// Fabric mod with remap type entry "static"
+		STATIC      | ["fabric.mod.json": "{}", "META-INF/MANIFEST.MF": manifest("Fabric-Loom-Mixin-Remap-Type", "static")]	// Fabric mod with remap type entry "static"
 	}
 
 	// Test that a mod with the same or older version of loom can be read
@@ -138,8 +138,8 @@ class ArtifactMetadataTest extends Specification {
 		"1.4"       | "1.4.1"
 		"1.4"       | "1.4.99"
 		"1.4"       | "1.4.local"
-		"1.5"		| "1.4.99"
-		"2.0"		| "1.4.99"
+		"1.5"       | "1.4.99"
+		"2.0"       | "1.4.99"
 	}
 
 	// Test that a mod with the same or older version of loom can be read
@@ -176,8 +176,8 @@ class ArtifactMetadataTest extends Specification {
 		"1.4"       | "1.4.1"
 		"1.4"       | "1.4.99"
 		"1.4"       | "1.4.local"
-		"1.5"		| "1.4.99"
-		"2.0"		| "1.4.99"
+		"1.5"       | "1.4.99"
+		"2.0"       | "1.4.99"
 		// Usually invalid
 		"1.4"       | "1.5"
 		"1.4"       | "1.5.00"
@@ -202,8 +202,8 @@ class ArtifactMetadataTest extends Specification {
 		"1.4"       | "1.4.1"
 		"1.4"       | "1.4.99"
 		"1.4"       | "1.4.local"
-		"1.5"		| "1.4.99"
-		"2.0"		| "1.4.99"
+		"1.5"       | "1.4.99"
+		"2.0"       | "1.4.99"
 		// Usually invalid
 		"1.4"       | "1.5"
 		"1.4"       | "1.5.00"

--- a/src/test/groovy/net/fabricmc/loom/test/unit/ArtifactMetadataTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/ArtifactMetadataTest.groovy
@@ -145,7 +145,7 @@ class ArtifactMetadataTest extends Specification {
 	// Test that a mod with the same or older version of loom can be read
 	def "Invalid loom version"() {
 		given:
-		def zip = createModWithRemapType(modLoomVersion, "mixin")
+		def zip = createModWithRemapType(modLoomVersion, "static")
 		when:
 		def metadata = createMetadata(zip, loomVersion)
 		then:


### PR DESCRIPTION
I think there is an inversion in the logic introduced in https://github.com/FabricMC/fabric-loom/pull/980

The comments for `MixinRemapType.STATIC` say "Jar does not use refmaps, so will be remapped by tiny-remapper"
And the comments for `validateLoomVersion` say "This is only done for jars with tiny-remapper remapped mixins."

So I think the logic should be checking `== STATIC` instead of `!= STATIC`