### PR TITLE
Fix invisible log levels being enabled in the log4j config

### DIFF
--- a/src/main/resources/log4j2.fabric.xml
+++ b/src/main/resources/log4j2.fabric.xml
@@ -59,7 +59,7 @@
 	</Appenders>
 	<Loggers>
 		<Logger level="${sys:fabric.log.level:-info}" name="net.minecraft"/>
-		<Root level="all">
+		<Root level="${sys:fabric.log.debug.level:-debug}">
 			<AppenderRef ref="DebugFile" level="${sys:fabric.log.debug.level:-debug}"/>
 			<AppenderRef ref="SysOut" level="${sys:fabric.log.level:-info}"/>
 			<AppenderRef ref="LatestFile" level="${sys:fabric.log.level:-info}"/>


### PR DESCRIPTION
The previous level made loggers report that e.g. the trace level is always enabled which is clearly wrong.