### PR TITLE
create backup jars for legacy merged mapped minecraft providers

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/AbstractMappedMinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/AbstractMappedMinecraftProvider.java
@@ -85,7 +85,7 @@ public abstract class AbstractMappedMinecraftProvider<M extends MinecraftProvide
 			throw new IllegalStateException("No remapped jars provided");
 		}
 
-		if (!areOutputsValid(remappedJars) || context.refreshOutputs() || !hasBackupJars(minecraftJars)) {
+		if (shouldRemapInputs(context, remappedJars, minecraftJars)) {
 			try {
 				remapInputs(remappedJars, context.configContext());
 				createBackupJars(minecraftJars);
@@ -191,6 +191,23 @@ public abstract class AbstractMappedMinecraftProvider<M extends MinecraftProvide
 
 	protected String getDependencyNotation(MinecraftJar.Type type) {
 		return "net.minecraft:%s:%s".formatted(getName(type), getVersion());
+	}
+
+	protected boolean shouldRemapInputs(ProvideContext context) {
+		final List<RemappedJars> remappedJars = getRemappedJars();
+		final List<MinecraftJar> minecraftJars = remappedJars.stream()
+				.map(RemappedJars::outputJar)
+				.toList();
+
+		if (remappedJars.isEmpty()) {
+			throw new IllegalStateException("No remapped jars provided");
+		}
+
+		return shouldRemapInputs(context, remappedJars, minecraftJars);
+	}
+
+	private boolean shouldRemapInputs(ProvideContext context, List<RemappedJars> remappedJars, List<MinecraftJar> minecraftJars) {
+		return !areOutputsValid(remappedJars) || context.refreshOutputs() || !hasBackupJars(minecraftJars);
 	}
 
 	private boolean areOutputsValid(List<RemappedJars> remappedJars) {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/IntermediaryMinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/IntermediaryMinecraftProvider.java
@@ -82,22 +82,22 @@ public abstract sealed class IntermediaryMinecraftProvider<M extends MinecraftPr
 
 			// this check must be done before the client and server impls are provided
 			// because the merging only needs to happen if the remapping step is run
-			final boolean mergeJars = client.shouldRemapInputs(context) || server.shouldRemapInputs(context);
+			final boolean refreshOutputs = client.shouldRefreshOutputs(context)
+					|| server.shouldRefreshOutputs(context)
+					|| this.shouldRefreshOutputs(context);
 
 			// Map the client and server jars separately
 			server.provide(context);
 			client.provide(context);
 
-			if (mergeJars) {
+			if (refreshOutputs) {
 				// then merge them
 				MergedMinecraftProvider.mergeJars(
 							client.getEnvOnlyJar().toFile(),
 							server.getEnvOnlyJar().toFile(),
 							getMergedJar().toFile()
 				);
-			}
 
-			if (mergeJars || !hasBackupJars(minecraftJars)) {
 				createBackupJars(minecraftJars);
 			}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/IntermediaryMinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/IntermediaryMinecraftProvider.java
@@ -111,6 +111,13 @@ public abstract sealed class IntermediaryMinecraftProvider<M extends MinecraftPr
 		}
 
 		@Override
+		public List<? extends OutputJar> getOutputJars() {
+			return List.of(
+				new SimpleOutputJar(getMergedJar())
+			);
+		}
+
+		@Override
 		public List<MinecraftJar.Type> getDependencyTypes() {
 			return List.of(MinecraftJar.Type.MERGED);
 		}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/IntermediaryMinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/IntermediaryMinecraftProvider.java
@@ -78,6 +78,8 @@ public abstract sealed class IntermediaryMinecraftProvider<M extends MinecraftPr
 
 		@Override
 		public List<MinecraftJar> provide(ProvideContext context) throws Exception {
+			final List<MinecraftJar> minecraftJars = List.of(getMergedJar());
+
 			// Map the client and server jars separately
 			server.provide(context);
 			client.provide(context);
@@ -89,7 +91,11 @@ public abstract sealed class IntermediaryMinecraftProvider<M extends MinecraftPr
 						getMergedJar().toFile()
 			);
 
-			return List.of(getMergedJar());
+			if (!hasBackupJars(minecraftJars)) {
+				createBackupJars(minecraftJars);
+			}
+
+			return minecraftJars;
 		}
 
 		@Override

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/NamedMinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/NamedMinecraftProvider.java
@@ -127,6 +127,13 @@ public abstract class NamedMinecraftProvider<M extends MinecraftProvider> extend
 		}
 
 		@Override
+		public List<? extends OutputJar> getOutputJars() {
+			return List.of(
+				new SimpleOutputJar(getMergedJar())
+			);
+		}
+
+		@Override
 		public List<MinecraftJar.Type> getDependencyTypes() {
 			return List.of(MinecraftJar.Type.MERGED);
 		}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/NamedMinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/NamedMinecraftProvider.java
@@ -89,22 +89,22 @@ public abstract class NamedMinecraftProvider<M extends MinecraftProvider> extend
 
 			// this check must be done before the client and server impls are provided
 			// because the merging only needs to happen if the remapping step is run
-			final boolean mergeJars = client.shouldRemapInputs(childContext) || server.shouldRemapInputs(childContext);
+			final boolean refreshOutputs = client.shouldRefreshOutputs(childContext)
+					|| server.shouldRefreshOutputs(childContext)
+					|| this.shouldRefreshOutputs(childContext);
 
 			// Map the client and server jars separately
 			server.provide(childContext);
 			client.provide(childContext);
 
-			if (mergeJars) {
+			if (refreshOutputs) {
 				// then merge them
 				MergedMinecraftProvider.mergeJars(
 							client.getEnvOnlyJar().toFile(),
 							server.getEnvOnlyJar().toFile(),
 							getMergedJar().toFile()
 				);
-			}
 
-			if (mergeJars || !hasBackupJars(minecraftJars)) {
 				createBackupJars(minecraftJars);
 			}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/NamedMinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/NamedMinecraftProvider.java
@@ -85,6 +85,7 @@ public abstract class NamedMinecraftProvider<M extends MinecraftProvider> extend
 		@Override
 		public List<MinecraftJar> provide(ProvideContext context) throws Exception {
 			final ProvideContext childContext = context.withApplyDependencies(false);
+			final List<MinecraftJar> minecraftJars = List.of(getMergedJar());
 
 			// Map the client and server jars separately
 			server.provide(childContext);
@@ -97,6 +98,10 @@ public abstract class NamedMinecraftProvider<M extends MinecraftProvider> extend
 						getMergedJar().toFile()
 			);
 
+			if (!hasBackupJars(minecraftJars)) {
+				createBackupJars(minecraftJars);
+			}
+
 			getMavenHelper(MinecraftJar.Type.MERGED).savePom();
 
 			if (context.applyDependencies()) {
@@ -106,7 +111,7 @@ public abstract class NamedMinecraftProvider<M extends MinecraftProvider> extend
 				);
 			}
 
-			return List.of(getMergedJar());
+			return minecraftJars;
 		}
 
 		@Override

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/ProcessedNamedMinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/ProcessedNamedMinecraftProvider.java
@@ -82,6 +82,14 @@ public abstract class ProcessedNamedMinecraftProvider<M extends MinecraftProvide
 	}
 
 	@Override
+	public List<? extends OutputJar> getOutputJars() {
+		return parentMinecraftProvider.getMinecraftJars().stream()
+				.map(this::getProcessedJar)
+				.map(SimpleOutputJar::new)
+				.toList();
+	}
+
+	@Override
 	public MavenScope getMavenScope() {
 		return MavenScope.LOCAL;
 	}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/ProcessedNamedMinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/ProcessedNamedMinecraftProvider.java
@@ -65,7 +65,7 @@ public abstract class ProcessedNamedMinecraftProvider<M extends MinecraftProvide
 
 		parentMinecraftProvider.provide(context.withApplyDependencies(false));
 
-		boolean requiresProcessing = context.refreshOutputs() || !hasBackupJars(minecraftJars) || parentMinecraftJars.stream()
+		boolean requiresProcessing = shouldRefreshOutputs(context) || parentMinecraftJars.stream()
 				.map(this::getProcessedPath)
 				.anyMatch(jarProcessorManager::requiresProcessingJar);
 


### PR DESCRIPTION
this fixes crashes when e.g. running `genSources` for legacy mc versions