### PR TITLE
Unpick code cleanup 1

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/decompile/DecompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/decompile/DecompileConfiguration.java
@@ -24,18 +24,12 @@
 
 package net.fabricmc.loom.configuration.decompile;
 
-import java.io.File;
-
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.ConfigurationContainer;
 
 import net.fabricmc.loom.LoomGradleExtension;
-import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftJar;
 import net.fabricmc.loom.configuration.providers.minecraft.mapped.MappedMinecraftProvider;
-import net.fabricmc.loom.task.GenerateSourcesTask;
-import net.fabricmc.loom.util.Constants;
 
 public abstract class DecompileConfiguration<T extends MappedMinecraftProvider> {
 	static final String DEFAULT_DECOMPILER = "Vineflower";
@@ -55,15 +49,4 @@ public abstract class DecompileConfiguration<T extends MappedMinecraftProvider> 
 	public abstract String getTaskName(MinecraftJar.Type type);
 
 	public abstract void afterEvaluation();
-
-	protected final void configureUnpick(GenerateSourcesTask task, File unpickOutputJar) {
-		final ConfigurationContainer configurations = task.getProject().getConfigurations();
-
-		task.getUnpickDefinitions().set(mappingConfiguration.getUnpickDefinitionsFile());
-		task.getUnpickOutputJar().set(unpickOutputJar);
-		task.getUnpickConstantJar().setFrom(configurations.getByName(Constants.Configurations.MAPPING_CONSTANTS));
-		task.getUnpickClasspath().setFrom(configurations.getByName(Constants.Configurations.MINECRAFT_COMPILE_LIBRARIES));
-		task.getUnpickClasspath().from(configurations.getByName(Constants.Configurations.MOD_COMPILE_CLASSPATH_MAPPED));
-		extension.getMinecraftJars(MappingsNamespace.NAMED).forEach(task.getUnpickClasspath()::from);
-	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/decompile/SingleJarDecompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/decompile/SingleJarDecompileConfiguration.java
@@ -24,7 +24,6 @@
 
 package net.fabricmc.loom.configuration.decompile;
 
-import java.io.File;
 import java.util.List;
 
 import org.gradle.api.Project;
@@ -63,11 +62,6 @@ public class SingleJarDecompileConfiguration extends DecompileConfiguration<Mapp
 				task.dependsOn(project.getTasks().named("validateAccessWidener"));
 				task.setDescription("Decompile minecraft using %s.".formatted(decompilerName));
 				task.setGroup(Constants.TaskGroup.FABRIC);
-
-				if (mappingConfiguration.hasUnpickDefinitions()) {
-					final File outputJar = new File(extension.getMappingConfiguration().mappingsWorkingDir().toFile(), "minecraft-unpicked.jar");
-					configureUnpick(task, outputJar);
-				}
 			});
 		});
 

--- a/src/main/java/net/fabricmc/loom/configuration/decompile/SplitDecompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/decompile/SplitDecompileConfiguration.java
@@ -24,8 +24,6 @@
 
 package net.fabricmc.loom.configuration.decompile;
 
