### PR TITLE
Make LineNumberRemapper stop trying to guess line numbers

### DIFF
--- a/src/main/java/net/fabricmc/loom/decompilers/LineNumberRemapper.java
+++ b/src/main/java/net/fabricmc/loom/decompilers/LineNumberRemapper.java
@@ -106,20 +106,16 @@ public record LineNumberRemapper(ClassLineNumbers lineNumbers) {
 			return new MethodVisitor(api, super.visitMethod(access, name, descriptor, signature, exceptions)) {
 				@Override
 				public void visitLineNumber(int line, Label start) {
-					int tLine = line;
-
-					if (tLine <= 0) {
+					if (line <= 0) {
 						super.visitLineNumber(line, start);
-					} else if (tLine >= lineNumbers.maxLine()) {
+					} else if (line >= lineNumbers.maxLine()) {
 						super.visitLineNumber(lineNumbers.maxLineDest(), start);
 					} else {
-						Integer matchedLine = null;
+						Integer matchedLine = lineNumbers.lineMap().get(line);
 
-						while (tLine <= lineNumbers.maxLine() && ((matchedLine = lineNumbers.lineMap().get(tLine)) == null)) {
-							tLine++;
+						if (matchedLine != null) {
+							super.visitLineNumber(matchedLine, start);
 						}
-
-						super.visitLineNumber(matchedLine != null ? matchedLine : lineNumbers.maxLineDest(), start);
 					}
 				}
 			};


### PR DESCRIPTION
Usually the guesses were wrong, so instead let's not generate a LineNumberTable for lines that lack a mapping in the linemap. This makes the behavior on decompiler bugs/issues more predictable.