### PR TITLE
Add a Gradle property to override the runtime java compat version.

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftLibraryProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftLibraryProvider.java
@@ -119,8 +119,21 @@ public class MinecraftLibraryProvider {
 	}
 
 	private List<Library> processLibraries(List<Library> libraries) {
-		final LibraryContext libraryContext = new LibraryContext(minecraftProvider.getVersionInfo(), JavaVersion.current());
+		final LibraryContext libraryContext = new LibraryContext(minecraftProvider.getVersionInfo(), getTargetRuntimeJavaVersion());
 		return processorManager.processLibraries(libraries, libraryContext);
+	}
+
+	private JavaVersion getTargetRuntimeJavaVersion() {
+		final Object property = project.findProperty(Constants.Properties.RUNTIME_JAVA_COMPATIBILITY_VERSION);
+
+		if (property != null) {
+			// This is very much a last ditch effort to allow users to set the runtime java version
+			// It's not recommended and will likely cause support confusion if it has been changed without good reason.
+			project.getLogger().warn("Runtime java compatibility version has manually been set to: %s".formatted(property));
+			return JavaVersion.toVersion(property);
+		}
+
+		return JavaVersion.current();
 	}
 
 	private void applyClientLibrary(Library library) {

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -134,6 +134,11 @@ public class Constants {
 		public static final String LIBRARY_PROCESSORS = "fabric.loom.libraryProcessors";
 		@ApiStatus.Experimental
 		public static final String SANDBOX = "fabric.loom.experimental.sandbox";
+		/**
+		 * When set the version of java that will be assumed that the game will run on, this defaults to the current java version.
+		 * Only set this when you have a good reason to do so, the default should be fine for almost all cases.
+		 */
+		public static final String RUNTIME_JAVA_COMPATIBILITY_VERSION = "fabric.loom.runtimeJavaCompatibilityVersion";
 	}
 
 	public static final class Manifest {


### PR DESCRIPTION
People keep asking for it, changing it will almost certainly cause issues later on hence the warning log level.