-import java.io.File;
-
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -56,21 +54,11 @@ public final class SplitDecompileConfiguration extends DecompileConfiguration<Ma
 		final TaskProvider<Task> commonDecompileTask = createDecompileTasks("Common", task -> {
 			task.getInputJarName().set(commonJar.getName());
 			task.getSourcesOutputJar().fileValue(GenerateSourcesTask.getJarFileWithSuffix("-sources.jar", commonJar.getPath()));
-
-			if (mappingConfiguration.hasUnpickDefinitions()) {
-				File unpickJar = new File(extension.getMappingConfiguration().mappingsWorkingDir().toFile(), "minecraft-common-unpicked.jar");
-				configureUnpick(task, unpickJar);
-			}
 		});
 
 		final TaskProvider<Task> clientOnlyDecompileTask = createDecompileTasks("ClientOnly", task -> {
 			task.getInputJarName().set(clientOnlyJar.getName());
 			task.getSourcesOutputJar().fileValue(GenerateSourcesTask.getJarFileWithSuffix("-sources.jar", clientOnlyJar.getPath()));
-
-			if (mappingConfiguration.hasUnpickDefinitions()) {
-				File unpickJar = new File(extension.getMappingConfiguration().mappingsWorkingDir().toFile(), "minecraft-clientonly-unpicked.jar");
-				configureUnpick(task, unpickJar);
-			}
 
 			// Don't allow them to run at the same time.
 			task.mustRunAfter(commonDecompileTask);

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsFactory.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsFactory.java
@@ -47,6 +47,7 @@ import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.configuration.ConfigContext;
 import net.fabricmc.loom.configuration.mods.dependency.LocalMavenHelper;
 import net.fabricmc.loom.configuration.providers.mappings.extras.unpick.UnpickLayer;
+import net.fabricmc.loom.configuration.providers.mappings.unpick.UnpickMetadata;
 import net.fabricmc.loom.configuration.providers.mappings.utils.AddConstructorMappingVisitor;
 import net.fabricmc.loom.util.ZipUtils;
 import net.fabricmc.mappingio.adapter.MappingDstNsReorder;
@@ -148,7 +149,7 @@ public record LayeredMappingsFactory(LayeredMappingSpec spec) {
 			return;
 		}
 
-		ZipUtils.add(mappingsFile, "extras/definitions.unpick", unpickData.definitions());
-		ZipUtils.add(mappingsFile, "extras/unpick.json", unpickData.metadata().asJson());
+		ZipUtils.add(mappingsFile, UnpickMetadata.UNPICK_DEFINITIONS_PATH, unpickData.definitions());
+		ZipUtils.add(mappingsFile, UnpickMetadata.UNPICK_METADATA_PATH, unpickData.rawMetadata());
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import com.google.gson.JsonObject;
 import org.apache.tools.ant.util.StringUtils;
 import org.gradle.api.Project;
 import org.gradle.api.provider.Provider;
@@ -52,6 +51,7 @@ import net.fabricmc.loom.LoomGradlePlugin;
 import net.fabricmc.loom.configuration.DependencyInfo;
 import net.fabricmc.loom.configuration.providers.mappings.tiny.MappingsMerger;
 import net.fabricmc.loom.configuration.providers.mappings.tiny.TinyJarInfo;
+import net.fabricmc.loom.configuration.providers.mappings.unpick.UnpickMetadata;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.DeletingFileVisitor;
@@ -76,7 +76,7 @@ public class MappingConfiguration {
 	public final Path tinyMappingsJar;
 	private final Path unpickDefinitions;
 
-	private boolean hasUnpickDefinitions;
+	@Nullable
 	private UnpickMetadata unpickMetadata;
 	private Map<String, String> signatureFixes;
 
@@ -145,14 +145,17 @@ public class MappingConfiguration {
 	}
 
 	public void applyToProject(Project project, DependencyInfo dependency) {
-		if (hasUnpickDefinitions()) {
-			String notation = String.format("%s:%s:%s:constants",
-					dependency.getDependency().getGroup(),
-					dependency.getDependency().getName(),
-					dependency.getDependency().getVersion()
-			);
+		if (unpickMetadata != null) {
+			if (unpickMetadata.hasConstants()) {
+				String notation = String.format("%s:%s:%s:constants",
+						dependency.getDependency().getGroup(),
+						dependency.getDependency().getName(),
+						dependency.getDependency().getVersion()
+				);
 
-			project.getDependencies().add(Constants.Configurations.MAPPING_CONSTANTS, notation);
+				project.getDependencies().add(Constants.Configurations.MAPPING_CONSTANTS, notation);
+			}
+
 			populateUnpickClasspath(project);
 		}
 
@@ -218,8 +221,8 @@ public class MappingConfiguration {
 	}
 
 	private void extractUnpickDefinitions(FileSystem jar) throws IOException {
-		Path unpickPath = jar.getPath("extras/definitions.unpick");
-		Path unpickMetadataPath = jar.getPath("extras/unpick.json");
+		Path unpickPath = jar.getPath(UnpickMetadata.UNPICK_DEFINITIONS_PATH);
+		Path unpickMetadataPath = jar.getPath(UnpickMetadata.UNPICK_METADATA_PATH);
 
 		if (!Files.exists(unpickPath) || !Files.exists(unpickMetadataPath)) {
 			return;
@@ -227,8 +230,7 @@ public class MappingConfiguration {
 
 		Files.copy(unpickPath, unpickDefinitions, StandardCopyOption.REPLACE_EXISTING);
 
-		unpickMetadata = parseUnpickMetadata(unpickMetadataPath);
-		hasUnpickDefinitions = true;
+		unpickMetadata = UnpickMetadata.parse(unpickMetadataPath);
 	}
 
 	private void extractSignatureFixes(FileSystem jar) throws IOException {
@@ -244,23 +246,14 @@ public class MappingConfiguration {
 		}
 	}
 
-	private UnpickMetadata parseUnpickMetadata(Path input) throws IOException {
-		JsonObject jsonObject = LoomGradlePlugin.GSON.fromJson(Files.readString(input, StandardCharsets.UTF_8), JsonObject.class);
-
-		if (!jsonObject.has("version") || jsonObject.get("version").getAsInt() != 1) {
-			throw new UnsupportedOperationException("Unsupported unpick version");
-		}
-
-		return new UnpickMetadata(
-				jsonObject.get("unpickGroup").getAsString(),
-				jsonObject.get("unpickVersion").getAsString()
-		);
-	}
-
 	private void populateUnpickClasspath(Project project) {
+		// TODO remove when adding support for V2
+		// This wont be added as we will ignore the unpick version in V1 metadata's
+		UnpickMetadata.V1 metadata = (UnpickMetadata.V1) unpickMetadata;
+
 		String unpickCliName = "unpick-cli";
 		project.getDependencies().add(Constants.Configurations.UNPICK_CLASSPATH,
-				String.format("%s:%s:%s", unpickMetadata.unpickGroup, unpickCliName, unpickMetadata.unpickVersion)
+				String.format("%s:%s:%s", metadata.unpickGroup(), unpickCliName, metadata.unpickVersion())
 		);
 
 		// Unpick ships with a slightly older version of asm, ensure it runs with at least the same version as loom.
@@ -324,18 +317,11 @@ public class MappingConfiguration {
 	}
 
 	public boolean hasUnpickDefinitions() {
-		return hasUnpickDefinitions;
+		return unpickMetadata != null;
 	}
 
 	@Nullable
 	public Map<String, String> getSignatureFixes() {
 		return signatureFixes;
-	}
-
-	public String getBuildServiceName(String name, String from, String to) {
-		return "%s:%s:%s>%S".formatted(name, mappingsIdentifier(), from, to);
-	}
-
-	public record UnpickMetadata(String unpickGroup, String unpickVersion) {
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsLayer.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsLayer.java
@@ -36,6 +36,7 @@ import net.fabricmc.loom.api.mappings.layered.MappingLayer;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.configuration.providers.mappings.extras.unpick.UnpickLayer;
 import net.fabricmc.loom.configuration.providers.mappings.intermediary.IntermediaryMappingLayer;
+import net.fabricmc.loom.configuration.providers.mappings.unpick.UnpickMetadata;
 import net.fabricmc.loom.util.FileSystemUtil;
 import net.fabricmc.loom.util.ZipUtils;
 import net.fabricmc.mappingio.MappingReader;
@@ -52,9 +53,6 @@ public record FileMappingsLayer(
 		boolean unpick,
 		String mergeNamespace
 ) implements MappingLayer, UnpickLayer {
-	private static final String UNPICK_METADATA_PATH = "extras/unpick.json";
-	private static final String UNPICK_DEFINITIONS_PATH = "extras/definitions.unpick";
-
 	@Override
 	public void visit(MappingVisitor mappingVisitor) throws IOException {
 		// Bare file
@@ -102,8 +100,8 @@ public record FileMappingsLayer(
 		}
 
 		try (FileSystemUtil.Delegate fileSystem = FileSystemUtil.getJarFileSystem(path)) {
-			final Path unpickMetadata = fileSystem.get().getPath(UNPICK_METADATA_PATH);
-			final Path unpickDefinitions = fileSystem.get().getPath(UNPICK_DEFINITIONS_PATH);
+			final Path unpickMetadata = fileSystem.get().getPath(UnpickMetadata.UNPICK_METADATA_PATH);
+			final Path unpickDefinitions = fileSystem.get().getPath(UnpickMetadata.UNPICK_DEFINITIONS_PATH);
 
 			if (!Files.exists(unpickMetadata)) {
 				// No unpick in this zip

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/unpick/UnpickMetadata.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/unpick/UnpickMetadata.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2022 FabricMC
+ * Copyright (c) 2025 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,27 +22,47 @@
  * SOFTWARE.
  */
 
-package net.fabricmc.loom.configuration.providers.mappings.extras.unpick;
+package net.fabricmc.loom.configuration.providers.mappings.unpick;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
+import com.google.gson.JsonObject;
 
-import net.fabricmc.loom.configuration.providers.mappings.unpick.UnpickMetadata;
+import net.fabricmc.loom.LoomGradlePlugin;
 
-@ApiStatus.Experimental
-public interface UnpickLayer {
-	@Nullable
-	UnpickData getUnpickData() throws IOException;
+public sealed interface UnpickMetadata permits UnpickMetadata.V1 {
+	String UNPICK_METADATA_PATH = "extras/unpick.json";
+	String UNPICK_DEFINITIONS_PATH = "extras/definitions.unpick";
 
-	record UnpickData(UnpickMetadata metadata, byte[] rawMetadata, byte[] definitions) {
-		public static UnpickData read(Path metadataPath, Path definitionPath) throws IOException {
-			final byte[] definitions = Files.readAllBytes(definitionPath);
-			final byte[] metadata = Files.readAllBytes(metadataPath);
-			return new UnpickData(UnpickMetadata.parse(metadataPath), metadata, definitions);
+	boolean hasConstants();
+
+	record V1(String unpickGroup, String unpickVersion) implements UnpickMetadata {
+		@Override
+		public boolean hasConstants() {
+			return true;
+		}
+	}
+
+	static UnpickMetadata parse(Path path) throws IOException {
+		JsonObject jsonObject = LoomGradlePlugin.GSON.fromJson(Files.readString(path, StandardCharsets.UTF_8), JsonObject.class);
+
+		if (!jsonObject.has("version")) {
+			throw new UnsupportedOperationException("Missing unpick metadata version");
+		}
+
+		int version = jsonObject.get("version").getAsInt();
+
+		switch (version) {
+		case 1 -> {
+			return new V1(
+					jsonObject.get("unpickGroup").getAsString(),
+					jsonObject.get("unpickVersion").getAsString()
+			);
+		}
+		default -> throw new UnsupportedOperationException("Unsupported unpick metadata version: %s. Please update loom.".formatted(version));
 		}
 	}
 }

--- a/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
@@ -36,9 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -50,13 +48,10 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.services.ServiceReference;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
@@ -74,8 +69,6 @@ import org.gradle.workers.WorkerExecutor;
 import org.gradle.workers.internal.WorkerDaemonClientsManager;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import net.fabricmc.loom.api.decompilers.DecompilationMetadata;
 import net.fabricmc.loom.api.decompilers.DecompilerOptions;
@@ -88,13 +81,13 @@ import net.fabricmc.loom.decompilers.cache.CachedData;
 import net.fabricmc.loom.decompilers.cache.CachedFileStoreImpl;
 import net.fabricmc.loom.decompilers.cache.CachedJarProcessor;
 import net.fabricmc.loom.task.service.SourceMappingsService;
+import net.fabricmc.loom.task.service.UnpickService;
 import net.fabricmc.loom.util.Checksum;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.ExceptionUtil;
 import net.fabricmc.loom.util.FileSystemUtil;
 import net.fabricmc.loom.util.IOStringConsumer;
 import net.fabricmc.loom.util.Platform;
-import net.fabricmc.loom.util.SLF4JAdapterHandler;
 import net.fabricmc.loom.util.gradle.GradleUtils;
 import net.fabricmc.loom.util.gradle.SyncTaskBuildService;
 import net.fabricmc.loom.util.gradle.ThreadedProgressLoggerConsumer;
@@ -104,6 +97,7 @@ import net.fabricmc.loom.util.gradle.daemon.DaemonUtils;
 import net.fabricmc.loom.util.ipc.IPCClient;
 import net.fabricmc.loom.util.ipc.IPCServer;
 import net.fabricmc.loom.util.service.ScopedServiceFactory;
+import net.fabricmc.loom.util.service.ServiceFactory;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
 @UntrackedTask(because = "Manually invoked, has internal caching")
@@ -132,28 +126,6 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 	// Contains the remapped linenumbers
 	@OutputFile
 	protected abstract ConfigurableFileCollection getClassesOutputJar(); // Single jar
-
-	// Unpick
-	@InputFile
-	@Optional
-	public abstract RegularFileProperty getUnpickDefinitions();
-
-	@InputFiles
-	@Optional
-	public abstract ConfigurableFileCollection getUnpickConstantJar();
-
-	@InputFiles
-	@Optional
-	public abstract ConfigurableFileCollection getUnpickClasspath();
-
-	@InputFiles
-	@Optional
-	@ApiStatus.Internal
-	public abstract ConfigurableFileCollection getUnpickRuntimeClasspath();
-
-	@OutputFile
-	@Optional
-	public abstract RegularFileProperty getUnpickOutputJar();
 
 	@Input
 	@Option(option = "use-cache", description = "Use the decompile cache")
@@ -199,6 +171,10 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 	@Nested
 	protected abstract Property<DaemonUtils.Context> getDaemonUtilsContext();
 
+	@Nested
+	@Optional
+	protected abstract Property<UnpickService.Options> getUnpickOptions();
+
 	// Prevent Gradle from running two gen sources tasks in parallel
 	@ServiceReference(SyncTaskBuildService.NAME)
 	abstract Property<SyncTaskBuildService> getSyncTask();
@@ -241,7 +217,6 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 
 		getMinecraftCompileLibraries().from(getProject().getConfigurations().getByName(Constants.Configurations.MINECRAFT_COMPILE_LIBRARIES));
 		getDecompileCacheFile().set(getExtension().getFiles().getDecompileCache(CACHE_VERSION));
-		getUnpickRuntimeClasspath().from(getProject().getConfigurations().getByName(Constants.Configurations.UNPICK_CLASSPATH));
 
 		getUseCache().convention(true);
 		getResetCache().convention(getExtension().refreshDeps());
@@ -252,6 +227,8 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 		getMaxCacheFileAge().set(GradleUtils.getIntegerPropertyProvider(getProject(), Constants.Properties.DECOMPILE_CACHE_MAX_AGE).orElse(90));
 
 		getDaemonUtilsContext().set(getProject().getObjects().newInstance(DaemonUtils.Context.class, getProject()));
+
+		getUnpickOptions().set(UnpickService.createOptions(this));
 
 		mustRunAfter(getProject().getTasks().withType(AbstractRemapJarTask.class));
 	}
@@ -264,57 +241,59 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 			throw new UnsupportedOperationException("GenSources task requires a 64bit JVM to run due to the memory requirements.");
 		}
 
-		if (!getUseCache().get()) {
-			getLogger().info("Not using decompile cache.");
+		try (ScopedServiceFactory serviceFactory = new ScopedServiceFactory()) {
+			if (!getUseCache().get()) {
+				getLogger().info("Not using decompile cache.");
 
-			try (var timer = new Timer("Decompiled sources")) {
-				runWithoutCache();
+				try (var timer = new Timer("Decompiled sources")) {
+					runWithoutCache(serviceFactory);
+				} catch (Exception e) {
+					ExceptionUtil.processException(e, getDaemonUtilsContext().get());
+					throw ExceptionUtil.createDescriptiveWrapper(RuntimeException::new, "Failed to decompile", e);
+				}
+
+				return;
+			}
+
+			getLogger().info("Using decompile cache.");
+
+			try (var timer = new Timer("Decompiled sources with cache")) {
+				final Path cacheFile = getDecompileCacheFile().getAsFile().get().toPath();
+
+				if (getResetCache().get()) {
+					getLogger().warn("Resetting decompile cache");
+					Files.deleteIfExists(cacheFile);
+				}
+
+				// TODO ensure we have a lock on this file to prevent multiple tasks from running at the same time
+				Files.createDirectories(cacheFile.getParent());
+
+				if (Files.exists(cacheFile)) {
+					try (FileSystemUtil.Delegate fs = FileSystemUtil.getJarFileSystem(cacheFile, true)) {
+						// Success, cache exists and can be read
+					} catch (IOException e) {
+						getLogger().warn("Discarding invalid decompile cache file: {}", cacheFile, e);
+						Files.delete(cacheFile);
+					}
+				}
+
+				try (FileSystemUtil.Delegate fs = FileSystemUtil.getJarFileSystem(cacheFile, true)) {
+					runWithCache(serviceFactory, fs.getRoot());
+				}
 			} catch (Exception e) {
 				ExceptionUtil.processException(e, getDaemonUtilsContext().get());
 				throw ExceptionUtil.createDescriptiveWrapper(RuntimeException::new, "Failed to decompile", e);
 			}
-
-			return;
-		}
-
-		getLogger().info("Using decompile cache.");
-
-		try (var timer = new Timer("Decompiled sources with cache")) {
-			final Path cacheFile = getDecompileCacheFile().getAsFile().get().toPath();
-
-			if (getResetCache().get()) {
-				getLogger().warn("Resetting decompile cache");
-				Files.deleteIfExists(cacheFile);
-			}
-
-			// TODO ensure we have a lock on this file to prevent multiple tasks from running at the same time
-			Files.createDirectories(cacheFile.getParent());
-
-			if (Files.exists(cacheFile)) {
-				try (FileSystemUtil.Delegate fs = FileSystemUtil.getJarFileSystem(cacheFile, true)) {
-					// Success, cache exists and can be read
-				} catch (IOException e) {
-					getLogger().warn("Discarding invalid decompile cache file: {}", cacheFile, e);
-					Files.delete(cacheFile);
-				}
-			}
-
-			try (FileSystemUtil.Delegate fs = FileSystemUtil.getJarFileSystem(cacheFile, true)) {
-				runWithCache(fs.getRoot());
-			}
-		} catch (Exception e) {
-			ExceptionUtil.processException(e, getDaemonUtilsContext().get());
-			throw ExceptionUtil.createDescriptiveWrapper(RuntimeException::new, "Failed to decompile", e);
 		}
 	}
 
-	private void runWithCache(Path cacheRoot) throws IOException {
+	private void runWithCache(ServiceFactory serviceFactory, Path cacheRoot) throws IOException {
 		final Path classesInputJar = getClassesInputJar().getSingleFile().toPath();
 		final Path sourcesOutputJar = getSourcesOutputJar().get().getAsFile().toPath();
 		final Path classesOutputJar = getClassesOutputJar().getSingleFile().toPath();
 		final var cacheRules = new CachedFileStoreImpl.CacheRules(getMaxCachedFiles().get(), Duration.ofDays(getMaxCacheFileAge().get()));
 		final var decompileCache = new CachedFileStoreImpl<>(cacheRoot, CachedData.SERIALIZER, cacheRules);
-		final String cacheKey = getCacheKey();
+		final String cacheKey = getCacheKey(serviceFactory);
 		final CachedJarProcessor cachedJarProcessor = new CachedJarProcessor(decompileCache, cacheKey);
 		final CachedJarProcessor.WorkRequest workRequest;
 
@@ -336,9 +315,10 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 			Path workInputJar = workToDoJob.incomplete();
 			@Nullable Path existingClasses = (job instanceof CachedJarProcessor.PartialWorkJob partialWorkJob) ? partialWorkJob.existingClasses() : null;
 
-			if (getUnpickDefinitions().isPresent()) {
+			if (usingUnpick()) {
 				try (var timer = new Timer("Unpick")) {
-					workInputJar = unpickJar(workInputJar, existingClasses);
+					UnpickService unpick = serviceFactory.get(getUnpickOptions());
+					workInputJar = unpick.unpickJar(getWorkerExecutor(), workInputJar, existingClasses);
 				}
 			}
 
@@ -373,16 +353,17 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 		}
 	}
 
-	private void runWithoutCache() throws IOException {
+	private void runWithoutCache(ServiceFactory serviceFactory) throws IOException {
 		final Path classesInputJar = getClassesInputJar().getSingleFile().toPath();
 		final Path sourcesOutputJar = getSourcesOutputJar().get().getAsFile().toPath();
 		final Path classesOutputJar = getClassesOutputJar().getSingleFile().toPath();
 
 		Path workClassesJar = classesInputJar;
 
-		if (getUnpickDefinitions().isPresent()) {
+		if (usingUnpick()) {
 			try (var timer = new Timer("Unpick")) {
-				workClassesJar = unpickJar(workClassesJar, null);
+				UnpickService unpick = serviceFactory.get(getUnpickOptions());
+				workClassesJar = unpick.unpickJar(getWorkerExecutor(), workClassesJar, null);
 			}
 		}
 
@@ -417,10 +398,14 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 		Files.move(tempJar, classesOutputJar, StandardCopyOption.REPLACE_EXISTING);
 	}
 
-	private String getCacheKey() {
+	private String getCacheKey(ServiceFactory serviceFactory) {
 		var sj = new StringJoiner(",");
 		sj.add(getDecompilerCheckKey());
-		sj.add(getUnpickCacheKey());
+
+		if (usingUnpick()) {
+			UnpickService unpick = serviceFactory.get(getUnpickOptions());
+			sj.add(unpick.getUnpickCacheKey());
+		}
 
 		getLogger().info("Decompile cache data: {}", sj);
 
@@ -434,24 +419,11 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 	private String getDecompilerCheckKey() {
 		var sj = new StringJoiner(",");
 		sj.add(decompilerOptions.getDecompilerClassName().get());
-		sj.add(fileCollectionHash(decompilerOptions.getClasspath()));
+		sj.add(Checksum.fileCollectionHash(decompilerOptions.getClasspath()));
 
 		for (Map.Entry<String, String> entry : decompilerOptions.getOptions().get().entrySet()) {
 			sj.add(entry.getKey() + "=" + entry.getValue());
 		}
-
-		return sj.toString();
-	}
-
-	private String getUnpickCacheKey() {
-		if (!getUnpickDefinitions().isPresent()) {
-			return "";
-		}
-
-		var sj = new StringJoiner(",");
-		sj.add(fileHash(getUnpickDefinitions().getAsFile().get()));
-		sj.add(fileCollectionHash(getUnpickConstantJar()));
-		sj.add(fileCollectionHash(getUnpickRuntimeClasspath()));
 
 		return sj.toString();
 	}
@@ -483,45 +455,6 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 		}
 
 		return readLineNumbers(lineMapFile);
-	}
-
-	private Path unpickJar(Path inputJar, @Nullable Path existingClasses) {
-		final Path outputJar = getUnpickOutputJar().get().getAsFile().toPath();
-		final List<String> args = getUnpickArgs(inputJar, outputJar, existingClasses);
-
-		WorkQueue workQueue = getWorkerExecutor().classLoaderIsolation(spec -> {
-			spec.getClasspath().from(getUnpickRuntimeClasspath());
-		});
-
-		workQueue.submit(UnpickAction.class, params -> {
-			params.getMainClass().set("daomephsta.unpick.cli.Main");
-			params.getArgs().set(args);
-		});
-
-		workQueue.await();
-
-		return outputJar;
-	}
-
-	private List<String> getUnpickArgs(Path inputJar, Path outputJar, @Nullable Path existingClasses) {
-		var fileArgs = new ArrayList<File>();
-
-		fileArgs.add(inputJar.toFile());
-		fileArgs.add(outputJar.toFile());
-		fileArgs.add(getUnpickDefinitions().get().getAsFile());
-		fileArgs.add(getUnpickConstantJar().getSingleFile());
-
-		for (File file : getUnpickClasspath()) {
-			fileArgs.add(file);
-		}
-
-		if (existingClasses != null) {
-			fileArgs.add(existingClasses.toFile());
-		}
-
-		return fileArgs.stream()
-				.map(File::getAbsolutePath)
-				.toList();
 	}
 
 	private void remapLineNumbers(ClassLineNumbers lineNumbers, Path inputJar, Path outputJar) throws IOException {
@@ -596,28 +529,8 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 		return !Boolean.getBoolean("fabric.loom.genSources.debug");
 	}
 
-	public interface UnpickParams extends WorkParameters {
-		Property<String> getMainClass();
-		ListProperty<String> getArgs();
-	}
-
-	public abstract static class UnpickAction implements WorkAction<UnpickParams> {
-		private static final Logger LOGGER = LoggerFactory.getLogger(UnpickAction.class);
-
-		@Override
-		public void execute() {
-			java.util.logging.Logger logger = java.util.logging.Logger.getLogger("unpick");
-			logger.setUseParentHandlers(false);
-			logger.addHandler(new SLF4JAdapterHandler(LOGGER, true));
-
-			try {
-				Class<?> unpickEntrypoint = Class.forName(getParameters().getMainClass().get());
-				unpickEntrypoint.getMethod("main", String[].class)
-						.invoke(null, (Object) getParameters().getArgs().get().toArray(String[]::new));
-			} catch (ClassNotFoundException | InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
-				throw new RuntimeException("Failed to run unpick", e);
-			}
-		}
+	private boolean usingUnpick() {
+		return getUnpickOptions().isPresent();
 	}
 
 	public interface DecompileParams extends WorkParameters {
@@ -734,26 +647,6 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 		} catch (ClassNotFoundException e) {
 			throw new RuntimeException(e);
 		}
-	}
-
-	private static String fileHash(File file) {
-		try {
-			return Checksum.sha256Hex(Files.readAllBytes(file.toPath()));
-		} catch (IOException e) {
-			throw new UncheckedIOException(e);
-		}
-	}
-
-	private static String fileCollectionHash(FileCollection files) {
-		var sj = new StringJoiner(",");
-
-		files.getFiles()
-				.stream()
-				.sorted(Comparator.comparing(File::getAbsolutePath))
-				.map(GenerateSourcesTask::fileHash)
-				.forEach(sj::add);
-
-		return sj.toString();
 	}
 
 	public interface MappingsProcessor {

--- a/src/main/java/net/fabricmc/loom/task/service/UnpickService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/UnpickService.java
@@ -82,16 +82,16 @@ public class UnpickService extends Service<UnpickService.Options> {
 
 	public static Provider<Options> createOptions(GenerateSourcesTask task) {
 		final Project project = task.getProject();
-
-		return TYPE.create(project, options -> {
-			ConfigurationContainer configurations = project.getConfigurations();
+		return TYPE.maybeCreate(project, options -> {
 			LoomGradleExtension extension = LoomGradleExtension.get(project);
 			MappingConfiguration mappingConfiguration = extension.getMappingConfiguration();
-			File mappingsWorkingDir = mappingConfiguration.mappingsWorkingDir().toFile();
 
 			if (!mappingConfiguration.hasUnpickDefinitions()) {
-				throw new IllegalStateException("Unpick definitions not set");
+				return false;
 			}
+
+			ConfigurationContainer configurations = project.getConfigurations();
+			File mappingsWorkingDir = mappingConfiguration.mappingsWorkingDir().toFile();
 
 			options.getUnpickRuntimeClasspath().from(configurations.getByName(Constants.Configurations.UNPICK_CLASSPATH));
 			options.getUnpickDefinitions().set(mappingConfiguration.getUnpickDefinitionsFile());
@@ -101,6 +101,7 @@ public class UnpickService extends Service<UnpickService.Options> {
 			options.getUnpickClasspath().setFrom(configurations.getByName(Constants.Configurations.MINECRAFT_COMPILE_LIBRARIES));
 			options.getUnpickClasspath().from(configurations.getByName(Constants.Configurations.MOD_COMPILE_CLASSPATH_MAPPED));
 			extension.getMinecraftJars(MappingsNamespace.NAMED).forEach(options.getUnpickClasspath()::from);
+			return true;
 		});
 	}
 

--- a/src/main/java/net/fabricmc/loom/task/service/UnpickService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/UnpickService.java
@@ -1,0 +1,186 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.service;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.workers.WorkAction;
+import org.gradle.workers.WorkParameters;
+import org.gradle.workers.WorkQueue;
+import org.gradle.workers.WorkerExecutor;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
+import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
+import net.fabricmc.loom.task.GenerateSourcesTask;
+import net.fabricmc.loom.util.Checksum;
+import net.fabricmc.loom.util.Constants;
+import net.fabricmc.loom.util.SLF4JAdapterHandler;
+import net.fabricmc.loom.util.service.Service;
+import net.fabricmc.loom.util.service.ServiceFactory;
+import net.fabricmc.loom.util.service.ServiceType;
+
+public class UnpickService extends Service<UnpickService.Options> {
+	public static final ServiceType<Options, UnpickService> TYPE = new ServiceType<>(Options.class, UnpickService.class);
+
+	public interface Options extends Service.Options {
+		@InputFile
+		RegularFileProperty getUnpickDefinitions();
+
+		@InputFiles
+		ConfigurableFileCollection getUnpickConstantJar();
+
+		@InputFiles
+		ConfigurableFileCollection getUnpickClasspath();
+
+		@InputFiles
+		ConfigurableFileCollection getUnpickRuntimeClasspath();
+
+		@OutputFile
+		RegularFileProperty getUnpickOutputJar();
+	}
+
+	public static Provider<Options> createOptions(GenerateSourcesTask task) {
+		final Project project = task.getProject();
+
+		return TYPE.create(project, options -> {
+			ConfigurationContainer configurations = project.getConfigurations();
+			LoomGradleExtension extension = LoomGradleExtension.get(project);
+			MappingConfiguration mappingConfiguration = extension.getMappingConfiguration();
+			File mappingsWorkingDir = mappingConfiguration.mappingsWorkingDir().toFile();
+
+			if (!mappingConfiguration.hasUnpickDefinitions()) {
+				throw new IllegalStateException("Unpick definitions not set");
+			}
+
+			options.getUnpickRuntimeClasspath().from(configurations.getByName(Constants.Configurations.UNPICK_CLASSPATH));
+			options.getUnpickDefinitions().set(mappingConfiguration.getUnpickDefinitionsFile());
+			options.getUnpickOutputJar().set(task.getInputJarName().map(s -> project.getLayout()
+					.dir(project.provider(() -> mappingsWorkingDir)).get().file(s + "-unpicked.jar")));
+			options.getUnpickConstantJar().setFrom(configurations.getByName(Constants.Configurations.MAPPING_CONSTANTS));
+			options.getUnpickClasspath().setFrom(configurations.getByName(Constants.Configurations.MINECRAFT_COMPILE_LIBRARIES));
+			options.getUnpickClasspath().from(configurations.getByName(Constants.Configurations.MOD_COMPILE_CLASSPATH_MAPPED));
+			extension.getMinecraftJars(MappingsNamespace.NAMED).forEach(options.getUnpickClasspath()::from);
+		});
+	}
+
+	public UnpickService(Options options, ServiceFactory serviceFactory) {
+		super(options, serviceFactory);
+	}
+
+	public Path unpickJar(WorkerExecutor workerExecutor, Path inputJar, @Nullable Path existingClasses) {
+		final Path outputJar = getOptions().getUnpickOutputJar().get().getAsFile().toPath();
+		final List<String> args = getUnpickArgs(inputJar, outputJar, existingClasses);
+
+		WorkQueue workQueue = workerExecutor.classLoaderIsolation(spec -> {
+			spec.getClasspath().from(getOptions().getUnpickRuntimeClasspath());
+		});
+
+		workQueue.submit(UnpickAction.class, params -> {
+			params.getMainClass().set("daomephsta.unpick.cli.Main");
+			params.getArgs().set(args);
+		});
+
+		workQueue.await();
+
+		return outputJar;
+	}
+
+	private List<String> getUnpickArgs(Path inputJar, Path outputJar, @Nullable Path existingClasses) {
+		var fileArgs = new ArrayList<File>();
+
+		fileArgs.add(inputJar.toFile());
+		fileArgs.add(outputJar.toFile());
+		fileArgs.add(getOptions().getUnpickDefinitions().get().getAsFile());
+		fileArgs.add(getOptions().getUnpickConstantJar().getSingleFile());
+
+		for (File file : getOptions().getUnpickClasspath()) {
+			fileArgs.add(file);
+		}
+
+		if (existingClasses != null) {
+			fileArgs.add(existingClasses.toFile());
+		}
+
+		return fileArgs.stream()
+				.map(File::getAbsolutePath)
+				.toList();
+	}
+
+	public String getUnpickCacheKey() {
+		if (!getOptions().getUnpickDefinitions().isPresent()) {
+			return "";
+		}
+
+		var sj = new StringJoiner(",");
+		sj.add(Checksum.fileHash(getOptions().getUnpickDefinitions().getAsFile().get()));
+		sj.add(Checksum.fileCollectionHash(getOptions().getUnpickConstantJar()));
+		sj.add(Checksum.fileCollectionHash(getOptions().getUnpickRuntimeClasspath()));
+
+		return sj.toString();
+	}
+
+	public interface UnpickParams extends WorkParameters {
+		Property<String> getMainClass();
+		ListProperty<String> getArgs();
+	}
+
+	public abstract static class UnpickAction implements WorkAction<UnpickParams> {
+		private static final Logger LOGGER = LoggerFactory.getLogger(UnpickAction.class);
+
+		@Override
+		public void execute() {
+			java.util.logging.Logger logger = java.util.logging.Logger.getLogger("unpick");
+			logger.setUseParentHandlers(false);
+			logger.addHandler(new SLF4JAdapterHandler(LOGGER, true));
+
+			try {
+				Class<?> unpickEntrypoint = Class.forName(getParameters().getMainClass().get());
+				unpickEntrypoint.getMethod("main", String[].class)
+						.invoke(null, (Object) getParameters().getArgs().get().toArray(String[]::new));
+			} catch (ClassNotFoundException | InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
+				throw new RuntimeException("Failed to run unpick", e);
+			}
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/Checksum.java
+++ b/src/main/java/net/fabricmc/loom/util/Checksum.java
@@ -29,6 +29,8 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.StringJoiner;
 
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
@@ -36,6 +38,7 @@ import com.google.common.io.BaseEncoding;
 import com.google.common.io.ByteSource;
 import com.google.common.io.Files;
 import org.gradle.api.Project;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 
@@ -103,5 +106,25 @@ public class Checksum {
 		String str = project.getProjectDir().getAbsolutePath() + ":" + project.getPath();
 		String hex = sha1Hex(str.getBytes(StandardCharsets.UTF_8));
 		return hex.substring(hex.length() - 16);
+	}
+
+	public static String fileHash(File file) {
+		try {
+			return Checksum.sha256Hex(java.nio.file.Files.readAllBytes(file.toPath()));
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	public static String fileCollectionHash(FileCollection files) {
+		var sj = new StringJoiner(",");
+
+		files.getFiles()
+				.stream()
+				.sorted(Comparator.comparing(File::getAbsolutePath))
+				.map(Checksum::fileHash)
+				.forEach(sj::add);
+
+		return sj.toString();
 	}
 }

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -74,6 +74,7 @@ public class Constants {
 		public static final String LOADER_DEPENDENCIES = "loaderLibraries";
 		public static final String LOOM_DEVELOPMENT_DEPENDENCIES = "loomDevelopmentDependencies";
 		public static final String MAPPING_CONSTANTS = "mappingsConstants";
+		@Deprecated // TODO: Remove when replacing the unpick cli
 		public static final String UNPICK_CLASSPATH = "unpick";
 		/**
 		 * A configuration that behaves like {@code runtimeOnly} but is not

--- a/src/main/java/net/fabricmc/loom/util/service/ServiceType.java
+++ b/src/main/java/net/fabricmc/loom/util/service/ServiceType.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2024 FabricMC
+ * Copyright (c) 2024-2025 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,7 @@
 package net.fabricmc.loom.util.service;
 
 import java.lang.reflect.Method;
+import java.util.function.Function;
 
 import org.gradle.api.Action;
 import org.gradle.api.Project;
@@ -40,9 +41,22 @@ public record ServiceType<O extends Service.Options, S extends Service<O>>(Class
 	 * Create an instance of the options class for the given service class.
 	 * @param project The {@link Project} to create the options for.
 	 * @param action An action to configure the options.
-	 * @return The created options instance.
+	 * @return The created options provider.
 	 */
 	public Provider<O> create(Project project, Action<O> action) {
+		return maybeCreate(project, o -> {
+			action.execute(o);
+			return true;
+		});
+	}
+
+	/**
+	 * Maybe create an instance of the options class for the given service class.
+	 * @param project The {@link Project} to create the options for.
+	 * @param function A function to configure the options, returning true if the options should be created.
+	 * @return The created options provider.
+	 */
+	public Provider<O> maybeCreate(Project project, Function<O, Boolean> function) {
 		return project.provider(() -> {
 			O options = project.getObjects().newInstance(optionsClass);
 
@@ -54,8 +68,12 @@ public record ServiceType<O extends Service.Options, S extends Service<O>>(Class
 
 			options.getServiceClass().set(serviceClass.getName());
 			options.getServiceClass().finalizeValue();
-			action.execute(options);
-			return options;
+
+			if (function.apply(options)) {
+				return options;
+			}
+
+			return null;
 		});
 	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/UnpickLayerTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/UnpickLayerTest.groovy
@@ -27,6 +27,7 @@ package net.fabricmc.loom.test.unit.layeredmappings
 import net.fabricmc.loom.api.mappings.layered.spec.FileSpec
 import net.fabricmc.loom.configuration.providers.mappings.file.FileMappingsSpecBuilderImpl
 import net.fabricmc.loom.configuration.providers.mappings.intermediary.IntermediaryMappingsSpec
+import net.fabricmc.loom.configuration.providers.mappings.unpick.UnpickMetadata
 
 class UnpickLayerTest extends LayeredMappingsSpecification {
 	def "read unpick data from yarn"() {
@@ -41,7 +42,7 @@ class UnpickLayerTest extends LayeredMappingsSpecification {
 				)
 		def metadata = unpickData.metadata()
 		then:
-		metadata.version() == 1
+		metadata instanceof UnpickMetadata.V1
 		metadata.unpickGroup() == "net.fabricmc.unpick"
 		metadata.unpickVersion() == "2.2.0"
 


### PR DESCRIPTION
First pass at cleaning up the existing unpick code before adding V3 support. The main change in this PR is moving most of the unpick related code out of gen sources task into UnpickService and making preparations for a v2 file format.