### PR TITLE
Fix `transformJson` mis-encoding.

### DIFF
--- a/src/main/java/net/fabricmc/loom/util/ZipUtils.java
+++ b/src/main/java/net/fabricmc/loom/util/ZipUtils.java
@@ -205,7 +205,7 @@ public class ZipUtils {
 	}
 
 	public static <T> int transformJson(Class<T> typeOfT, Path zip, Map<String, UnsafeUnaryOperator<T>> transforms) throws IOException {
-		return transformMapped(zip, transforms, bytes -> LoomGradlePlugin.GSON.fromJson(new InputStreamReader(new ByteArrayInputStream(bytes)), typeOfT),
+		return transformMapped(zip, transforms, bytes -> LoomGradlePlugin.GSON.fromJson(new InputStreamReader(new ByteArrayInputStream(bytes), StandardCharsets.UTF_8), typeOfT),
 				s -> LoomGradlePlugin.GSON.toJson(s, typeOfT).getBytes(StandardCharsets.UTF_8));
 	}
 


### PR DESCRIPTION
This is a mis-encoding bug, the InputStreamReader uses the system encoding by default.  
In most of Windows system installations, it was not UTF-8, for Chinese users, it may be GB18030.  
Reading and writing use different encodings, which will cause garbled when injecting access wideners, especially for CJK characters, etc. (Users may write any string in the `description` field and any of `authors` fields in `fabric.mod.json`.)  