### PR TITLE
Make ExceptionUtil & DaemonUtils config cache safe.

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -72,6 +72,7 @@ import net.fabricmc.loom.util.ExceptionUtil;
 import net.fabricmc.loom.util.ProcessUtil;
 import net.fabricmc.loom.util.gradle.GradleUtils;
 import net.fabricmc.loom.util.gradle.SourceSetHelper;
+import net.fabricmc.loom.util.gradle.daemon.DaemonUtils;
 import net.fabricmc.loom.util.service.ScopedServiceFactory;
 import net.fabricmc.loom.util.service.ServiceFactory;
 
@@ -112,7 +113,7 @@ public abstract class CompileConfiguration implements Runnable {
 				extension.setDependencyManager(dependencyManager);
 				dependencyManager.handleDependencies(getProject(), serviceFactory);
 			} catch (Exception e) {
-				ExceptionUtil.processException(e, getProject());
+				ExceptionUtil.processException(e, DaemonUtils.Context.fromProject(getProject()));
 				disownLock();
 				throw ExceptionUtil.createDescriptiveWrapper(RuntimeException::new, "Failed to setup Minecraft", e);
 			}

--- a/src/main/java/net/fabricmc/loom/util/ExceptionUtil.java
+++ b/src/main/java/net/fabricmc/loom/util/ExceptionUtil.java
@@ -31,7 +31,6 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.function.BiFunction;
 
-import org.gradle.api.Project;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +59,7 @@ public final class ExceptionUtil {
 		return constructor.apply(descriptiveMessage, cause);
 	}
 
-	public static void processException(Throwable e, Project project) {
+	public static void processException(Throwable e, DaemonUtils.Context context) {
 		Throwable cause = e;
 		boolean unrecoverable = false;
 
@@ -68,7 +67,7 @@ public final class ExceptionUtil {
 			if (cause instanceof FileSystemUtil.UnrecoverableZipException) {
 				unrecoverable = true;
 			} else if (cause instanceof FileSystemException fse) {
-				printFileLocks(fse.getFile(), project);
+				printFileLocks(fse.getFile());
 				break;
 			}
 
@@ -76,11 +75,11 @@ public final class ExceptionUtil {
 		}
 
 		if (unrecoverable) {
-			DaemonUtils.tryStopGradleDaemon(project);
+			DaemonUtils.tryStopGradleDaemon(context);
 		}
 	}
 
-	private static void printFileLocks(String filename, Project project) {
+	private static void printFileLocks(String filename) {
 		final Path path = Paths.get(filename);
 
 		if (!Files.exists(path)) {
@@ -100,13 +99,13 @@ public final class ExceptionUtil {
 			return;
 		}
 
-		final ProcessUtil processUtil = ProcessUtil.create(project);
+		final ProcessUtil processUtil = ProcessUtil.create(LOGGER.isInfoEnabled() ? ProcessUtil.ArgumentVisibility.SHOW_SENSITIVE : ProcessUtil.ArgumentVisibility.HIDE);
 
 		final String noun = processes.size() == 1 ? "process has" : "processes have";
-		project.getLogger().error("The following {} a lock on the file '{}':", noun, path);
+		LOGGER.error("The following {} a lock on the file '{}':", noun, path);
 
 		for (ProcessHandle process : processes) {
-			project.getLogger().error(processUtil.printWithParents(process));
+			LOGGER.error(processUtil.printWithParents(process));
 		}
 	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/integration/buildSrc/stopDaemon/TestPlugin.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/buildSrc/stopDaemon/TestPlugin.groovy
@@ -85,7 +85,7 @@ class TestPlugin implements Plugin<Project> {
 		def future = handler.daemonConnection.thenAccept { it.waitForAndProcessStop() }
 
 		// Stop the daemon
-		def result = DaemonUtils.stopWhenIdle(project)
+		def result = DaemonUtils.stopWhenIdle(DaemonUtils.Context.fromProject(project))
 
 		// Wait for the connection to be processed, this should have already happened, as the above call is blocking
 		future.join()

--- a/src/test/groovy/net/fabricmc/loom/test/unit/ProcessUtilTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/ProcessUtilTest.groovy
@@ -24,15 +24,13 @@
 
 package net.fabricmc.loom.test.unit
 
-import org.gradle.api.logging.LogLevel
-import spock.lang.Specification
-
 import net.fabricmc.loom.util.ProcessUtil
+import spock.lang.Specification
 
 class ProcessUtilTest extends Specification {
 	def "print process info"() {
 		when:
-		def output = new ProcessUtil(LogLevel.DEBUG).printWithParents(ProcessHandle.current())
+		def output = new ProcessUtil(ProcessUtil.ArgumentVisibility.SHOW_SENSITIVE).printWithParents(ProcessHandle.current())
 
 		then:
 		// Just a simple check to see if the output is not empty

--- a/src/test/groovy/net/fabricmc/loom/test/unit/ProcessUtilTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/ProcessUtilTest.groovy
@@ -24,8 +24,9 @@
 
 package net.fabricmc.loom.test.unit
 
-import net.fabricmc.loom.util.ProcessUtil
 import spock.lang.Specification
+
+import net.fabricmc.loom.util.ProcessUtil
 
 class ProcessUtilTest extends Specification {
 	def "print process info"() {


### PR DESCRIPTION
This only effected the fatal zip error cases so is not caught by the tests.