### PR TITLE
Add custom mappings support to abstract remap jar task.

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/AbstractRemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractRemapJarTask.java
@@ -94,6 +94,14 @@ public abstract class AbstractRemapJarTask extends Jar {
 	@Optional
 	public abstract Property<String> getClientOnlySourceSetName();
 
+	/**
+	 * Optionally supply a single mapping file or jar file containing mappings to be used for remapping.
+	 */
+	@ApiStatus.Experimental
+	@InputFiles
+	@Optional
+	public abstract ConfigurableFileCollection getCustomMappings();
+
 	@Input
 	@Optional
 	@ApiStatus.Internal

--- a/src/main/java/net/fabricmc/loom/task/service/TinyRemapperService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/TinyRemapperService.java
@@ -49,6 +49,8 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.extension.RemapperExtensionHolder;
@@ -67,6 +69,8 @@ import net.fabricmc.tinyremapper.extension.mixin.MixinExtension;
 
 public class TinyRemapperService extends Service<TinyRemapperService.Options> implements Closeable {
 	public static final ServiceType<Options, TinyRemapperService> TYPE = new ServiceType<>(Options.class, TinyRemapperService.class);
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(TinyRemapperService.class);
 
 	public interface Options extends Service.Options {
 		@Input
@@ -102,7 +106,7 @@ public class TinyRemapperService extends Service<TinyRemapperService.Options> im
 
 			options.getFrom().set(remapJarTask.getSourceNamespace());
 			options.getTo().set(remapJarTask.getTargetNamespace());
-			options.getMappings().add(MappingsService.createOptionsWithProjectMappings(project, options.getFrom(), options.getTo()));
+			options.getMappings().add(createMappingsOptions(remapJarTask));
 
 			if (legacyMixin) {
 				options.getMixinApMappings().set(MixinAPMappingService.createOptions(project, options.getFrom(), options.getTo()));
@@ -113,6 +117,37 @@ public class TinyRemapperService extends Service<TinyRemapperService.Options> im
 			options.getClasspath().from(classpath);
 			options.getKnownIndyBsms().set(extension.getKnownIndyBsms().get().stream().sorted().toList());
 			options.getRemapperExtensions().set(extension.getRemapperExtensions());
+		});
+	}
+
+	private static Provider<MappingsService.Options> createMappingsOptions(AbstractRemapJarTask remapJarTask) {
+		final Project project = remapJarTask.getProject();
+
+		return project.provider(() -> {
+			if (remapJarTask.getCustomMappings().isEmpty()) {
+				LOGGER.debug("Using default project mappings for remapping");
+				return MappingsService.createOptionsWithProjectMappings(
+						project,
+						remapJarTask.getSourceNamespace(),
+						remapJarTask.getTargetNamespace()
+				).get();
+			}
+
+			// Custom mappings:
+			File mappingsFile = remapJarTask.getCustomMappings().getSingleFile();
+
+			// TODO possibly move this to MappingsService
+			if (mappingsFile.getName().endsWith(".zip") || mappingsFile.getName().endsWith(".jar")) {
+				mappingsFile = project.zipTree(mappingsFile).matching(patternFilterable -> patternFilterable.include("mappings/mappings.tiny")).getSingleFile();
+			}
+
+			LOGGER.info("Using custom mappings for remap task: {}", mappingsFile);
+			return MappingsService.createOptions(
+							project,
+							mappingsFile.toPath(),
+							remapJarTask.getSourceNamespace(), remapJarTask.getTargetNamespace(),
+							false)
+					.get();
 		});
 	}
 

--- a/src/test/groovy/net/fabricmc/loom/test/integration/SimpleProjectTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/SimpleProjectTest.groovy
@@ -141,7 +141,7 @@ class SimpleProjectTest extends Specification implements GradleProjectTestTrait 
 				dependencies {
 					mojangMappings loom.officialMojangMappings()
 				}
-				
+
 				tasks.register("remapMojmap", net.fabricmc.loom.task.RemapJarTask) {
 					sourceNamespace = "intermediary"
 					targetNamespace = "named"

--- a/src/test/groovy/net/fabricmc/loom/test/integration/SimpleProjectTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/SimpleProjectTest.groovy
@@ -127,4 +127,39 @@ class SimpleProjectTest extends Specification implements GradleProjectTestTrait 
 		where:
 		version << STANDARD_TEST_VERSIONS
 	}
+
+	@Unroll
+	def "custom remap mappings (gradle #version)"() {
+		// Initial conditions: a project with a resource file to delete.
+		setup:
+		def gradle = gradleProject(project: "simple", version: version)
+		gradle.buildGradle << """
+				configurations {
+					mojangMappings
+				}
+
+				dependencies {
+					mojangMappings loom.officialMojangMappings()
+				}
+				
+				tasks.register("remapMojmap", net.fabricmc.loom.task.RemapJarTask) {
+					sourceNamespace = "intermediary"
+					targetNamespace = "named"
+					inputFile = tasks.remapJar.archiveFile
+					customMappings.from(configurations.mojangMappings)
+					archiveClassifier = "mojmap"
+
+					addNestedDependencies = false // Jars have already been included in the remapJar task
+				}
+				"""
+
+		when:
+		def result = gradle.run(task: "remapMojmap")
+
+		then:
+		result.task(":remapMojmap").outcome == SUCCESS
+
+		where:
+		version << STANDARD_TEST_VERSIONS
+	}
 }

--- a/src/test/resources/projects/simple/src/main/java/net/fabricmc/example/ExampleMod.java
+++ b/src/test/resources/projects/simple/src/main/java/net/fabricmc/example/ExampleMod.java
@@ -15,5 +15,7 @@ public class ExampleMod implements ModInitializer {
 	public void onInitialize() {
 		LOGGER.info("Hello simple Fabric mod!");
 		LOGGER.info("Hello World!");
+
+		net.minecraft.util.Identifier id = null;
 	}
 }


### PR DESCRIPTION
Closes #1296

See test for example usage. This isnt an ideal long term solution, but it can easily be done today without too much fuss. Correctly setting up the classpath (if required) is left up to the user.

A custom task could be used to create a set of merged mappings to remove the need to first map to intermediary and then to the 2nd named set of mappings. This would ease the issue of correctly configuring the classpath.