### PR TITLE
Filter Out New Realms Error Message

### DIFF
--- a/src/main/resources/log4j2.fabric.xml
+++ b/src/main/resources/log4j2.fabric.xml
@@ -9,6 +9,7 @@
 				<RegexFilter regex="^Failed to verify authentication$" onMatch="DENY" onMismatch="NEUTRAL"/>
 				<RegexFilter regex="^Failed to fetch user properties$" onMatch="DENY" onMismatch="NEUTRAL"/>
 				<RegexFilter regex="^Couldn't connect to realms$" onMatch="DENY" onMismatch="NEUTRAL"/>
+				<RegexFilter regex="^Failed to fetch Realms feature flags$" onMatch="DENY" onMismatch="NEUTRAL"/>
 			</Filters>
 			<PatternLayout>
 				<LoggerNamePatternSelector defaultPattern="%style{[%d{HH:mm:ss}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(%logger{1})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}" disableAnsi="${sys:fabric.log.disableAnsi:-true}">


### PR DESCRIPTION
There's a new Realms error message in 1.21.5!

![image](https://github.com/user-attachments/assets/a3539fa3-1ed8-4c48-b328-f397c00c78b2)

This PR adds another log filter, similar to the already existing ones.