### PR TITLE
Add Groovy import order to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,6 @@
-[*.{gradle,java,kotlin}]
+[*.{gradle,groovy,java,kotlin}]
 indent_style = tab
 ij_continuation_indent_size = 8
 ij_java_imports_layout = $*,|,java.**,|,javax.**,|,*,|,net.fabricmc.**
 ij_java_class_count_to_use_import_on_demand = 999
+ij_groovy_imports_layout = java.**,|,javax.**,|,*,|,net.fabricmc.**,|,$*

--- a/src/main/java/net/fabricmc/loom/configuration/fabricapi/FabricApiTesting.java
+++ b/src/main/java/net/fabricmc/loom/configuration/fabricapi/FabricApiTesting.java
@@ -103,7 +103,7 @@ public abstract class FabricApiTesting extends FabricApiAbstractSourceSet {
 
 		if (settings.getEnableClientGameTests().get()) {
 			// Not ideal as there may be multiple resources directories, if this isnt correct the mod will need to override this.
-			final File resourcesDir = testSourceSet.getResources().getFiles().stream().findAny().orElse(null);
+			final File resourcesDir = testSourceSet.getResources().getSrcDirs().stream().findFirst().orElse(null);
 
 			RunConfigSettings clientGameTest = extension.getRunConfigs().create("clientGameTest", run -> {
 				run.inherit(extension.getRunConfigs().getByName("client"));


### PR DESCRIPTION
This lets IDEA autoformat the imports correctly.