### PR TITLE
Add task for launching Enigma against the intermediary jar in dev envs

### DIFF
--- a/gradle/runtime.libs.versions.toml
+++ b/gradle/runtime.libs.versions.toml
@@ -12,8 +12,9 @@ jetbrains-annotations = "26.0.2"
 native-support = "1.0.1"
 fabric-installer = "1.0.3"
 
-# Debug tools
+# Dev tools
 renderdoc = "1.37"
+enigma = "2.5.2"
 
 [libraries]
 # Decompilers
@@ -29,5 +30,6 @@ jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "j
 native-support = { module = "net.fabricmc:fabric-loom-native-support", version.ref = "native-support" }
 fabric-installer = { module = "net.fabricmc:fabric-installer", version.ref = "fabric-installer" }
 
-# Debug tools
+# Dev tools
 renderdoc = { module = "org.renderdoc:renderdoc", version.ref = "renderdoc" } # Not a maven dependency
+enigma-swing = { module = "cuchaz:enigma-swing", version.ref = "enigma" }

--- a/gradle/runtime.libs.versions.toml
+++ b/gradle/runtime.libs.versions.toml
@@ -14,7 +14,7 @@ fabric-installer = "1.0.3"
 
 # Dev tools
 renderdoc = "1.37"
-enigma = "2.5.2"
+enigma = "3.0.1"
 
 [libraries]
 # Decompilers

--- a/src/main/java/net/fabricmc/loom/task/tool/ModEnigmaTask.java
+++ b/src/main/java/net/fabricmc/loom/task/tool/ModEnigmaTask.java
@@ -24,6 +24,8 @@
 
 package net.fabricmc.loom.task.tool;
 
+import java.nio.file.Path;
+
 import javax.inject.Inject;
 
 import org.gradle.api.Project;
