### PR TITLE
Fix layered mappings being dropped on none obfuscated classes.

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsFactory.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsFactory.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2021 FabricMC
+ * Copyright (c) 2021-2025 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,6 +36,7 @@ import java.util.Map;
 
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Dependency;
+import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,10 +51,12 @@ import net.fabricmc.loom.configuration.providers.mappings.extras.unpick.UnpickLa
 import net.fabricmc.loom.configuration.providers.mappings.unpick.UnpickMetadata;
 import net.fabricmc.loom.configuration.providers.mappings.utils.AddConstructorMappingVisitor;
 import net.fabricmc.loom.util.ZipUtils;
+import net.fabricmc.mappingio.MappingVisitor;
 import net.fabricmc.mappingio.adapter.MappingDstNsReorder;
 import net.fabricmc.mappingio.adapter.MappingSourceNsSwitch;
 import net.fabricmc.mappingio.format.tiny.Tiny2FileWriter;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
+import net.fabricmc.mappingio.tree.VisitableMappingTree;
 
 public record LayeredMappingsFactory(LayeredMappingSpec spec) {
 	private static final String GROUP = "loom";
@@ -120,14 +123,19 @@ public record LayeredMappingsFactory(LayeredMappingSpec spec) {
 		try (Writer writer = new StringWriter()) {
 			var tiny2Writer = new Tiny2FileWriter(writer, false);
 
-			MappingDstNsReorder nsReorder = new MappingDstNsReorder(tiny2Writer, List.of(MappingsNamespace.NAMED.toString(), MappingsNamespace.OFFICIAL.toString()));
-			MappingSourceNsSwitch nsSwitch = new MappingSourceNsSwitch(nsReorder, MappingsNamespace.INTERMEDIARY.toString(), true);
-			AddConstructorMappingVisitor addConstructor = new AddConstructorMappingVisitor(nsSwitch);
-			mappings.accept(addConstructor);
+			processMappings(mappings, tiny2Writer);
 
 			Files.deleteIfExists(mappingsFile);
 			ZipUtils.add(mappingsFile, "mappings/mappings.tiny", writer.toString().getBytes(StandardCharsets.UTF_8));
 		}
+	}
+
+	@VisibleForTesting
+	public static void processMappings(VisitableMappingTree mappings, MappingVisitor visitor) throws IOException {
+		MappingDstNsReorder nsReorder = new MappingDstNsReorder(visitor, List.of(MappingsNamespace.NAMED.toString(), MappingsNamespace.OFFICIAL.toString()));
+		MappingSourceNsSwitch nsSwitch = new MappingSourceNsSwitch(nsReorder, MappingsNamespace.INTERMEDIARY.toString(), false);
+		AddConstructorMappingVisitor addConstructor = new AddConstructorMappingVisitor(nsSwitch);
+		mappings.accept(addConstructor);
 	}
 
 	private void writeSignatureFixes(LayeredMappingsProcessor processor, List<MappingLayer> layers, Path mappingsFile) throws IOException {

--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingsSpecification.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingsSpecification.groovy
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2021 FabricMC
+ * Copyright (c) 2021-2025 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,10 +41,10 @@ import net.fabricmc.loom.api.mappings.layered.MappingsNamespace
 import net.fabricmc.loom.api.mappings.layered.spec.MappingsSpec
 import net.fabricmc.loom.configuration.providers.mappings.IntermediateMappingsService
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingSpec
+import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsFactory
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsProcessor
 import net.fabricmc.loom.configuration.providers.mappings.extras.unpick.UnpickLayer
 import net.fabricmc.loom.configuration.providers.mappings.intermediary.IntermediaryMappingLayer
-import net.fabricmc.loom.configuration.providers.mappings.utils.AddConstructorMappingVisitor
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider
 import net.fabricmc.loom.test.LoomTestConstants
 import net.fabricmc.loom.test.unit.LoomMocks
@@ -52,8 +52,6 @@ import net.fabricmc.loom.util.Constants
 import net.fabricmc.loom.util.download.Download
 import net.fabricmc.loom.util.download.DownloadBuilder
 import net.fabricmc.mappingio.MappingReader
-import net.fabricmc.mappingio.adapter.MappingDstNsReorder
-import net.fabricmc.mappingio.adapter.MappingSourceNsSwitch
 import net.fabricmc.mappingio.format.tiny.Tiny2FileWriter
 import net.fabricmc.mappingio.tree.MemoryMappingTree
 
@@ -127,10 +125,7 @@ abstract class LayeredMappingsSpecification extends Specification implements Lay
 
 	MemoryMappingTree reorder(MemoryMappingTree mappingTree) {
 		def reorderedMappings = new MemoryMappingTree()
-		def nsReorder = new MappingDstNsReorder(reorderedMappings, Collections.singletonList(MappingsNamespace.NAMED.toString()))
-		def nsSwitch = new MappingSourceNsSwitch(nsReorder, MappingsNamespace.INTERMEDIARY.toString(), true)
-		def addConstructor = new AddConstructorMappingVisitor(nsSwitch)
-		mappingTree.accept(addConstructor)
+		LayeredMappingsFactory.processMappings(mappingTree, reorderedMappings)
 		return reorderedMappings
 	}
 

--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingsTestConstants.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingsTestConstants.groovy
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2021-2022 FabricMC
+ * Copyright (c) 2021-2025 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,6 +29,7 @@ import net.fabricmc.loom.configuration.providers.minecraft.MinecraftVersionMeta
 interface LayeredMappingsTestConstants {
 	public static final String INTERMEDIARY_1_17_URL = "https://maven.fabricmc.net/net/fabricmc/intermediary/1.17/intermediary-1.17-v2.jar"
 	public static final String INTERMEDIARY_1_16_5_URL = "https://maven.fabricmc.net/net/fabricmc/intermediary/1.16.5/intermediary-1.16.5-v2.jar"
+	public static final String INTERMEDIARY_1_21_5_URL = "https://maven.fabricmc.net/net/fabricmc/intermediary/1.21.5/intermediary-1.21.5-v2.jar"
 
 	public static final Map<String, MinecraftVersionMeta.Download> DOWNLOADS_1_17 = [
 		client_mappings: new MinecraftVersionMeta.Download(null, "227d16f520848747a59bef6f490ae19dc290a804", 6431705, "https://launcher.mojang.com/v1/objects/227d16f520848747a59bef6f490ae19dc290a804/client.txt"),
@@ -42,7 +43,16 @@ interface LayeredMappingsTestConstants {
 	]
 	public static final MinecraftVersionMeta VERSION_META_1_16_5 = new MinecraftVersionMeta(null, null, null, 0, DOWNLOADS_1_16_5, null, null, null, null, 0, "2021-01-14T16:05:32+00:00", null, null, null)
 
-	public static final String PARCHMENT_NOTATION = "org.parchmentmc.data:parchment-1.16.5:20210608-SNAPSHOT@zip"
-	public static final String PARCHMENT_URL = "https://maven.parchmentmc.net/org/parchmentmc/data/parchment-1.16.5/20210608-SNAPSHOT/parchment-1.16.5-20210608-SNAPSHOT.zip"
+	public static final Map<String, MinecraftVersionMeta.Download> DOWNLOADS_1_21_5 = [
+		client_mappings: new MinecraftVersionMeta.Download(null, "57669731d542f98646772e91a0d68628f9827a5c", 10670987, "https://piston-data.mojang.com/v1/objects/57669731d542f98646772e91a0d68628f9827a5c/client.txt"),
+		server_mappings: new MinecraftVersionMeta.Download(null, "f4812c1d66d0098a94616b19c21829e591d0af3a", 8027211, "https://piston-data.mojang.com/v1/objects/f4812c1d66d0098a94616b19c21829e591d0af3a/server.txt")
+	]
+	public static final MinecraftVersionMeta VERSION_META_1_21_5 = new MinecraftVersionMeta(null, null, null, 0, DOWNLOADS_1_21_5, null, null, null, null, 0, "2025-03-25T12:14:58+00:00", null, null, null)
+
+	public static final String PARCHMENT_1_16_NOTATION = "org.parchmentmc.data:parchment-1.16.5:20210608-SNAPSHOT@zip"
+	public static final String PARCHMENT_1_16_URL = "https://maven.parchmentmc.net/org/parchmentmc/data/parchment-1.16.5/20210608-SNAPSHOT/parchment-1.16.5-20210608-SNAPSHOT.zip"
+	public static final String PARCHMENT_1_21_5_NOTATION = "org.parchmentmc.data:parchment-1.21.5:2025.04.19@zip"
+	public static final String PARCHMENT_1_21_5_URL = "https://maven.parchmentmc.net/org/parchmentmc/data/parchment-1.16.5/20210608-SNAPSHOT/parchment-1.16.5-20210608-SNAPSHOT.zip"
+
 	public static final String YARN_1_17_URL = "https://maven.fabricmc.net/net/fabricmc/yarn/1.17%2Bbuild.13/yarn-1.17%2Bbuild.13-v2.jar"
 }

--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/ParchmentMappingLayerTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/ParchmentMappingLayerTest.groovy
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2021 FabricMC
+ * Copyright (c) 2021-2025 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,11 +36,11 @@ class ParchmentMappingLayerTest extends LayeredMappingsSpecification {
 		mockMinecraftProvider.getVersionInfo() >> VERSION_META_1_16_5
 		mockMinecraftProvider.minecraftVersion() >> "1.16.5"
 		when:
-		withMavenFile(PARCHMENT_NOTATION, downloadFile(PARCHMENT_URL, "parchment.zip"))
+		withMavenFile(PARCHMENT_1_16_NOTATION, downloadFile(PARCHMENT_1_16_URL, "parchment.zip"))
 		def mappings = getLayeredMappings(
 				new IntermediaryMappingsSpec(),
 				new MojangMappingsSpec(true),
-				new ParchmentMappingsSpec(FileSpec.create(PARCHMENT_NOTATION), false)
+				new ParchmentMappingsSpec(FileSpec.create(PARCHMENT_1_16_NOTATION), false)
 				)
 		def tiny = getTiny(mappings)
 		def reorderedMappings = reorder(mappings)
@@ -61,11 +61,11 @@ class ParchmentMappingLayerTest extends LayeredMappingsSpecification {
 		mockMinecraftProvider.getVersionInfo() >> VERSION_META_1_16_5
 		mockMinecraftProvider.minecraftVersion() >> "1.16.5"
 		when:
-		withMavenFile(PARCHMENT_NOTATION, downloadFile(PARCHMENT_URL, "parchment.zip"))
+		withMavenFile(PARCHMENT_1_16_NOTATION, downloadFile(PARCHMENT_1_16_URL, "parchment.zip"))
 		def mappings = getLayeredMappings(
 				new IntermediaryMappingsSpec(),
 				new MojangMappingsSpec(true),
-				new ParchmentMappingsSpec(FileSpec.create(PARCHMENT_NOTATION), true)
+				new ParchmentMappingsSpec(FileSpec.create(PARCHMENT_1_16_NOTATION), true)
 				)
 		def tiny = getTiny(mappings)
 		def reorderedMappings = reorder(mappings)
@@ -77,5 +77,28 @@ class ParchmentMappingLayerTest extends LayeredMappingsSpecification {
 		mappings.classes[0].getDstName(0) == "net/minecraft/class_2573"
 		mappings.classes[0].methods[0].args[0].srcName.hashCode() == 109757064
 		reorderedMappings.getClass("net/minecraft/class_2573").getMethod("method_10913", "(Lnet/minecraft/class_1799;Lnet/minecraft/class_1767;)V").args.size() > 0
+	}
+
+	def "Read 1.21.5 parchment mappings" () {
+		setup:
+		intermediaryUrl = INTERMEDIARY_1_21_5_URL
+		mockMinecraftProvider.getVersionInfo() >> VERSION_META_1_21_5
+		mockMinecraftProvider.minecraftVersion() >> "1.21.5"
+		when:
+		withMavenFile(PARCHMENT_1_21_5_NOTATION, downloadFile(PARCHMENT_1_21_5_URL, "parchment-1.21.5.zip"))
+		def mappings = getLayeredMappings(
+				new IntermediaryMappingsSpec(),
+				new MojangMappingsSpec(true),
+				new ParchmentMappingsSpec(FileSpec.create(PARCHMENT_1_21_5_NOTATION), true)
+				)
+		def reorderedMappings = reorder(mappings)
+		def named = reorderedMappings.getNamespaceId("named")
+		then:
+		mappings.srcNamespace == "named"
+		mappings.dstNamespaces == ["intermediary", "official"]
+		reorderedMappings.getClass("com/mojang/blaze3d/platform/GlStateManager", named)
+				.getMethod("_activeTexture", "(I)V", named)
+				.getArg(0, 0, null)
+				.getDstName(named) == "textureIn"
 	}
 }


### PR DESCRIPTION
See: https://github.com/FabricMC/fabric-loom/pull/1323#issuecomment-3001298955

The only functional change in this PR is `MappingSourceNsSwitch` no longer drops missing src namespace mappings, the rest is just test improvements (so this code isnt duplicated between the tests)