### PR TITLE
Run library processor for server-only projects for Minecraft versions without  bundle metadata

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftLibraryProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftLibraryProvider.java
@@ -37,7 +37,6 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.provider.Provider;
 
 import net.fabricmc.loom.LoomGradleExtension;
-import net.fabricmc.loom.configuration.providers.BundleMetadata;
 import net.fabricmc.loom.configuration.providers.minecraft.library.Library;
 import net.fabricmc.loom.configuration.providers.minecraft.library.LibraryContext;
 import net.fabricmc.loom.configuration.providers.minecraft.library.LibraryProcessorManager;
@@ -108,13 +107,7 @@ public class MinecraftLibraryProvider {
 	}
 
 	private void provideServerLibraries() {
-		final BundleMetadata serverBundleMetadata = minecraftProvider.getServerBundleMetadata();
-
-		if (serverBundleMetadata == null) {
-			return;
-		}
-
-		final List<Library> libraries = MinecraftLibraryHelper.getServerLibraries(serverBundleMetadata);
+		final List<Library> libraries = MinecraftLibraryHelper.getServerLibraries(minecraftProvider.getServerBundleMetadata());
 		final List<Library> processLibraries = processLibraries(libraries);
 		processLibraries.forEach(this::applyServerLibrary);
 	}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftLibraryProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftLibraryProvider.java
@@ -37,6 +37,7 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.provider.Provider;
 
 import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.configuration.providers.BundleMetadata;
 import net.fabricmc.loom.configuration.providers.minecraft.library.Library;
 import net.fabricmc.loom.configuration.providers.minecraft.library.LibraryContext;
 import net.fabricmc.loom.configuration.providers.minecraft.library.LibraryProcessorManager;
@@ -107,7 +108,8 @@ public class MinecraftLibraryProvider {
 	}
 
 	private void provideServerLibraries() {
-		final List<Library> libraries = MinecraftLibraryHelper.getServerLibraries(minecraftProvider.getServerBundleMetadata());
+		final BundleMetadata serverBundleMetadata = minecraftProvider.getServerBundleMetadata();
+		final List<Library> libraries = serverBundleMetadata != null ? MinecraftLibraryHelper.getServerLibraries(serverBundleMetadata) : Collections.emptyList();
 		final List<Library> processLibraries = processLibraries(libraries);
 		processLibraries.forEach(this::applyServerLibrary);
 	}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/MinecraftLibraryHelper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/MinecraftLibraryHelper.java
@@ -27,6 +27,7 @@ package net.fabricmc.loom.configuration.providers.minecraft.library;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -89,12 +90,12 @@ public class MinecraftLibraryHelper {
 	}
 
 	public static List<Library> getServerLibraries(BundleMetadata bundleMetadata) {
+		Objects.requireNonNull(bundleMetadata);
+
 		var libraries = new ArrayList<Library>();
 
-		if (bundleMetadata != null) {
-			for (BundleMetadata.Entry library : bundleMetadata.libraries()) {
-				libraries.add(Library.fromMaven(library.name(), Library.Target.COMPILE));
-			}
+		for (BundleMetadata.Entry library : bundleMetadata.libraries()) {
+			libraries.add(Library.fromMaven(library.name(), Library.Target.COMPILE));
 		}
 
 		return libraries;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/MinecraftLibraryHelper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/MinecraftLibraryHelper.java
@@ -27,7 +27,6 @@ package net.fabricmc.loom.configuration.providers.minecraft.library;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -90,12 +89,12 @@ public class MinecraftLibraryHelper {
 	}
 
 	public static List<Library> getServerLibraries(BundleMetadata bundleMetadata) {
-		Objects.requireNonNull(bundleMetadata);
-
 		var libraries = new ArrayList<Library>();
 
-		for (BundleMetadata.Entry library : bundleMetadata.libraries()) {
-			libraries.add(Library.fromMaven(library.name(), Library.Target.COMPILE));
+		if (bundleMetadata != null) {
+			for (BundleMetadata.Entry library : bundleMetadata.libraries()) {
+				libraries.add(Library.fromMaven(library.name(), Library.Target.COMPILE));
+			}
 		}
 
 		return libraries;


### PR DESCRIPTION
This allows custom library processors to be run on server-only projects for older versions.