### PR TITLE
Support putting run configs in folders

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
@@ -38,10 +38,12 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import groovy.xml.XmlUtil;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
@@ -60,6 +62,8 @@ import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.gradle.SourceSetReference;
 
 public class RunConfig {
+	private static final Pattern VARIABLE = Pattern.compile("%[A-Z_]+%");
+
 	public String configName;
 	public String eclipseProjectName;
 	public String ideaModuleName;
@@ -72,6 +76,7 @@ public class RunConfig {
 	public transient SourceSet sourceSet;
 	public Map<String, Object> environmentVariables;
 	public String projectName;
+	public String folderName;
 
 	// Turns camelCase/PascalCase into Capital Case
 	// caseConversionExample -> Case Conversion Example
@@ -151,6 +156,7 @@ public class RunConfig {
 		runConfig.environmentVariables = new HashMap<>();
 		runConfig.environmentVariables.putAll(settings.getEnvironmentVariables());
 		runConfig.projectName = project.getName();
+		runConfig.folderName = settings.getIdeConfigFolder().getOrNull();
 
 		return runConfig;
 	}
@@ -172,17 +178,20 @@ public class RunConfig {
 			runDir = relativePath + "/" + runDir;
 		}
 
-		dummyConfig = dummyConfig.replace("%NAME%", configName);
-		dummyConfig = dummyConfig.replace("%MAIN_CLASS%", mainClass);
-		dummyConfig = dummyConfig.replace("%ECLIPSE_PROJECT%", eclipseProjectName);
-		dummyConfig = dummyConfig.replace("%IDEA_MODULE%", ideaModuleName);
-		dummyConfig = dummyConfig.replace("%RUN_DIRECTORY%", runDir);
-		dummyConfig = dummyConfig.replace("%PROGRAM_ARGS%", joinArguments(programArgs).replaceAll("\"", "&quot;"));
-		dummyConfig = dummyConfig.replace("%VM_ARGS%", joinArguments(vmArgs).replaceAll("\"", "&quot;"));
-		dummyConfig = dummyConfig.replace("%IDEA_ENV_VARS%", getEnvVars("<env name=\"%s\" value=\"%s\"/>"));
-		dummyConfig = dummyConfig.replace("%ECLIPSE_ENV_VARS%", getEnvVars("<mapEntry key=\"%s\" value=\"%s\"/>"));
+		var replacements = Map.of(
+				"%NAME%", configName,
+				"%MAIN_CLASS%", mainClass,
+				"%ECLIPSE_PROJECT%", eclipseProjectName,
+				"%IDEA_MODULE%", ideaModuleName,
+				"%RUN_DIRECTORY%", runDir,
+				"%PROGRAM_ARGS%", joinArguments(programArgs).replaceAll("\"", "&quot;"),
+				"%VM_ARGS%", joinArguments(vmArgs).replaceAll("\"", "&quot;"),
+				"%IDEA_ENV_VARS%", getEnvVars("<env name=\"%s\" value=\"%s\"/>"),
+				"%ECLIPSE_ENV_VARS%", getEnvVars("<mapEntry key=\"%s\" value=\"%s\"/>"),
+				"%IDEA_FOLDER_NAME%", folderName == null ? "" : "folderName=\"" + XmlUtil.escapeXml(folderName) + "\""
+		);
 
-		return dummyConfig;
+		return VARIABLE.matcher(dummyConfig).replaceAll(x -> replacements.getOrDefault(x.group(), ""));
 	}
 
 	private String getEnvVars(String pattern) {

--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
@@ -40,7 +40,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.gradle.api.JavaVersion;
@@ -50,9 +49,6 @@ import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.plugins.ide.eclipse.model.EclipseModel;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.configuration.InstallerData;
@@ -76,42 +72,6 @@ public class RunConfig {
 	public transient SourceSet sourceSet;
 	public Map<String, Object> environmentVariables;
 	public String projectName;
-
-	public Element genRuns(Element doc) {
-		Element root = this.addXml(doc, "component", ImmutableMap.of("name", "ProjectRunConfigurationManager"));
-		root = addXml(root, "configuration", ImmutableMap.of("default", "false", "name", configName, "type", "Application", "factoryName", "Application"));
-
-		this.addXml(root, "module", ImmutableMap.of("name", ideaModuleName));
-		this.addXml(root, "option", ImmutableMap.of("name", "MAIN_CLASS_NAME", "value", mainClass));
-		this.addXml(root, "option", ImmutableMap.of("name", "WORKING_DIRECTORY", "value", runDirIdeaUrl));
-
-		if (!vmArgs.isEmpty()) {
-			this.addXml(root, "option", ImmutableMap.of("name", "VM_PARAMETERS", "value", joinArguments(vmArgs)));
-		}
-
-		if (!programArgs.isEmpty()) {
-			this.addXml(root, "option", ImmutableMap.of("name", "PROGRAM_PARAMETERS", "value", joinArguments(programArgs)));
-		}
-
-		return root;
-	}
-
-	public Element addXml(Node parent, String name, Map<String, String> values) {
-		Document doc = parent.getOwnerDocument();
-
-		if (doc == null) {
-			doc = (Document) parent;
-		}
-
-		Element e = doc.createElement(name);
-
-		for (Map.Entry<String, String> entry : values.entrySet()) {
-			e.setAttribute(entry.getKey(), entry.getValue());
-		}
-
-		parent.appendChild(e);
-		return e;
-	}
 
 	// Turns camelCase/PascalCase into Capital Case
 	// caseConversionExample -> Case Conversion Example

--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
@@ -383,8 +383,8 @@ public abstract class RunConfigSettings implements Named {
 
 	/**
 	 * Group this run config under the given folder.
-	 * <p>
-	 * This is currently only supported on IntelliJ IDEA.
+	 *
+	 * <p>This is currently only supported on IntelliJ IDEA.
 	 *
 	 * @return The property used to set the config folder.
 	 */

--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
@@ -48,7 +48,7 @@ import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.Platform;
 import net.fabricmc.loom.util.gradle.SourceSetHelper;
 
-public class RunConfigSettings implements Named {
+public abstract class RunConfigSettings implements Named {
 	/**
 	 * Arguments for the JVM, such as system properties.
 	 */
@@ -362,6 +362,7 @@ public class RunConfigSettings implements Named {
 		defaultMainClass = parent.defaultMainClass;
 		source = parent.source;
 		ideConfigGenerated = parent.ideConfigGenerated;
+		getIdeConfigFolder().set(parent.getIdeConfigFolder());
 	}
 
 	public void makeRunDir() {
@@ -379,6 +380,15 @@ public class RunConfigSettings implements Named {
 	public void setIdeConfigGenerated(boolean ideConfigGenerated) {
 		this.ideConfigGenerated = ideConfigGenerated;
 	}
+
+	/**
+	 * Group this run config under the given folder.
+	 * <p>
+	 * This is currently only supported on IntelliJ IDEA.
+	 *
+	 * @return The property used to set the config folder.
+	 */
+	public abstract Property<String> getIdeConfigFolder();
 
 	@ApiStatus.Internal
 	@ApiStatus.Experimental

--- a/src/main/resources/idea_run_config_template.xml
+++ b/src/main/resources/idea_run_config_template.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="%NAME%" type="Application" factoryName="Application">
+  <configuration default="false" name="%NAME%" type="Application" factoryName="Application" %IDEA_FOLDER_NAME%>
     <option name="MAIN_CLASS_NAME" value="%MAIN_CLASS%" />
     <module name="%IDEA_MODULE%" />
     <option name="PROGRAM_PARAMETERS" value="%PROGRAM_ARGS%" />

--- a/src/test/groovy/net/fabricmc/loom/test/unit/IdeaClasspathModificationsTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/IdeaClasspathModificationsTest.groovy
@@ -69,6 +69,7 @@ class IdeaClasspathModificationsTest extends Specification {
 		dummyConfig = dummyConfig.replace("%RUN_DIRECTORY%", ".run")
 		dummyConfig = dummyConfig.replace("%PROGRAM_ARGS%", RunConfig.joinArguments([]).replaceAll("\"", "&quot;"))
 		dummyConfig = dummyConfig.replace("%VM_ARGS%", RunConfig.joinArguments([]).replaceAll("\"", "&quot;"))
+		dummyConfig = dummyConfig.replace("%IDEA_FOLDER_NAME%", "")
 
 		return dummyConfig
 	}


### PR DESCRIPTION
 - Remove unused `RunConfig.genRuns`.
 - Rewrite templating to do a single find-and-replace, rather than a chain of them.
 - Add a new `ideConfigFolder` option, which sets the `folderName` attribute on the IDEA config file.

![IntellJ Idea's run config drop down. There is a folder called "Fabric", where which contains a list of runs (e.g. client, server).](https://github.com/user-attachments/assets/671077df-3402-4943-9608-b82d81d8e7cc)


I wasn't quite sure the best way to expose settings from `RunConfigSettings`, as it's currently a bit ad-hoc. For now, I've gone with the simplest option (a `Property<String>` getter), but happy to change that if preferred! 