### PR TITLE
Fix lazily provided layered mappings causing crash

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -166,10 +166,10 @@ public abstract class CompileConfiguration implements Runnable {
 		extension.setMinecraftProvider(minecraftProvider);
 		minecraftProvider.provide();
 
-		// Created any layered mapping files.
+		final DependencyInfo mappingsDep = DependencyInfo.create(getProject(), Configurations.MAPPINGS);
+		// Created any layered mapping files. (After resolving the mappings dependency)
 		LayeredMappingsFactory.afterEvaluate(configContext);
 
-		final DependencyInfo mappingsDep = DependencyInfo.create(getProject(), Configurations.MAPPINGS);
 		final MappingConfiguration mappingConfiguration = MappingConfiguration.create(getProject(), configContext.serviceFactory(), mappingsDep, minecraftProvider);
 		extension.setMappingConfiguration(mappingConfiguration);
 		mappingConfiguration.applyToProject(getProject(), mappingsDep);

--- a/src/test/groovy/net/fabricmc/loom/test/integration/LazyLayeredMappingsTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/LazyLayeredMappingsTest.groovy
@@ -33,18 +33,18 @@ import static net.fabricmc.loom.test.LoomTestConstants.STANDARD_TEST_VERSIONS
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 class LazyLayeredMappingsTest extends Specification implements GradleProjectTestTrait {
-    @Unroll
-    def "Ensure mappings configuration is lazy when using layered #version"() {
-        setup:
-        def gradle = gradleProject(project: "lazyLayeredMappings", version: version)
+	@Unroll
+	def "Ensure mappings configuration is lazy when using layered #version"() {
+		setup:
+		def gradle = gradleProject(project: "lazyLayeredMappings", version: version)
 
-        when:
-        def result = gradle.run(task: "build")
+		when:
+		def result = gradle.run(task: "build")
 
-        then:
-        result.task(":build").outcome == SUCCESS
+		then:
+		result.task(":build").outcome == SUCCESS
 
-        where:
-        version << STANDARD_TEST_VERSIONS
-    }
+		where:
+		version << STANDARD_TEST_VERSIONS
+	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/integration/LazyLayeredMappingsTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/LazyLayeredMappingsTest.groovy
@@ -1,0 +1,50 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2018-2021 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.integration
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import net.fabricmc.loom.test.util.GradleProjectTestTrait
+
+import static net.fabricmc.loom.test.LoomTestConstants.STANDARD_TEST_VERSIONS
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class LazyLayeredMappingsTest extends Specification implements GradleProjectTestTrait {
+    @Unroll
+    def "Ensure mappings configuration is lazy when using layered #version"() {
+        setup:
+        def gradle = gradleProject(project: "lazyLayeredMappings", version: version)
+
+        when:
+        def result = gradle.run(task: "build")
+
+        then:
+        result.task(":build").outcome == SUCCESS
+
+        where:
+        version << STANDARD_TEST_VERSIONS
+    }
+}

--- a/src/test/resources/projects/lazyLayeredMappings/build.gradle
+++ b/src/test/resources/projects/lazyLayeredMappings/build.gradle
@@ -1,0 +1,14 @@
+plugins {
+	id 'fabric-loom'
+}
+
+dependencies {
+	minecraft libs.minecraft
+	mappings project.provider {
+		loom.layered() {
+			officialMojangMappings()
+		}
+	}
+
+	modImplementation libs.fabricLoader
+}

--- a/src/test/resources/projects/lazyLayeredMappings/gradle/libs.versions.toml
+++ b/src/test/resources/projects/lazyLayeredMappings/gradle/libs.versions.toml
@@ -1,0 +1,7 @@
+[versions]
+minecraft = "1.16.5"
+fabricLoader = "0.11.3"
+
+[libraries]
+minecraft = { module = "com.mojang:minecraft", version.ref = "minecraft" }
+fabricLoader = { module = "net.fabricmc:fabric-loader", version.ref = "fabricLoader" }


### PR DESCRIPTION
## Problem

```groovy
mappings project.provider {
	loom.layered() {
		officialMojangMappings()
	}
}
```

The above is the configuration that caused the following crash.
```
> Failed to setup Minecraft, java.lang.IllegalStateException: Layered mappings have already been evaluated
```

## Why is this behaviour wanted?

This allows people to use providers to define the mappings used by a project, for example, a gradle plugin that wraps Loom might define parchment via a extension property.

```groovy
mappings myExtension.parchmentArtifact.orElse("").map { parchmentArtifact ->
	loom.layered() {
		officialMojangMappings()

		if (!parchmentArtifact.isEmpty()) {
			parchment(parchmentArtifact)
		}
	}
}
```
*excuse the possible invalid groovy syntax, I am used to Kotlin DSL*

## Code analysis
During `setupMinecraft` in `CompileConfiguration`:
```java
// 1
LayeredMappingsFactory.afterEvaluate(configContext);

// 2
final DependencyInfo mappingsDep = DependencyInfo.create(getProject(), Configurations.MAPPINGS);

// 3
final MappingConfiguration mappingConfiguration = MappingConfiguration.create(getProject(), configContext.serviceFactory(), mappingsDep, minecraftProvider);
```
1. LayeredMappings are finalised - `afterEvaluate` method prevents any further configuration being made to the layered spec via `loom.layered() {}`.
2. The dependency for mappings is fetched, this is where the provider is called upon and `loom.layered()` in the buildscript is now evaluated.
3. Loom then applies the mapping that was fetched in step 2

Can you see the problem?

### How did this work before?

Previously, Loom relied on the fact that the buildscript itself is evaluated before `setupMinecraft`. Which meant that if a `loom.layered() {}` was called, it would happen before it was finalised.

Using a provider exposed the problem: the layered spec is finalised before actually *retrieving* the dependency for mappings. The layered spec would finalise and THEN the provider would trigger, trying to call `loom.layered() {}` .

### The fix

The fix is simple, finalise the layered mappings factory AFTER retrieving the dependency. Just swap lines 1 and 2.

```java
// 2
final DependencyInfo mappingsDep = DependencyInfo.create(getProject(), Configurations.MAPPINGS);

// 1
LayeredMappingsFactory.afterEvaluate(configContext);

// 3
final MappingConfiguration mappingConfiguration = MappingConfiguration.create(getProject(), configContext.serviceFactory(), mappingsDep, minecraftProvider);
```

An integration test has been added to test for this.