### PR TITLE
Fix progress logger

### DIFF
--- a/src/main/java/net/fabricmc/loom/util/gradle/ProgressGroup.java
+++ b/src/main/java/net/fabricmc/loom/util/gradle/ProgressGroup.java
@@ -60,7 +60,7 @@ public class ProgressGroup implements Closeable {
 
 		ProgressLogger progressLogger = this.progressLoggerFactory.newOperation(getClass(), progressGroup);
 		progressLogger.setDescription(name);
-		progressLogger.start(name, null);
+		progressLogger.start(name, name);
 		return progressLogger;
 	}
 


### PR DESCRIPTION
This param is documented that it can be null or empty, but it cannot...

Fixes https://github.com/FabricMC/fabric-loom/issues/1335