### PR TITLE
Disable jar verification by default

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftProvider.java
@@ -122,7 +122,7 @@ public abstract class MinecraftProvider {
 	}
 
 	private void verifyJars() throws IOException, SignatureVerificationFailure {
-		if (GradleUtils.getBooleanProperty(getProject(), Constants.Properties.DISABLE_MINECRAFT_VERIFICATION)) {
+		if (GradleUtils.getBooleanProperty(getProject(), Constants.Properties.DISABLE_MINECRAFT_VERIFICATION, true)) {
 			LOGGER.info("Skipping Minecraft jar verification!");
 		}
 

--- a/src/main/java/net/fabricmc/loom/util/gradle/GradleUtils.java
+++ b/src/main/java/net/fabricmc/loom/util/gradle/GradleUtils.java
@@ -103,7 +103,11 @@ public final class GradleUtils {
 	}
 
 	public static boolean getBooleanProperty(Project project, String key) {
-		return getBooleanPropertyProvider(project, key).getOrElse(false);
+		return getBooleanProperty(project, key, false);
+	}
+
+	public static boolean getBooleanProperty(Project project, String key, boolean defaultValue) {
+		return getBooleanPropertyProvider(project, key).getOrElse(defaultValue);
 	}
 
 	public static Object getProperty(Project project, String key) {

--- a/src/test/resources/projects/minimalBase/gradle.properties
+++ b/src/test/resources/projects/minimalBase/gradle.properties
@@ -1,0 +1,1 @@
+fabric.loom.disableMinecraftVerification=false


### PR DESCRIPTION
I dont have a good solution for old server jars that arent on Mojang's launcher meta.