### PR TITLE
Stop the JVM from printing a ClosedChannelException stacktrace for each entry in a zip

### DIFF
--- a/src/main/java/net/fabricmc/loom/util/FileSystemUtil.java
+++ b/src/main/java/net/fabricmc/loom/util/FileSystemUtil.java
@@ -72,6 +72,16 @@ public final class FileSystemUtil {
 
 		@Override
 		public void close() throws IOException {
+			// JDK-8316882, a separate JDK bug where a zip FS cannot be closed on an interrupted thread
+			// Doing so will fail, after a stack trace is printed for each entry of the zip
+			// TODO is there a better way to know if the underlying file channel is closed?
+			if (Thread.currentThread().isInterrupted()) {
+				// We leak here as we never actually free the zip FS, but this is the best we can do
+				// Lets assume the JVM effectively fucked here, so throw a UnrecoverableZipException forcing it to exit
+				// When a build is canceled a new Gradle daemon will be started, so this is not a big deal
+				throw new UnrecoverableZipException("Cannot close zip FS on interrupted thread", new InterruptedException());
+			}
+
 			try {
 				reference.close();
 			} catch (IOException e) {

--- a/src/main/java/net/fabricmc/loom/util/gradle/daemon/DaemonUtils.java
+++ b/src/main/java/net/fabricmc/loom/util/gradle/daemon/DaemonUtils.java
@@ -73,6 +73,11 @@ public final class DaemonUtils {
 
 	@VisibleForTesting
 	public static boolean stopWhenIdle(Project project) {
+		// Clear the interrupted flag if set.
+		if (Thread.currentThread().isInterrupted()) {
+			assert Thread.interrupted();
+		}
+
 		DaemonInfo daemonInfo = findCurrentDaemon(project);
 
 		if (daemonInfo == null) {

--- a/src/main/java/net/fabricmc/loom/util/gradle/daemon/DaemonUtils.java
+++ b/src/main/java/net/fabricmc/loom/util/gradle/daemon/DaemonUtils.java
@@ -74,9 +74,7 @@ public final class DaemonUtils {
 	@VisibleForTesting
 	public static boolean stopWhenIdle(Project project) {
 		// Clear the interrupted flag if set.
-		if (Thread.currentThread().isInterrupted()) {
-			assert Thread.interrupted();
-		}
+		Thread.interrupted();
 
 		DaemonInfo daemonInfo = findCurrentDaemon(project);
 

--- a/src/test/groovy/net/fabricmc/loom/test/unit/ClosedZipFSReproducer.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/ClosedZipFSReproducer.groovy
@@ -24,6 +24,7 @@
 
 package net.fabricmc.loom.test.unit
 
+import java.nio.channels.ClosedChannelException
 import java.nio.file.FileSystem
 import java.nio.file.FileSystemAlreadyExistsException
 import java.nio.file.FileSystemException
@@ -34,7 +35,7 @@ import java.nio.file.Path
 
 import spock.lang.Specification
 
-// Test to prove https://bugs.openjdk.org/browse/JDK-8291712
+// Test to prove https://bugs.openjdk.org/browse/JDK-8291712 and https://bugs.openjdk.org/browse/JDK-8316882
 // If this test starts failing on a new JDK, it is likely that the bug has been fixed!
 class ClosedZipFSReproducer extends Specification {
 	def "JDK-8291712"() {
@@ -68,6 +69,33 @@ class ClosedZipFSReproducer extends Specification {
 
 		then:
 		!fs.isOpen()
+	}
+
+	def "JDK-8316882"() {
+		when:
+		Path tempDir = Files.createTempDirectory("test")
+		Path zipFile = tempDir.resolve("example.zip")
+
+		// Create a new ZipFileSystem, and write a file to it
+		openZipFS(zipFile, true).withCloseable {
+			Files.writeString(it.getPath("test.txt"), "Hello, World!")
+		}
+
+		// Open the existing ZipFileSystem, interrupt the thread before reading the file
+		def fs = openZipFS(zipFile, false)
+
+		Thread.currentThread().interrupt()
+		Files.readString(fs.getPath("test.txt"))
+
+		// Close then unexpectedly throws ClosedChannelException
+		fs.close()
+
+		then:
+		thrown(ClosedChannelException)
+
+		// Reset the interrupt status
+		Thread.interrupted()
+		!Thread.currentThread().isInterrupted()
 	}
 
 	private static FileSystem openZipFS(Path path, boolean create) throws IOException {

--- a/src/test/groovy/net/fabricmc/loom/test/unit/ZipUtilsTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/ZipUtilsTest.groovy
@@ -242,6 +242,39 @@ class ZipUtilsTest extends Specification {
 		thrown FileSystemUtil.UnrecoverableZipException
 	}
 
+	// Also see: ClosedZipFSReproducer
+	def "interrupted thread"() {
+		given:
+		def dir = File.createTempDir()
+		def zip = File.createTempFile("loom-zip-test", ".zip").toPath()
+		new File(dir, "test.json").text = """
+		{
+			"test": "This is a test of transforming"
+		}
+		"""
+		ZipUtils.pack(dir.toPath(), zip)
+
+		when:
+
+		ZipUtils.transformJson(JsonObject.class, zip, "test.json") { json ->
+			Thread.currentThread().interrupt()
+
+			json
+		}
+
+		then:
+		thrown FileSystemUtil.UnrecoverableZipException
+
+		// Reset the interrupt status
+		Thread.currentThread().isInterrupted()
+		Thread.interrupted()
+		!Thread.currentThread().isInterrupted()
+
+		cleanup:
+		// Cleanup after the mess we made.
+		FileSystemUtil.getJarFileSystem(zip, false).close()
+	}
+
 	def "reprocess uncompressed"() {
 		given:
 		// Create a reproducible input zip


### PR DESCRIPTION
Works around https://bugs.openjdk.org/browse/JDK-8316882

Fixes https://github.com/FabricMC/fabric-loom/issues/1212

See: https://github.com/openjdk/jdk/blob/master/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java#L2028

If anyone has any ideas on how to better tell if the file channel used within zip fs is closed or not let me know.