### PR TITLE
fix: make JarNester deterministic

### DIFF
--- a/src/main/java/net/fabricmc/loom/build/nesting/JarNester.java
+++ b/src/main/java/net/fabricmc/loom/build/nesting/JarNester.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -52,7 +53,7 @@ public class JarNester {
 		Preconditions.checkArgument(FabricModJsonFactory.isModJar(modJar), "Cannot nest jars into none mod jar " + modJar.getName());
 
 		// Ensure deterministic ordering of entries in fabric.mod.json
-		Collection<File> sortedJars = jars.stream().sorted().toList();
+		Collection<File> sortedJars = jars.stream().sorted(Comparator.comparing(File::getName)).toList();
 
 		try {
 			ZipUtils.add(modJar.toPath(), sortedJars.stream().map(file -> {

--- a/src/main/java/net/fabricmc/loom/build/nesting/JarNester.java
+++ b/src/main/java/net/fabricmc/loom/build/nesting/JarNester.java
@@ -51,8 +51,11 @@ public class JarNester {
 
 		Preconditions.checkArgument(FabricModJsonFactory.isModJar(modJar), "Cannot nest jars into none mod jar " + modJar.getName());
 
+		// Ensure deterministic ordering of entries in fabric.mod.json
+		Collection<File> sortedJars = jars.stream().sorted().toList();
+
 		try {
-			ZipUtils.add(modJar.toPath(), jars.stream().map(file -> {
+			ZipUtils.add(modJar.toPath(), sortedJars.stream().map(file -> {
 				try {
 					return new Pair<>("META-INF/jars/" + file.getName(), Files.readAllBytes(file.toPath()));
 				} catch (IOException e) {
@@ -67,7 +70,7 @@ public class JarNester {
 					nestedJars = new JsonArray();
 				}
 
-				for (File file : jars) {
+				for (File file : sortedJars) {
 					String nestedJarPath = "META-INF/jars/" + file.getName();
 					Preconditions.checkArgument(FabricModJsonFactory.isModJar(file), "Cannot nest none mod jar: " + file.getName());
 


### PR DESCRIPTION
Sorts the list of jars to nest before adding them to fabric.mod.json to ensure the ordering is deterministic.