### PR TITLE
Build Loom to target Java 21

### DIFF
--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -142,7 +142,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 17, 21 ]
+        java: [ 21 ]
         os: [ windows-2025, ubuntu-24.04, macos-15 ]
 
     runs-on: ${{ matrix.os }}

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ tasks.withType(JavaCompile).configureEach {
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 	kotlinOptions {
-		jvmTarget = "17"
+		jvmTarget = "21"
 	}
 }
 
@@ -183,13 +183,13 @@ base {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 17
+	it.options.release = 21
 }
 
 java {
 	withSourcesJar()
-	sourceCompatibility = JavaVersion.VERSION_17
-	targetCompatibility = JavaVersion.VERSION_17
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
 }
 
 spotless {


### PR DESCRIPTION
This PR bumps the minimum Gradle java version to 21. This was already required when using Minecraft versions compiled for Java 21 so should have minimal impact. Mods can still be built targeting versions down to Java 8.

Please make any objections known.