@@ -31,8 +33,9 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.Classpath;
-import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.UntrackedTask;
@@ -47,8 +50,9 @@ import net.fabricmc.loom.util.LoomVersions;
 public abstract class ModEnigmaTask extends AbstractLoomTask {
 	private static final String ENIGMA_MAIN_CLASS = "cuchaz.enigma.gui.Main";
 
-	@InputFile
-	public abstract RegularFileProperty getMinecraftJar(); // TODO: what do we do with split jars?
+	// Must be a ListProperty because the order matters.
+	@Input
+	public abstract ListProperty<Path> getMinecraftJars();
 
 	/**
 	 * The mapping file path. It must be a single Enigma-formatted file.
@@ -64,13 +68,10 @@ public abstract class ModEnigmaTask extends AbstractLoomTask {
 	protected abstract ExecOperations getExecOperations();
 
 	public ModEnigmaTask() {
-		getMinecraftJar().set(getProject().getLayout().file(getProject().provider(() -> {
+		getMinecraftJars().convention(getProject().provider(() -> {
 			// Only supports the common jar in split setups
-			return getExtension()
-					.getMinecraftJars(MappingsNamespace.INTERMEDIARY)
-					.getFirst()
-					.toFile();
-		})));
+			return getExtension().getMinecraftJars(MappingsNamespace.INTERMEDIARY);
+		}));
 		getToolClasspath().from(getEnigmaClasspath(getProject()));
 	}
 
@@ -85,7 +86,11 @@ public abstract class ModEnigmaTask extends AbstractLoomTask {
 			spec.getMainClass().set(ENIGMA_MAIN_CLASS);
 			spec.setClasspath(getToolClasspath());
 			spec.jvmArgs("-Xmx2048m");
-			spec.args("-jar", getMinecraftJar().get().getAsFile().getAbsolutePath());
+
+			for (Path path : getMinecraftJars().get()) {
+				spec.args("-jar", path.toAbsolutePath().toString());
+			}
+
 			spec.args("-mappings", getMappingFile().get().getAsFile().getAbsolutePath());
 		});
 	}

--- a/src/main/java/net/fabricmc/loom/task/tool/ModEnigmaTask.java
+++ b/src/main/java/net/fabricmc/loom/task/tool/ModEnigmaTask.java
@@ -24,6 +24,7 @@
 
 package net.fabricmc.loom.task.tool;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import javax.inject.Inject;
@@ -33,6 +34,9 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.problems.ProblemId;
+import org.gradle.api.problems.ProblemReporter;
+import org.gradle.api.problems.Problems;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
@@ -44,6 +48,7 @@ import org.jetbrains.annotations.ApiStatus;
 
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.task.AbstractLoomTask;
+import net.fabricmc.loom.util.LoomProblems;
 import net.fabricmc.loom.util.LoomVersions;
 
 /**
@@ -60,6 +65,7 @@ import net.fabricmc.loom.util.LoomVersions;
  */
 @UntrackedTask(because = "Enigma should always launch")
 public abstract class ModEnigmaTask extends AbstractLoomTask {
+	private static final ProblemId MAPPINGS_MISSING_PROBLEM = LoomProblems.problemId("mappings-missing", "Mapping file doesn't exist");
 	private static final String ENIGMA_MAIN_CLASS = "cuchaz.enigma.gui.Main";
 
 	// Must be a ListProperty because the order matters.
@@ -82,6 +88,10 @@ public abstract class ModEnigmaTask extends AbstractLoomTask {
 	@Inject
 	protected abstract ExecOperations getExecOperations();
 
+	@ApiStatus.Internal
+	@Inject
+	protected abstract Problems getProblems();
+
 	public ModEnigmaTask() {
 		getMinecraftJars().convention(getProject().provider(() -> getExtension().getMinecraftJars(MappingsNamespace.INTERMEDIARY)));
 		getToolClasspath().from(getEnigmaClasspath(getProject()));
@@ -94,6 +104,16 @@ public abstract class ModEnigmaTask extends AbstractLoomTask {
 
 	@TaskAction
 	public void launch() {
+		final Path mappingFile = getMappingFile().get().getAsFile().toPath().toAbsolutePath();
+
+		if (Files.notExists(mappingFile)) {
+			final ProblemReporter reporter = getProblems().getReporter();
+			reporter.throwing(new RuntimeException("Mapping file " + mappingFile + " doesn't exist"), MAPPINGS_MISSING_PROBLEM,
+					spec -> spec
+							.fileLocation(mappingFile.toString())
+							.solution("Create the missing mapping file. Remember to add it to the fabric.mod.json if needed!"));
+		}
+
 		getExecOperations().javaexec(spec -> {
 			spec.getMainClass().set(ENIGMA_MAIN_CLASS);
 			spec.setClasspath(getToolClasspath());
@@ -103,7 +123,7 @@ public abstract class ModEnigmaTask extends AbstractLoomTask {
 				spec.args("-jar", path.toAbsolutePath().toString());
 			}
 
-			spec.args("-mappings", getMappingFile().get().getAsFile().getAbsolutePath());
+			spec.args("-mappings", mappingFile.toString());
 		});
 	}
 }

--- a/src/main/java/net/fabricmc/loom/task/tool/ModEnigmaTask.java
+++ b/src/main/java/net/fabricmc/loom/task/tool/ModEnigmaTask.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.tool;
+
+import javax.inject.Inject;
+
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.UntrackedTask;
+import org.gradle.process.ExecOperations;
+import org.jetbrains.annotations.ApiStatus;
+
+import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
+import net.fabricmc.loom.task.AbstractLoomTask;
+import net.fabricmc.loom.util.LoomVersions;
+
+@UntrackedTask(because = "Enigma should always launch")
+public abstract class ModEnigmaTask extends AbstractLoomTask {
+	private static final String ENIGMA_MAIN_CLASS = "cuchaz.enigma.gui.Main";
+
+	@InputFile
+	public abstract RegularFileProperty getMinecraftJar(); // TODO: what do we do with split jars?
+
+	/**
+	 * The mapping file path. It must be a single Enigma-formatted file.
+	 */
+	@OutputFile
+	public abstract RegularFileProperty getMappingFile();
+
+	@Classpath
+	public abstract ConfigurableFileCollection getToolClasspath();
+
+	@ApiStatus.Internal
+	@Inject
+	protected abstract ExecOperations getExecOperations();
+
+	public ModEnigmaTask() {
+		getMinecraftJar().set(getProject().getLayout().file(getProject().provider(() -> {
+			// Only supports the common jar in split setups
+			return getExtension()
+					.getMinecraftJars(MappingsNamespace.INTERMEDIARY)
+					.getFirst()
+					.toFile();
+		})));
+		getToolClasspath().from(getEnigmaClasspath(getProject()));
+	}
+
+	private static FileCollection getEnigmaClasspath(Project project) {
+		final Dependency enigmaDep = project.getDependencies().create(LoomVersions.ENIGMA_SWING.mavenNotation());
+		return project.getConfigurations().detachedConfiguration(enigmaDep);
+	}
+
+	@TaskAction
+	public void launch() {
+		getExecOperations().javaexec(spec -> {
+			spec.getMainClass().set(ENIGMA_MAIN_CLASS);
+			spec.setClasspath(getToolClasspath());
+			spec.jvmArgs("-Xmx2048m");
+			spec.args("-jar", getMinecraftJar().get().getAsFile().getAbsolutePath());
+			spec.args("-mappings", getMappingFile().get().getAsFile().getAbsolutePath());
+		});
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/tool/ModEnigmaTask.java
+++ b/src/main/java/net/fabricmc/loom/task/tool/ModEnigmaTask.java
@@ -46,6 +46,18 @@ import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.task.AbstractLoomTask;
 import net.fabricmc.loom.util.LoomVersions;
 
+/**
+ * Add this task to a mod development environment to use Enigma against the game jars.
+ * This can be used for writing mod-provided javadoc etc.
+ *
+ * <p>Usage:
+ * {@snippet lang=groovy :
+ * tasks.register('enigma', ModEnigmaTask) {
+ * 	// Must be a single Enigma-formatted mapping file:
+ * 	mappingFile = file('src/main/resources/my_mod_data.enigma')
+ * }
+ * }
+ */
 @UntrackedTask(because = "Enigma should always launch")
 public abstract class ModEnigmaTask extends AbstractLoomTask {
 	private static final String ENIGMA_MAIN_CLASS = "cuchaz.enigma.gui.Main";
@@ -60,6 +72,9 @@ public abstract class ModEnigmaTask extends AbstractLoomTask {
 	@OutputFile
 	public abstract RegularFileProperty getMappingFile();
 
+	/**
+	 * The Enigma classpath. You can add any Enigma plugin files to this file collection.
+	 */
 	@Classpath
 	public abstract ConfigurableFileCollection getToolClasspath();
 
@@ -68,10 +83,7 @@ public abstract class ModEnigmaTask extends AbstractLoomTask {
 	protected abstract ExecOperations getExecOperations();
 
 	public ModEnigmaTask() {
-		getMinecraftJars().convention(getProject().provider(() -> {
-			// Only supports the common jar in split setups
-			return getExtension().getMinecraftJars(MappingsNamespace.INTERMEDIARY);
-		}));
+		getMinecraftJars().convention(getProject().provider(() -> getExtension().getMinecraftJars(MappingsNamespace.INTERMEDIARY)));
 		getToolClasspath().from(getEnigmaClasspath(getProject()));
 	}
 

--- a/src/main/java/net/fabricmc/loom/task/tool/ModEnigmaTask.java
+++ b/src/main/java/net/fabricmc/loom/task/tool/ModEnigmaTask.java
@@ -54,7 +54,7 @@ import net.fabricmc.loom.util.LoomVersions;
  * {@snippet lang=groovy :
  * tasks.register('enigma', ModEnigmaTask) {
  * 	// Must be a single Enigma-formatted mapping file:
- * 	mappingFile = file('src/main/resources/my_mod_data.enigma')
+ * 	mappingFile = file('src/main/resources/my_mod_data.mapping')
  * }
  * }
  */

--- a/src/main/java/net/fabricmc/loom/util/LoomProblems.java
+++ b/src/main/java/net/fabricmc/loom/util/LoomProblems.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util;
+
+import org.gradle.api.problems.ProblemGroup;
+import org.gradle.api.problems.ProblemId;
+
+public final class LoomProblems {
+	public static final ProblemGroup PROBLEM_GROUP = ProblemGroup.create("loom", "Loom");
+
+	private LoomProblems() {
+	}
+
+	public static ProblemId problemId(String name, String displayName) {
+		return ProblemId.create(name, displayName, PROBLEM_GROUP);
+	}
+}


### PR DESCRIPTION
The task can be used for writing mod-provided javadoc.

Tested with a local copy of Fabric API's dev env where this task was added to all modules.