### PR TITLE
Call visitAnnotableParameterCount in AnnotationsApplyVisitor

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/AnnotationsApplyVisitor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/AnnotationsApplyVisitor.java
@@ -28,6 +28,7 @@ import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.RecordComponentVisitor;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.TypePath;
@@ -240,7 +241,18 @@ public record AnnotationsApplyVisitor(AnnotationsData annotationsData) implement
 			}
 
 			return new MethodVisitor(Constants.ASM_VERSION, mv) {
+				int syntheticParameterCount = 0;
+				boolean visitedAnnotableParameterCount = false;
 				boolean hasAddedAnnotations = false;
+
+				@Override
+				public void visitParameter(String name, int access) {
+					if ((access & Opcodes.ACC_SYNTHETIC) != 0) {
+						syntheticParameterCount++;
+					}
+
+					super.visitParameter(name, access);
+				}
 
 				@Override
 				public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
@@ -269,6 +281,16 @@ public record AnnotationsApplyVisitor(AnnotationsData annotationsData) implement
 					}
 
 					return super.visitParameterAnnotation(parameter, descriptor, visible);
+				}
+
+				@Override
+				public void visitAnnotableParameterCount(int parameterCount, boolean visible) {
+					if (!visible && !methodData.parameters().isEmpty()) {
+						parameterCount = Math.max(parameterCount, Type.getArgumentCount(descriptor) - syntheticParameterCount);
+						visitedAnnotableParameterCount = true;
+					}
+
+					super.visitAnnotableParameterCount(parameterCount, visible);
 				}
 
 				@Override
@@ -304,6 +326,11 @@ public record AnnotationsApplyVisitor(AnnotationsData annotationsData) implement
 						if (av != null) {
 							typeAnnotation.accept(av);
 						}
+					}
+
+					if (!visitedAnnotableParameterCount && !methodData.parameters().isEmpty()) {
+						mv.visitAnnotableParameterCount(Type.getArgumentCount(descriptor) - syntheticParameterCount, false);
+						visitedAnnotableParameterCount = true;
 					}
 
 					methodData.parameters().forEach((paramIndex, paramData) -> {


### PR DESCRIPTION
Along with this, we now specify that the parameter indexes in the `annotations.json` file is the annotable parameter index, not the real parameter index. Previously, what this index referred to was vague and unspecified.

Here's an example of what `javac` generates for an enum constructor, where there are two synthetic parameters for the name and the ordinal:
```java
enum Test {
  ;
  Test(@A String[] x, String a) {}
  @interface A {}
}
```
```
  // access flags 0x2
  // signature ([Ljava/lang/String;Ljava/lang/String;)V
  // declaration: void <init>(java.lang.String[], java.lang.String)
  private <init>(Ljava/lang/String;I[Ljava/lang/String;Ljava/lang/String;)V
    // parameter synthetic  <no name>
    // parameter synthetic  <no name>
    // parameter  <no name>
    // parameter  <no name>
    // annotable parameter count: 2 (invisible)
    @LTest$A;() // invisible, parameter 0
```
Here, the annotable parameter count is 2, which matches the number of non-synthetic parameters, as opposed to the number of parameters in the descriptor. The index for the parameter annotation is 0, because it is the 0th non-synthetic parameter, despite referring to parameter 2 in the descriptor.