### PR TITLE
Make the intergration tests easier to debug

### DIFF
--- a/src/test/groovy/net/fabricmc/loom/test/LoomTestConstants.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/LoomTestConstants.groovy
@@ -49,8 +49,7 @@ class LoomTestConstants {
 	public static final File TEST_DIR = new File("./.gradle/test-files")
 
 	// Try to detect if the debugging agent is enabled.
-	public static final boolean IS_DEBUGGING_ENABLED = ManagementFactory.runtimeMXBean.inputArguments
-															.any { it.startsWith('-agentlib:jdwp') }
+	public static final boolean IS_DEBUGGING_ENABLED = ManagementFactory.runtimeMXBean.inputArguments.any { it.startsWith('-agentlib:jdwp') }
 
 	/**
 	 * Nightly gradle versions get removed after a certain amount of time, lets check to see if its still online before running the tests.

--- a/src/test/groovy/net/fabricmc/loom/test/LoomTestConstants.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/LoomTestConstants.groovy
@@ -24,6 +24,8 @@
 
 package net.fabricmc.loom.test
 
+import java.lang.management.ManagementFactory
+
 import org.gradle.util.GradleVersion
 
 class LoomTestConstants {
@@ -45,6 +47,10 @@ class LoomTestConstants {
 	]).shuffled().toArray()
 
 	public static final File TEST_DIR = new File("./.gradle/test-files")
+
+	// Try to detect if the debugging agent is enabled.
+	public static final boolean IS_DEBUGGING_ENABLED = ManagementFactory.runtimeMXBean.inputArguments
+															.any { it.startsWith('-agentlib:jdwp') }
 
 	/**
 	 * Nightly gradle versions get removed after a certain amount of time, lets check to see if its still online before running the tests.

--- a/src/test/groovy/net/fabricmc/loom/test/util/GradleProjectTestTrait.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/util/GradleProjectTestTrait.groovy
@@ -28,7 +28,6 @@ import groovy.transform.Immutable
 import org.apache.commons.io.FileUtils
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
-import org.gradle.util.GradleVersion
 import spock.lang.Shared
 
 import net.fabricmc.loom.test.LoomTestConstants
@@ -149,7 +148,6 @@ trait GradleProjectTestTrait {
 		private String gradleHomeDir
 		private String warningMode
 		private boolean useBuildSrc
-		private boolean enableDebugging = true
 
 		BuildResult run(Map options) {
 			// Setup the system props to tell loom that its running in a test env
@@ -165,7 +163,8 @@ trait GradleProjectTestTrait {
 				args << options.task
 			}
 
-			boolean configurationCache = true
+			// Configuration cache is not compatible with the debugging agent.
+			boolean configurationCache = !LoomTestConstants.IS_DEBUGGING_ENABLED
 
 			if (options.containsKey("configurationCache")) {
 				configurationCache = options.configurationCache
@@ -197,10 +196,6 @@ trait GradleProjectTestTrait {
 				writeBuildSrcDeps(runner)
 			}
 
-			if (options.disableDebugging) {
-				enableDebugging = false
-			}
-
 			return options.expectFailure ? runner.buildAndFail() : runner.build()
 		}
 
@@ -210,8 +205,7 @@ trait GradleProjectTestTrait {
 					.withPluginClasspath()
 					.withGradleVersion(gradleVersion)
 					.forwardOutput()
-					// Only enable debugging when the current gradle version matches the version we are testing
-					.withDebug(enableDebugging && gradleVersion == GradleVersion.current().getVersion())
+					.withDebug(LoomTestConstants.IS_DEBUGGING_ENABLED)
 		}
 
 		File getProjectDir() {


### PR DESCRIPTION
Ive had enough of manually changing the intergration test when I want to attach a debugger. Disables configuration caching when the debugging agent is present (it caused the test to fail before anyway).