### PR TITLE
Run tests against Gradle 9 M9

### DIFF
--- a/gradle/test.libs.versions.toml
+++ b/gradle/test.libs.versions.toml
@@ -7,7 +7,8 @@ java-debug = "0.53.1"
 mixin = "0.15.3+mixin.0.8.7"
 bouncycastle = "1.80"
 
-gradle-nightly = "9.0-20250421234138+0000"
+gradle-latest = "9.0.0-milestone-9"
+gradle-nightly = "9.1.0-20250608001320+0000"
 fabric-loader = "0.16.14"
 
 [libraries]
@@ -18,6 +19,7 @@ javalin = { module = "io.javalin:javalin", version.ref = "javalin" }
 mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 java-debug = { module = "com.microsoft.java:com.microsoft.java.debug.core", version.ref = "java-debug" }
 mixin = { module = "net.fabricmc:sponge-mixin", version.ref = "mixin" }
+gradle-latest = { module = "org.gradle:dummy", version.ref = "gradle-latest" }
 gradle-nightly = { module = "org.gradle:dummy", version.ref = "gradle-nightly" }
 fabric-loader = { module = "net.fabricmc:fabric-loader", version.ref = "fabric-loader" }
 bcprov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }

--- a/src/test/groovy/net/fabricmc/loom/test/LoomTestConstants.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/LoomTestConstants.groovy
@@ -39,7 +39,10 @@ class LoomTestConstants {
 		DEFAULT_GRADLE,
 		LoomTestVersions.GRADLE_LATEST.version(),
 		PRE_RELEASE_GRADLE
-	] : [DEFAULT_GRADLE]).shuffled().toArray()
+	] : [
+		DEFAULT_GRADLE,
+		LoomTestVersions.GRADLE_LATEST.version()
+	]).shuffled().toArray()
 
 	public static final File TEST_DIR = new File("./.gradle/test-files")
 

