### PR TITLE
Create a real Gradle ObjectFactory for unit tests

### DIFF
--- a/src/main/java/net/fabricmc/loom/util/service/ServiceType.java
+++ b/src/main/java/net/fabricmc/loom/util/service/ServiceType.java
@@ -24,6 +24,8 @@
 
 package net.fabricmc.loom.util.service;
 
+import java.lang.reflect.Method;
+
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.provider.Provider;
@@ -43,6 +45,13 @@ public record ServiceType<O extends Service.Options, S extends Service<O>>(Class
 	public Provider<O> create(Project project, Action<O> action) {
 		return project.provider(() -> {
 			O options = project.getObjects().newInstance(optionsClass);
+
+			for (Method method : optionsClass.getDeclaredMethods()) {
+				// Gradle property values are lazily initialized, ensure that all of the values are not null
+				// Before we try to serialize the options as json
+				method.invoke(options);
+			}
+
 			options.getServiceClass().set(serviceClass.getName());
 			options.getServiceClass().finalizeValue();
 			action.execute(options);

--- a/src/test/groovy/net/fabricmc/loom/test/unit/TestServiceFactoryTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/TestServiceFactoryTest.groovy
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2024 FabricMC
+ * Copyright (c) 2025 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,24 +22,40 @@
  * SOFTWARE.
  */
 
-package net.fabricmc.loom.test.unit.service
+package net.fabricmc.loom.test.unit
 
-import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.Property
 import spock.lang.Specification
 
-import net.fabricmc.loom.test.util.GradleTestUtil
-import net.fabricmc.loom.util.service.ScopedServiceFactory
+import net.fabricmc.loom.test.util.TestServiceFactory
 
-abstract class ServiceTestBase extends Specification {
-	ScopedServiceFactory factory
-	Project project = GradleTestUtil.mockProject()
-
-	def setup() {
-		factory = new ScopedServiceFactory()
+class TestServiceFactoryTest extends Specification {
+	def "property"() {
+		setup:
+		def test = TestServiceFactory.objectFactory.newInstance(PropertyTest)
+		when:
+		test.example.set("hello")
+		then:
+		test.example.isPresent()
+		test.example.get() == "hello"
 	}
 
-	def cleanup() {
-		factory.close()
-		factory = null
+	def "file property"() {
+		setup:
+		def test = TestServiceFactory.objectFactory.newInstance(FileTest)
+		when:
+		test.example.from(new File("test"))
+		then:
+		test.example.files.size() == 1
+		test.example.singleFile != null
+	}
+
+	interface PropertyTest {
+		Property<String> getExample()
+	}
+
+	interface FileTest {
+		ConfigurableFileCollection getExample()
 	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/unit/service/MappingsServiceTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/service/MappingsServiceTest.groovy
@@ -24,20 +24,17 @@
 
 package net.fabricmc.loom.test.unit.service
 
-import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.provider.Property
-
 import net.fabricmc.loom.task.service.MappingsService
-import net.fabricmc.loom.test.util.GradleTestUtil
 
 class MappingsServiceTest extends ServiceTestBase {
 	def "get mapping tree"() {
 		given:
-		MappingsService service = factory.get(new TestOptions(
-				mappingsFile: GradleTestUtil.mockRegularFileProperty(new File("src/test/resources/mappings/PosInChunk.mappings")),
-				from: GradleTestUtil.mockProperty("intermediary"),
-				to: GradleTestUtil.mockProperty("named"),
-				))
+		def options = MappingsService.TYPE.create(project) {
+			it.mappingsFile.set(new File("src/test/resources/mappings/PosInChunk.mappings"))
+			it.from.set("intermediary")
+			it.to.set("named")
+		}
+		MappingsService service = factory.get(options)
 
 		when:
 		def mappingTree = service.memoryMappingTree
@@ -47,14 +44,5 @@ class MappingsServiceTest extends ServiceTestBase {
 
 		service.from == "intermediary"
 		service.to == "named"
-	}
-
-	static class TestOptions implements MappingsService.Options {
-		RegularFileProperty mappingsFile
-		Property<String> from
-		Property<String> to
-		Property<Boolean> remapLocals = GradleTestUtil.mockProperty(false)
-		Property<Boolean> AllowNoneExistent = GradleTestUtil.mockProperty(false)
-		Property<String> serviceClass = serviceClassProperty(MappingsService.TYPE)
 	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/unit/service/ScopedServiceFactoryTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/service/ScopedServiceFactoryTest.groovy
@@ -25,20 +25,19 @@
 package net.fabricmc.loom.test.unit.service
 
 import groovy.transform.InheritConstructors
-import groovy.transform.TupleConstructor
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import spock.lang.Specification
 
-import net.fabricmc.loom.test.util.GradleTestUtil
 import net.fabricmc.loom.util.service.ScopedServiceFactory
 import net.fabricmc.loom.util.service.Service
 import net.fabricmc.loom.util.service.ServiceType
 
-class ScopedServiceFactoryTest extends Specification {
+class ScopedServiceFactoryTest extends ServiceTestBase {
 	def "create service"() {
 		given:
-		def options = new TestServiceOptions(GradleTestUtil.mockProperty("hello"))
+		def options = TestService.TYPE.create(project) {
+			it.example.set("hello")
+		}
 		def factory = new ScopedServiceFactory()
 
 		when:
@@ -53,7 +52,9 @@ class ScopedServiceFactoryTest extends Specification {
 
 	def "reuse service"() {
 		given:
-		def options = new TestServiceOptions(GradleTestUtil.mockProperty("hello"))
+		def options = TestService.TYPE.create(project) {
+			it.example.set("hello")
+		}
 		def factory = new ScopedServiceFactory()
 
 		when:
@@ -69,8 +70,12 @@ class ScopedServiceFactoryTest extends Specification {
 
 	def "reuse service different options instance"() {
 		given:
-		def options = new TestServiceOptions(GradleTestUtil.mockProperty("hello"))
-		def options2 = new TestServiceOptions(GradleTestUtil.mockProperty("hello"))
+		def options = TestService.TYPE.create(project) {
+			it.example.set("hello")
+		}
+		def options2 = TestService.TYPE.create(project) {
+			it.example.set("hello")
+		}
 		def factory = new ScopedServiceFactory()
 
 		when:
@@ -86,8 +91,12 @@ class ScopedServiceFactoryTest extends Specification {
 
 	def "Separate instances"() {
 		given:
-		def options = new TestServiceOptions(GradleTestUtil.mockProperty("hello"))
-		def options2 = new TestServiceOptions(GradleTestUtil.mockProperty("world"))
+		def options = TestService.TYPE.create(project) {
+			it.example.set("hello")
+		}
+		def options2 = TestService.TYPE.create(project) {
+			it.example.set("world")
+		}
 		def factory = new ScopedServiceFactory()
 
 		when:
@@ -105,7 +114,9 @@ class ScopedServiceFactoryTest extends Specification {
 
 	def "close service"() {
 		given:
-		def options = new TestServiceOptions(GradleTestUtil.mockProperty("hello"))
+		def options = TestService.TYPE.create(project) {
+			it.example.set("hello")
+		}
 		def factory = new ScopedServiceFactory()
 
 		when:
@@ -117,10 +128,10 @@ class ScopedServiceFactoryTest extends Specification {
 	}
 
 	@InheritConstructors
-	static class TestService extends Service<Options> implements Closeable {
-		static ServiceType<TestService.Options, TestService> TYPE = new ServiceType(TestService.Options.class, TestService.class)
+	static class TestService extends Service<TestOptions> implements Closeable {
+		static ServiceType<TestOptions, TestService> TYPE = new ServiceType(TestOptions, TestService)
 
-		interface Options extends Service.Options {
+		static interface TestOptions extends Service.Options {
 			@Input
 			Property<String> getExample();
 		}
@@ -135,11 +146,5 @@ class ScopedServiceFactoryTest extends Specification {
 		void close() throws Exception {
 			closed = true
 		}
-	}
-
-	@TupleConstructor
-	static class TestServiceOptions implements TestService.Options {
-		Property<String> example
-		Property<String> serviceClass = ServiceTestBase.serviceClassProperty(TestService.TYPE)
 	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/unit/service/SourceRemapperServiceTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/service/SourceRemapperServiceTest.groovy
@@ -27,13 +27,10 @@ package net.fabricmc.loom.test.unit.service
 import java.nio.file.Files
 import java.nio.file.Path
 
-import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.provider.Property
 import org.intellij.lang.annotations.Language
 
 import net.fabricmc.loom.task.service.MappingsService
 import net.fabricmc.loom.task.service.SourceRemapperService
-import net.fabricmc.loom.test.util.GradleTestUtil
 import net.fabricmc.loom.util.DeletingFileVisitor
 
 class SourceRemapperServiceTest extends ServiceTestBase {
@@ -49,15 +46,16 @@ class SourceRemapperServiceTest extends ServiceTestBase {
 		Files.writeString(sourceDirectory.resolve("Source.java"), SOURCE)
 		Files.writeString(mappings, MAPPINGS)
 
-		SourceRemapperService service = factory.get(new TestOptions(
-				mappings: GradleTestUtil.mockProperty(
-				new MappingsServiceTest.TestOptions(
-				mappingsFile: GradleTestUtil.mockRegularFileProperty(mappings.toFile()),
-				from: GradleTestUtil.mockProperty("named"),
-				to: GradleTestUtil.mockProperty("intermediary"),
-				)
-				),
-				))
+		def options = SourceRemapperService.TYPE.create(project) {
+			it.mappings.set(MappingsService.TYPE.create(project) {
+				it.mappingsFile.set(mappings.toFile())
+				it.from.set("named")
+				it.to.set("intermediary")
+			})
+			it.javaCompileRelease.set(17)
+		}
+
+		SourceRemapperService service = factory.get(options)
 
 		when:
 		service.remapSourcesJar(sourceDirectory, destDirectory)
@@ -85,11 +83,4 @@ class SourceRemapperServiceTest extends ServiceTestBase {
     c	Source Source
     	m	()V	println	test
     """.trim()
-
-	static class TestOptions implements SourceRemapperService.Options {
-		Property<MappingsService.Options> mappings
-		Property<Integer> javaCompileRelease = GradleTestUtil.mockProperty(17)
-		ConfigurableFileCollection classpath = GradleTestUtil.mockConfigurableFileCollection()
-		Property<String> serviceClass = serviceClassProperty(SourceRemapperService.TYPE)
-	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/util/GradleTestUtil.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/util/GradleTestUtil.groovy
@@ -26,7 +26,6 @@ package net.fabricmc.loom.test.util
 
 import org.gradle.api.Project
 import org.gradle.api.artifacts.dsl.RepositoryHandler
-import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.file.SourceDirectorySet
@@ -64,9 +63,15 @@ class GradleTestUtil {
 	}
 
 	static Project mockProject() {
+		def objectFactory = TestServiceFactory.objectFactory
+		def providerFactory = TestServiceFactory.providerFactory
 		def mock = mock(Project.class)
 		def extensions = mockExtensionContainer()
 		when(mock.getExtensions()).thenReturn(extensions)
+		when(mock.getObjects()).thenReturn(objectFactory)
+		when(mock.provider(any())).thenAnswer {
+			providerFactory.provider(it.getArgument(0))
+		}
 		return mock
 	}
 
@@ -131,12 +136,6 @@ class GradleTestUtil {
 		def mock = mock(RegularFileProperty.class)
 		when(mock.get()).thenReturn(regularFile)
 		when(mock.isPresent()).thenReturn(true)
-		return mock
-	}
-
-	static ConfigurableFileCollection mockConfigurableFileCollection(File... files) {
-		def mock = mock(ConfigurableFileCollection.class)
-		when(mock.getFiles()).thenReturn(Set.of(files))
 		return mock
 	}
 

--- a/src/test/groovy/net/fabricmc/loom/test/util/TestServiceFactory.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/util/TestServiceFactory.groovy
@@ -1,0 +1,146 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.util
+
+import groovy.transform.CompileStatic
+import org.gradle.api.internal.CollectionCallbackActionDecorator
+import org.gradle.api.internal.MutationGuard
+import org.gradle.api.internal.MutationGuards
+import org.gradle.api.internal.collections.DefaultDomainObjectCollectionFactory
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory
+import org.gradle.api.internal.file.DefaultFileCollectionFactory
+import org.gradle.api.internal.file.DefaultFileLookup
+import org.gradle.api.internal.file.DefaultFilePropertyFactory
+import org.gradle.api.internal.file.FileCollectionFactory
+import org.gradle.api.internal.file.FilePropertyFactory
+import org.gradle.api.internal.file.FileResolver
+import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
+import org.gradle.api.internal.model.DefaultObjectFactory
+import org.gradle.api.internal.model.NamedObjectInstantiator
+import org.gradle.api.internal.provider.DefaultPropertyFactory
+import org.gradle.api.internal.provider.DefaultProviderFactory
+import org.gradle.api.internal.provider.PropertyFactory
+import org.gradle.api.internal.provider.PropertyHost
+import org.gradle.api.internal.tasks.DefaultTaskDependencyFactory
+import org.gradle.api.internal.tasks.properties.annotations.OutputPropertyRoleAnnotationHandler
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.tasks.util.PatternSet
+import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory
+import org.gradle.cache.internal.DefaultCrossBuildInMemoryCacheFactory
+import org.gradle.internal.Factory
+import org.gradle.internal.event.ListenerManager
+import org.gradle.internal.instantiation.InstantiatorFactory
+import org.gradle.internal.instantiation.generator.DefaultInstantiatorFactory
+import org.gradle.internal.nativeintegration.filesystem.FileSystem
+import org.gradle.internal.service.DefaultServiceRegistry
+import org.gradle.internal.service.Provides
+import org.gradle.internal.service.ServiceRegistrationProvider
+import org.gradle.internal.service.ServiceRegistry
+
+import static org.mockito.Mockito.mock
+
+/**
+ * Based on Gradle's own TestUtils, this class setups the Gradle DI system to be used within unit tests.
+ */
+@CompileStatic
+class TestServiceFactory {
+	public static final ServiceRegistry serviceRegistry = createServiceRegistry()
+	public static final ObjectFactory objectFactory = serviceRegistry.get(ObjectFactory)
+	public static final ProviderFactory providerFactory = serviceRegistry.get(ProviderFactory)
+
+	private static ServiceRegistry createServiceRegistry() {
+		def services = new DefaultServiceRegistry()
+		services.register {
+			it.add(DefaultPropertyFactory)
+			it.add(ProviderFactory, new DefaultProviderFactory())
+			it.add(PropertyHost, PropertyHost.NO_OP)
+			it.add(NamedObjectInstantiator)
+			it.add(CollectionCallbackActionDecorator, CollectionCallbackActionDecorator.NOOP)
+			it.add(MutationGuard, MutationGuards.identity())
+			it.add(FileCollectionFactory, fileCollectionFactory())
+			it.add(DefaultDomainObjectCollectionFactory)
+			it.add(CrossBuildInMemoryCacheFactory, new DefaultCrossBuildInMemoryCacheFactory(mock(ListenerManager)))
+			//noinspection unused
+			it.addProvider(new ServiceRegistrationProvider() {
+						@Provides
+						InstantiatorFactory createInstantiatorFactory(
+								CrossBuildInMemoryCacheFactory crossBuildInMemoryCacheFactory) {
+							return new DefaultInstantiatorFactory(
+									crossBuildInMemoryCacheFactory,
+									[],
+									new OutputPropertyRoleAnnotationHandler([])
+									)
+						}
+
+						@Provides
+						FilePropertyFactory createFilePropertyFactory(
+								PropertyHost propertyHost,
+								FileCollectionFactory fileCollectionFactory) {
+							return new DefaultFilePropertyFactory(
+									propertyHost,
+									fileResolver(),
+									fileCollectionFactory)
+						}
+
+						@Provides
+						ObjectFactory createObjectFactory(
+								InstantiatorFactory instantiatorFactory,
+								NamedObjectInstantiator namedObjectInstantiator,
+								PropertyFactory propertyFactory,
+								FilePropertyFactory filePropertyFactory,
+								FileCollectionFactory fileCollectionFactory,
+								DomainObjectCollectionFactory domainObjectCollectionFactory) {
+							return new DefaultObjectFactory(
+									instantiatorFactory.decorate(services),
+									namedObjectInstantiator,
+									mock(DirectoryFileTreeFactory),
+									mock(Factory) as Factory<PatternSet>,
+									propertyFactory,
+									filePropertyFactory,
+									DefaultTaskDependencyFactory.withNoAssociatedProject(),
+									fileCollectionFactory,
+									domainObjectCollectionFactory)
+						}
+					})
+		}
+
+		return services
+	}
+
+	private static FileResolver fileResolver() {
+		return new DefaultFileLookup().getFileResolver(new File(".").absoluteFile)
+	}
+
+	private static FileCollectionFactory fileCollectionFactory() {
+		return new DefaultFileCollectionFactory(
+				fileResolver(),
+				DefaultTaskDependencyFactory.withNoAssociatedProject(),
+				mock(DirectoryFileTreeFactory),
+				mock(Factory) as Factory<PatternSet>,
+				PropertyHost.NO_OP,
+				mock(FileSystem))
+	}
+}


### PR DESCRIPTION
This makes it possible to use the full gradle DI and proerty system within unit tests.

Is it using too much Gradle internals? As its test code I dont think so, im open to alternative suggestions.