### PR TITLE
Remove isRootProject from extension as it can hide `Project.getRootProject` when in the loom extension block.

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -99,8 +99,6 @@ public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 
 	FileCollection getMinecraftJarsCollection(MappingsNamespace mappingsNamespace);
 
-	boolean isRootProject();
-
 	@Override
 	MixinExtension getMixin();
 

--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
@@ -58,6 +58,7 @@ import net.fabricmc.loom.configuration.ide.idea.IdeaUtils;
 import net.fabricmc.loom.configuration.providers.BundleMetadata;
 import net.fabricmc.loom.configuration.providers.minecraft.library.LibraryContext;
 import net.fabricmc.loom.util.Constants;
+import net.fabricmc.loom.util.gradle.GradleUtils;
 import net.fabricmc.loom.util.gradle.SourceSetReference;
 
 public class RunConfig {
@@ -132,7 +133,7 @@ public class RunConfig {
 		RunConfig runConfig = new RunConfig();
 		runConfig.configName = configName;
 
-		if (appendProjectPath && !extension.isRootProject()) {
+		if (appendProjectPath && !GradleUtils.isRootProject(project)) {
 			runConfig.configName += " (" + project.getPath() + ")";
 		}
 

--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
@@ -46,6 +46,7 @@ import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftSourceSets;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.Platform;
+import net.fabricmc.loom.util.gradle.GradleUtils;
 import net.fabricmc.loom.util.gradle.SourceSetHelper;
 
 public abstract class RunConfigSettings implements Named {
@@ -139,7 +140,7 @@ public abstract class RunConfigSettings implements Named {
 		this.project = project;
 		this.appendProjectPathToConfigName = project.getObjects().property(Boolean.class).convention(true);
 		this.extension = LoomGradleExtension.get(project);
-		this.ideConfigGenerated = extension.isRootProject();
+		this.ideConfigGenerated = GradleUtils.isRootProject(project);
 		this.mainClass = project.getObjects().property(String.class).convention(project.provider(() -> {
 			Objects.requireNonNull(environment, "Run config " + name + " must specify environment");
 			Objects.requireNonNull(defaultMainClass, "Run config " + name + " must specify default main class");

--- a/src/main/java/net/fabricmc/loom/configuration/ide/idea/IdeaConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/idea/IdeaConfiguration.java
@@ -66,9 +66,7 @@ public abstract class IdeaConfiguration implements Runnable {
 	}
 
 	private void hookDownloadSources() {
-		LoomGradleExtension extension = LoomGradleExtension.get(getProject());
-
-		if (!extension.isRootProject()) {
+		if (!GradleUtils.isRootProject(getProject())) {
 			return;
 		}
 

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
@@ -217,11 +217,6 @@ public abstract class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl
 	}
 
 	@Override
-	public boolean isRootProject() {
-		return project.getRootProject() == project;
-	}
-
-	@Override
 	public MixinExtension getMixin() {
 		return this.mixinApExtension;
 	}

--- a/src/main/java/net/fabricmc/loom/util/gradle/GradleUtils.java
+++ b/src/main/java/net/fabricmc/loom/util/gradle/GradleUtils.java
@@ -124,4 +124,8 @@ public final class GradleUtils {
 		property.set(file);
 		return property.getAsFile().get();
 	}
+
+	public static boolean isRootProject(Project project) {
+		return project.getRootProject() == project;
+	}
 }


### PR DESCRIPTION
Remove isRootProject from extension as it can hide `Project.getRootProject` when in the loom extension block.