### PR TITLE
Select jar configuration based on which sides are present

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -41,6 +41,7 @@ import net.fabricmc.loom.configuration.LoomDependencyManager;
 import net.fabricmc.loom.configuration.accesswidener.AccessWidenerFile;
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsFactory;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
+import net.fabricmc.loom.configuration.providers.minecraft.MinecraftMetadataProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.library.LibraryProcessorManager;
 import net.fabricmc.loom.configuration.providers.minecraft.mapped.IntermediaryMinecraftProvider;
@@ -67,6 +68,10 @@ public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 	void setDependencyManager(LoomDependencyManager dependencyManager);
 
 	LoomDependencyManager getDependencyManager();
+
+	MinecraftMetadataProvider getMetadataProvider();
+
+	void setMetadataProvider(MinecraftMetadataProvider metadataProvider);
 
 	MinecraftProvider getMinecraftProvider();
 

--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -157,8 +157,16 @@ public abstract class CompileConfiguration implements Runnable {
 
 		var jarConfiguration = extension.getMinecraftJarConfiguration().get();
 
-		if (jarConfiguration == MinecraftJarConfiguration.MERGED && !metadataProvider.getVersionMeta().isVersionOrNewer(Constants.RELEASE_TIME_1_3)) {
-			jarConfiguration = MinecraftJarConfiguration.LEGACY_MERGED;
+		if (jarConfiguration == MinecraftJarConfiguration.MERGED) {
+			// if no configuration is selected by the user, attempt to select one
+			// based on the mc version and which sides are present for it
+			if (!metadataProvider.getVersionMeta().downloads().containsKey("server")) {
+				jarConfiguration = MinecraftJarConfiguration.CLIENT_ONLY;
+			} else if (!metadataProvider.getVersionMeta().downloads().containsKey("client")) {
+				jarConfiguration = MinecraftJarConfiguration.SERVER_ONLY;
+			} else if (!metadataProvider.getVersionMeta().isVersionOrNewer(Constants.RELEASE_TIME_1_3)) {
+				jarConfiguration = MinecraftJarConfiguration.LEGACY_MERGED;
+			}
 		}
 
 		// Provide the vanilla mc jars

--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -60,7 +60,6 @@ import net.fabricmc.loom.configuration.processors.MinecraftJarProcessorManager;
 import net.fabricmc.loom.configuration.processors.ModJavadocProcessor;
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsFactory;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
-import net.fabricmc.loom.configuration.providers.minecraft.MinecraftJarConfiguration;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftMetadataProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftSourceSets;
@@ -69,7 +68,6 @@ import net.fabricmc.loom.configuration.providers.minecraft.mapped.IntermediaryMi
 import net.fabricmc.loom.configuration.providers.minecraft.mapped.NamedMinecraftProvider;
 import net.fabricmc.loom.extension.MixinExtension;
 import net.fabricmc.loom.util.Checksum;
-import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.ExceptionUtil;
 import net.fabricmc.loom.util.ProcessUtil;
 import net.fabricmc.loom.util.gradle.GradleUtils;
@@ -154,20 +152,9 @@ public abstract class CompileConfiguration implements Runnable {
 		final LoomGradleExtension extension = configContext.extension();
 
 		final MinecraftMetadataProvider metadataProvider = MinecraftMetadataProvider.create(configContext);
+		extension.setMetadataProvider(metadataProvider);
 
 		var jarConfiguration = extension.getMinecraftJarConfiguration().get();
-
-		if (jarConfiguration == MinecraftJarConfiguration.MERGED) {
-			// if no configuration is selected by the user, attempt to select one
-			// based on the mc version and which sides are present for it
-			if (!metadataProvider.getVersionMeta().downloads().containsKey("server")) {
-				jarConfiguration = MinecraftJarConfiguration.CLIENT_ONLY;
-			} else if (!metadataProvider.getVersionMeta().downloads().containsKey("client")) {
-				jarConfiguration = MinecraftJarConfiguration.SERVER_ONLY;
-			} else if (!metadataProvider.getVersionMeta().isVersionOrNewer(Constants.RELEASE_TIME_1_3)) {
-				jarConfiguration = MinecraftJarConfiguration.LEGACY_MERGED;
-			}
-		}
 
 		// Provide the vanilla mc jars
 		final MinecraftProvider minecraftProvider = jarConfiguration.createMinecraftProvider(metadataProvider, configContext);

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
@@ -50,6 +50,7 @@ import net.fabricmc.loom.configuration.providers.mappings.IntermediaryMappingsPr
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsFactory;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
 import net.fabricmc.loom.configuration.providers.mappings.NoOpIntermediateMappingsProvider;
+import net.fabricmc.loom.configuration.providers.minecraft.MinecraftMetadataProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.library.LibraryProcessorManager;
 import net.fabricmc.loom.configuration.providers.minecraft.mapped.IntermediaryMinecraftProvider;
@@ -66,6 +67,7 @@ public abstract class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl
 	private final List<AccessWidenerFile> transitiveAccessWideners = new ArrayList<>();
 
 	private LoomDependencyManager dependencyManager;
+	private MinecraftMetadataProvider metadataProvider;
 	private MinecraftProvider minecraftProvider;
 	private MappingConfiguration mappingConfiguration;
 	private NamedMinecraftProvider<?> namedMinecraftProvider;
@@ -128,6 +130,16 @@ public abstract class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl
 	@Override
 	public LoomDependencyManager getDependencyManager() {
 		return Objects.requireNonNull(dependencyManager, "Cannot get LoomDependencyManager before it has been setup");
+	}
+
+	@Override
+	public MinecraftMetadataProvider getMetadataProvider() {
+		return Objects.requireNonNull(metadataProvider, "Cannot get MinecraftMetadataProvider before it has been setup");
+	}
+
+	@Override
+	public void setMetadataProvider(MinecraftMetadataProvider metadataProvider) {
+		this.metadataProvider = metadataProvider;
 	}
 
 	@Override


### PR DESCRIPTION
If the user does not specifically set the client-only or server-only configuration, then automatically configure this for versions where only one side exists. This does not happen at all for new versions anymore, but is common for Minecraft versions prior to Release 1.3, and the norm for versions prior to Beta 1.0.