### PR TITLE
Fix vscode `cwd` property for subprojects, delete unused `runDir` property

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/GenVsCodeProjectTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenVsCodeProjectTask.java
@@ -29,7 +29,6 @@ import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -140,7 +139,7 @@ public abstract class GenVsCodeProjectTask extends AbstractLoomTask {
 			toRemove.forEach(configurations::remove);
 			configurations.add(configurationJson);
 
-			Files.createDirectories(Paths.get(configuration.runDir));
+			Files.createDirectories(configuration.absoluteRunDirPath(getProject()));
 		}
 
 		final String json = LoomGradlePlugin.GSON.toJson(root);
@@ -158,23 +157,28 @@ public abstract class GenVsCodeProjectTask extends AbstractLoomTask {
 			String vmArgs,
 			String args,
 			Map<String, Object> env,
-			String projectName,
-			String runDir) implements Serializable {
+			String projectName) implements Serializable {
 		public static VsCodeConfiguration fromRunConfig(Project project, RunConfig runConfig) {
+			Path rootPath = project.getRootDir().toPath();
+			Path projectPath = project.getProjectDir().toPath();
+			Path relativeProjectPath = rootPath.relativize(projectPath);
 			return new VsCodeConfiguration(
 				"java",
 				runConfig.configName,
 				"launch",
-				"${workspaceFolder}/" + runConfig.runDir,
+				"${workspaceFolder}/" + relativeProjectPath.resolve(runConfig.runDir).toString(),
 				"integratedTerminal",
 				false,
 				runConfig.mainClass,
 				RunConfig.joinArguments(runConfig.vmArgs),
 				RunConfig.joinArguments(runConfig.programArgs),
 				new HashMap<>(runConfig.environmentVariables),
-				runConfig.projectName,
-				project.getProjectDir().toPath().resolve(runConfig.runDir).toAbsolutePath().toString()
+				runConfig.projectName
 			);
+		}
+
+		Path absoluteRunDirPath(Project project) {
+			return project.getRootDir().toPath().resolve(this.cwd.replace("${workspaceFolder}/", ""));
 		}
 	}
 }


### PR DESCRIPTION
This commit https://github.com/FabricMC/fabric-loom/commit/ce0a3308ffd433d9a8f48040e161a7231ed19eb9#diff-cec0045fe90b97a34702058c744a64e1efe8ddf298598a297d2eeb873e108dc2R110 made run configs relative to project.

Then this commit https://github.com/FabricMC/fabric-loom/commit/543e49dfe0fc871be7ea13dabb3be574ddaa5f79#diff-cec0045fe90b97a34702058c744a64e1efe8ddf298598a297d2eeb873e108dc2R162 added an unused `runDir` property for vscode `launch.json` file, and made `cwd` property non-relative again.