--- a/src/test/groovy/net/fabricmc/loom/test/LoomTestConstants.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/LoomTestConstants.groovy
@@ -37,6 +37,7 @@ class LoomTestConstants {
 	// Randomly sorted to ensure that all versions can run with a clean gradle home.
 	public final static List<String> STANDARD_TEST_VERSIONS = (NIGHTLY_EXISTS ? [
 		DEFAULT_GRADLE,
+		LoomTestVersions.GRADLE_LATEST.version(),
 		PRE_RELEASE_GRADLE
 	] : [DEFAULT_GRADLE]).shuffled().toArray()
 

--- a/src/test/groovy/net/fabricmc/loom/test/integration/FabricAPITest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/FabricAPITest.groovy
@@ -44,7 +44,7 @@ class FabricAPITest extends Specification implements GradleProjectTestTrait {
 		setup:
 		def gradle = gradleProject(
 				repo: "https://github.com/FabricMC/fabric.git",
-				commit: "d70d2c06bb8fafdb72c6778b29fb050618015ab3",
+				commit: "f84dc5662589fd56ac4b36a4b94920a15b1da29d",
 				version: version,
 				patch: "fabric_api"
 				)

--- a/src/test/groovy/net/fabricmc/loom/test/integration/FabricAPITest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/FabricAPITest.groovy
@@ -58,7 +58,7 @@ class FabricAPITest extends Specification implements GradleProjectTestTrait {
 				""".stripIndent()
 		}
 
-		def minecraftVersion = "1.21.4"
+		def minecraftVersion = "1.21.6-pre3"
 		def server = ServerRunner.create(gradle.projectDir, minecraftVersion)
 				.withMod(gradle.getOutputFile("fabric-api-999.0.0.jar"))
 

--- a/src/test/groovy/net/fabricmc/loom/test/integration/UnpickTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/UnpickTest.groovy
@@ -56,7 +56,10 @@ class UnpickTest extends Specification implements GradleProjectTestTrait {
 		result.output.contains(useCache ? "Using decompile cache." : "Not using decompile cache.")
 
 		where:
-		[version, useCache] << [STANDARD_TEST_VERSIONS, [true, false]].combinations()
+		[version, useCache] << [
+			STANDARD_TEST_VERSIONS,
+			[true, false]
+		].combinations()
 	}
 
 	def "unpick build"() {

--- a/src/test/groovy/net/fabricmc/loom/test/integration/UnpickTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/UnpickTest.groovy
@@ -56,8 +56,7 @@ class UnpickTest extends Specification implements GradleProjectTestTrait {
 		result.output.contains(useCache ? "Using decompile cache." : "Not using decompile cache.")
 
 		where:
-		version << STANDARD_TEST_VERSIONS
-		useCache << [true, false]
+		[version, useCache] << [STANDARD_TEST_VERSIONS, [true, false]].combinations()
 	}
 
 	def "unpick build"() {

--- a/src/test/resources/patches/fabric_api.patch
+++ b/src/test/resources/patches/fabric_api.patch
@@ -1,19 +1,20 @@
 diff --git a/build.gradle b/build.gradle
---- a/build.gradle	(revision d70d2c06bb8fafdb72c6778b29fb050618015ab3)
-+++ b/build.gradle	(date 1734958436644)
-@@ -13,7 +13,7 @@
+--- a/build.gradle	(revision f84dc5662589fd56ac4b36a4b94920a15b1da29d)
++++ b/build.gradle	(date 1749475915352)
+@@ -9,7 +9,7 @@
+ }
 
- def ENV = System.getenv()
-
--version = project.version + "+" + (ENV.GITHUB_RUN_NUMBER ? "" : "local-") + getBranch()
+ def branchProvider = providers.of(GitBranchValueSource.class) {}
+-version = project.version + "+" + (providers.environmentVariable("CI").present ? branchProvider.get().replace("/", "_") : "local")
 +version = "999.0.0"
  logger.lifecycle("Building Fabric: " + version)
 
  def metaProjects = [
-@@ -34,24 +34,7 @@
- import org.apache.commons.codec.digest.DigestUtils
+@@ -33,22 +33,8 @@
+ import java.net.http.HttpRequest
+ import java.net.http.HttpResponse
 
- def getSubprojectVersion(project) {
+-def getSubprojectVersion(Project project) {
 -	// Get the version from the gradle.properties file
 -	def version = project.properties["${project.name}-version"]
 -
@@ -21,32 +22,42 @@ diff --git a/build.gradle b/build.gradle
 -		throw new NullPointerException("Could not find version for " + project.name)
 -	}
 -
--	if (grgit == null) {
--		return version + "+nogit"
+-	if (!project.providers.environmentVariable("CI").present) {
+-		return version + "+local"
 -	}
 -
--	def latestCommits = grgit.log(paths: [project.name], maxCommits: 1)
--
--	if (latestCommits.isEmpty()) {
--		return version + "+uncommited"
+-	def hashProvider = project.providers.of(CommitHashValueSource.class) {
+-		parameters.directory = project.name
 -	}
--
--	return version + "+" + latestCommits.get(0).id.substring(0, 8) + DigestUtils.sha256Hex(project.rootProject.minecraft_version).substring(0, 2)
+-	return version + "+" + hashProvider.get().substring(0, 8) + DigestUtils.sha256Hex(project.rootProject.minecraft_version).substring(0, 2)
++def getSubprojectVersion(project) {
 +	return "999.0.0"
  }
 
- def getBranch() {
-@@ -250,10 +233,11 @@
- 	}
+ def moduleDependencies(project, List<String> depNames) {
+@@ -771,7 +757,7 @@
+ tasks.register('checkVersion') {
+ 	doFirst {
+ 		def xml = new URL("https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api/maven-metadata.xml").text
+-		def metadata = new XmlSlurper().parseText(xml)
++		def metadata = new groovy.xml.XmlSlurper().parseText(xml)
+ 		def versions = metadata.versioning.versions.version*.text();
+ 		if (versions.contains(version)) {
+ 			throw new RuntimeException("${version} has already been released!")
+Index: gradle/validate-annotations.gradle
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/gradle/validate-annotations.gradle b/gradle/validate-annotations.gradle
+--- a/gradle/validate-annotations.gradle	(revision f84dc5662589fd56ac4b36a4b94920a15b1da29d)
++++ b/gradle/validate-annotations.gradle	(date 1749476043862)
+@@ -13,7 +13,7 @@
 
- 	tasks.withType(ProcessResources).configureEach {
--		inputs.property "version", project.version
-+		def version = project.version
-+		inputs.property "version", version
+ tasks.check.dependsOn "validateAnnotations"
 
- 		filesMatching("fabric.mod.json") {
--			expand "version": project.version
-+			expand "version": version
- 		}
- 	}
+-class ValidateAnnotations extends SourceTask {
++abstract class ValidateAnnotations extends SourceTask {
+ 	private static final def API_STATUS_INTERNAL = ~/@ApiStatus\.Internal/
+ 	private static final def ENVIRONMENT = ~/@Environment/
 


### PR DESCRIPTION
The plan is to support both Gradle 8.14 and 9 for a little while as I expect the migration to 9 to be a bit painful for some. This PR runs the tests against 8.14, 9.0 and the latest nightly.