### PR TITLE
Add await() calls to tasks using WorkQueues

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/AbstractRemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractRemapJarTask.java
@@ -168,6 +168,8 @@ public abstract class AbstractRemapJarTask extends Jar {
 
 			action.execute(params);
 		});
+
+		workQueue.await();
 	}
 
 	protected abstract Provider<? extends ClientEntriesService.Options> getClientOnlyEntriesOptionsProvider(SourceSet clientSourceSet);

--- a/src/main/java/net/fabricmc/loom/task/ValidateMixinNameTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ValidateMixinNameTask.java
@@ -93,6 +93,8 @@ public abstract class ValidateMixinNameTask extends SourceTask {
 			params.getInputClasses().from(getSource().matching(pattern -> pattern.include("**/*.class")));
 			params.getSoftFailures().set(getSoftFailures());
 		});
+
+		workQueue.await();
 	}
 
 	public interface ValidateMixinsParams extends WorkParameters {


### PR DESCRIPTION
In particular, added it to AbstractRemapJarTask and ValidateMixinNameTask.

Without the call to await(), the tasks declare to Gradle that they're complete immediately, not waiting for the work to actually be done. This means that even after declaring a dependency on the task, any following tasks have the potential to start executing before the output file is ready. _Most of the time_ this is probably fine because they happen quickly but in my case I kept running into issues with file locks on the JARs output by the remap tasks when building my own custom plugin that sits on top of Loom.