### PR TITLE
fix: ignore some very very old kotlin classes to prevent them breaking remapping process

### DIFF
--- a/src/main/kotlin/net/fabricmc/loom/kotlin/remapping/KotlinClassMetadataRemappingAnnotationVisitor.kt
+++ b/src/main/kotlin/net/fabricmc/loom/kotlin/remapping/KotlinClassMetadataRemappingAnnotationVisitor.kt
@@ -62,8 +62,13 @@ class KotlinClassMetadataRemappingAnnotationVisitor(
                     "is using (${KotlinVersion.CURRENT}).",
             )
         }
+        val metadata = KotlinClassMetadata.readLenient(header)
+        if (metadata.version.major < 1 || (metadata.version.major == 1 && metadata.version.minor < 4)) {
+            logger.warn("$className is not supported by kotlin metadata remapping (version: ${metadata.version})")
+            return
+        }
 
-        when (val metadata = KotlinClassMetadata.readLenient(header)) {
+        when (metadata) {
             is KotlinClassMetadata.Class -> {
                 var klass = metadata.kmClass
                 klass = KotlinClassRemapper(remapper).remap(klass)

--- a/src/main/kotlin/net/fabricmc/loom/kotlin/remapping/KotlinClassMetadataRemappingAnnotationVisitor.kt
+++ b/src/main/kotlin/net/fabricmc/loom/kotlin/remapping/KotlinClassMetadataRemappingAnnotationVisitor.kt
@@ -65,6 +65,7 @@ class KotlinClassMetadataRemappingAnnotationVisitor(
         val metadata = KotlinClassMetadata.readLenient(header)
         if (metadata.version.major < 1 || (metadata.version.major == 1 && metadata.version.minor < 4)) {
             logger.warn("$className is not supported by kotlin metadata remapping (version: ${metadata.version})")
+            accept(next)
             return
         }
 


### PR DESCRIPTION
The current kotlin toolchain does not support pre-1.4 compiled classes, so I ignored them.

https://github.com/JetBrains/kotlin/blob/7c539b01f522d7ad458a3c774879277eccf03ffd/libraries/kotlinx-metadata/jvm/src/kotlin/metadata/jvm/KotlinClassMetadata.kt#L427