### PR TITLE
Fix DebugLineNumbersTest and run it on extended test runs.

### DIFF
--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -86,6 +86,7 @@ jobs:
       - run: ./gradlew printActionsTestName --name="${{ matrix.test }}" test --tests ${{ matrix.test }} --stacktrace --warning-mode fail
         env:
           TEST_WARNING_MODE: fail
+          EXTENDED_TESTS: ${{ github.event.inputs.extended_tests }}
         id: test
 
       - uses: actions/upload-artifact@v4

--- a/build.gradle
+++ b/build.gradle
@@ -336,6 +336,7 @@ publishing {
 tasks.register('writeActionsTestMatrix') {
 	doLast {
 		def testMatrix = []
+		def extendedTests = Boolean.parseBoolean(System.getenv('EXTENDED_TESTS') ?: 'false')
 		file('src/test/groovy/net/fabricmc/loom/test/integration').eachFile {
 			if (it.name.endsWith("Test.groovy")) {
 				if (it.name.endsWith("ReproducibleBuildTest.groovy")) {
@@ -343,7 +344,7 @@ tasks.register('writeActionsTestMatrix') {
 					return
 				}
 
-				if (it.name.endsWith("DebugLineNumbersTest.groovy")) {
+				if (it.name.endsWith("DebugLineNumbersTest.groovy") && !extendedTests) {
 					// Known flakey test
 					return
 				}

--- a/gradle/test.libs.versions.toml
+++ b/gradle/test.libs.versions.toml
@@ -3,7 +3,7 @@ spock = "2.3-groovy-3.0"
 junit = "5.12.2"
 javalin = "6.6.0"
 mockito = "5.17.0"
-java-debug = "0.52.0"
+java-debug = "0.53.1"
 mixin = "0.15.3+mixin.0.8.7"
 bouncycastle = "1.80"
 

--- a/src/test/groovy/net/fabricmc/loom/test/integration/DebugLineNumbersTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/DebugLineNumbersTest.groovy
@@ -52,9 +52,9 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 class DebugLineNumbersTest extends Specification implements GradleProjectTestTrait {
 	static final String MAPPINGS = "1.20.1-net.fabricmc.yarn.1_20_1.1.20.1+build.1-v2"
 	static final Map<String, Integer> BREAKPOINTS = [
-		"net.minecraft.server.dedicated.ServerPropertiesLoader": 16,
-		"net.minecraft.server.dedicated.MinecraftDedicatedServer": 107,
-		"net.minecraft.registry.RegistryOps": 67
+		"net.minecraft.server.dedicated.ServerPropertiesLoader": 12,
+		"net.minecraft.server.dedicated.MinecraftDedicatedServer": 105,
+		"net.minecraft.registry.RegistryOps": 44
 	]
 
 	def "Debug test"() {


### PR DESCRIPTION
DebugLineNumbersTest has been broken for a little while (since a decompiler update). It was previously impossible to run on CI, but now it will only run when the extended tests are enabled.