### PR TITLE
Add 'fabric.loom.disableObfuscation' property to disable all remapping.

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -123,12 +123,12 @@ public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 	boolean isCollectingDependencyVerificationMetadata();
 
 	/**
-	 * When enabled do not remap the output jars
+	 * When enabled do not remap the output jars.
 	 */
 	boolean dontRemapOutputs();
 
 	/**
-	 * When enabled disable all forms of remapping
+	 * When enabled disable all forms of remapping.
 	 */
 	boolean disableObfuscation();
 }

--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -37,7 +37,6 @@ import org.jetbrains.annotations.ApiStatus;
 import net.fabricmc.loom.api.LoomGradleExtensionAPI;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.configuration.InstallerData;
-import net.fabricmc.loom.configuration.LoomDependencyManager;
 import net.fabricmc.loom.configuration.accesswidener.AccessWidenerFile;
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsFactory;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
@@ -64,10 +63,6 @@ public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 	void setInstallerData(InstallerData data);
 
 	InstallerData getInstallerData();
-
-	void setDependencyManager(LoomDependencyManager dependencyManager);
-
-	LoomDependencyManager getDependencyManager();
 
 	MinecraftMetadataProvider getMetadataProvider();
 
@@ -126,4 +121,14 @@ public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 	 * @return true when '--write-verification-metadata` is set
 	 */
 	boolean isCollectingDependencyVerificationMetadata();
+
+	/**
+	 * When enabled do not remap the output jars
+	 */
+	boolean dontRemapOutputs();
+
+	/**
+	 * When enabled disable all forms of remapping
+	 */
+	boolean disableObfuscation();
 }

--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -51,6 +51,7 @@ import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.api.tasks.testing.Test;
+import org.jetbrains.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.InterfaceInjectionExtensionAPI;
@@ -187,7 +188,7 @@ public abstract class CompileConfiguration implements Runnable {
 		}
 
 		// Provide the remapped mc jars
-		final IntermediaryMinecraftProvider<?> intermediaryMinecraftProvider = jarConfiguration.createIntermediaryMinecraftProvider(project);
+		@Nullable IntermediaryMinecraftProvider<?> intermediaryMinecraftProvider = extension.disableObfuscation() ? null : jarConfiguration.createIntermediaryMinecraftProvider(project);
 		NamedMinecraftProvider<?> namedMinecraftProvider = jarConfiguration.createNamedMinecraftProvider(project);
 
 		registerGameProcessors(configContext);
@@ -200,8 +201,10 @@ public abstract class CompileConfiguration implements Runnable {
 
 		final var provideContext = new AbstractMappedMinecraftProvider.ProvideContext(true, extension.refreshDeps(), configContext);
 
-		extension.setIntermediaryMinecraftProvider(intermediaryMinecraftProvider);
-		intermediaryMinecraftProvider.provide(provideContext);
+		if (intermediaryMinecraftProvider != null) {
+			extension.setIntermediaryMinecraftProvider(intermediaryMinecraftProvider);
+			intermediaryMinecraftProvider.provide(provideContext);
+		}
 
 		extension.setNamedMinecraftProvider(namedMinecraftProvider);
 		namedMinecraftProvider.provide(provideContext);

--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -120,9 +120,8 @@ public abstract class CompileConfiguration implements Runnable {
 					setupMinecraft(configContext);
 				}
 
-				LoomDependencyManager dependencyManager = new LoomDependencyManager();
-				extension.setDependencyManager(dependencyManager);
-				dependencyManager.handleDependencies(getProject(), serviceFactory);
+				var dependencyManager = new LoomDependencyManager(getProject(), serviceFactory, extension);
+				dependencyManager.handleDependencies();
 			} catch (Exception e) {
 				ExceptionUtil.processException(e, DaemonUtils.Context.fromProject(getProject()));
 				disownLock();
@@ -173,17 +172,19 @@ public abstract class CompileConfiguration implements Runnable {
 		extension.setMinecraftProvider(minecraftProvider);
 		minecraftProvider.provide();
 
-		// Realise the dependencies without actually resolving them, this forces any lazy providers to be created, populating the layered mapping factories.
-		project.getConfigurations().getByName(Configurations.MAPPINGS).getDependencies().toArray();
+		if (!extension.disableObfuscation()) {
+			// Realise the dependencies without actually resolving them, this forces any lazy providers to be created, populating the layered mapping factories.
+			project.getConfigurations().getByName(Configurations.MAPPINGS).getDependencies().toArray();
 
-		// Created any layered mapping files.
-		LayeredMappingsFactory.afterEvaluate(configContext);
+			// Created any layered mapping files.
+			LayeredMappingsFactory.afterEvaluate(configContext);
 
-		// Resolve the mapping files from the configuration
-		final DependencyInfo mappingsDep = DependencyInfo.create(getProject(), Configurations.MAPPINGS);
-		final MappingConfiguration mappingConfiguration = MappingConfiguration.create(getProject(), configContext.serviceFactory(), mappingsDep, minecraftProvider);
-		extension.setMappingConfiguration(mappingConfiguration);
-		mappingConfiguration.applyToProject(getProject(), mappingsDep);
+			// Resolve the mapping files from the configuration
+			final DependencyInfo mappingsDep = DependencyInfo.create(getProject(), Configurations.MAPPINGS);
+			final MappingConfiguration mappingConfiguration = MappingConfiguration.create(getProject(), configContext.serviceFactory(), mappingsDep, minecraftProvider);
+			extension.setMappingConfiguration(mappingConfiguration);
+			mappingConfiguration.applyToProject(getProject(), mappingsDep);
+		}
 
 		// Provide the remapped mc jars
 		final IntermediaryMinecraftProvider<?> intermediaryMinecraftProvider = jarConfiguration.createIntermediaryMinecraftProvider(project);

--- a/src/main/java/net/fabricmc/loom/configuration/LoomConfigurations.java
+++ b/src/main/java/net/fabricmc/loom/configuration/LoomConfigurations.java
@@ -134,16 +134,18 @@ public abstract class LoomConfigurations implements Runnable {
 
 		extendsFrom(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME, Constants.Configurations.MAPPING_CONSTANTS);
 
-		register(Constants.Configurations.MAPPINGS, Role.RESOLVABLE);
-		register(Constants.Configurations.MAPPINGS_FINAL, Role.RESOLVABLE);
+		if (!extension.disableObfuscation()) {
+			register(Constants.Configurations.MAPPINGS, Role.RESOLVABLE);
+			register(Constants.Configurations.MAPPINGS_FINAL, Role.RESOLVABLE);
+			extendsFrom(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME, Constants.Configurations.MAPPINGS_FINAL);
+			extendsFrom(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME, Constants.Configurations.MAPPINGS_FINAL);
+
+			extension.createRemapConfigurations(SourceSetHelper.getMainSourceSet(getProject()));
+		}
+
 		register(Constants.Configurations.LOOM_DEVELOPMENT_DEPENDENCIES, Role.RESOLVABLE);
 		register(Constants.Configurations.LOCAL_RUNTIME, Role.RESOLVABLE);
 		extendsFrom(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME, Constants.Configurations.LOCAL_RUNTIME);
-
-		extension.createRemapConfigurations(SourceSetHelper.getMainSourceSet(getProject()));
-
-		extendsFrom(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME, Constants.Configurations.MAPPINGS_FINAL);
-		extendsFrom(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME, Constants.Configurations.MAPPINGS_FINAL);
 
 		extendsFrom(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME, Constants.Configurations.MINECRAFT_RUNTIME_LIBRARIES);
 

--- a/src/main/java/net/fabricmc/loom/configuration/LoomDependencyManager.java
+++ b/src/main/java/net/fabricmc/loom/configuration/LoomDependencyManager.java
@@ -31,9 +31,16 @@ import net.fabricmc.loom.configuration.mods.ModConfigurationRemapper;
 import net.fabricmc.loom.util.SourceRemapper;
 import net.fabricmc.loom.util.service.ServiceFactory;
 
-public class LoomDependencyManager {
-	public void handleDependencies(Project project, ServiceFactory serviceFactory) {
-		project.getLogger().info(":setting up loom dependencies");
+public record LoomDependencyManager(Project project, ServiceFactory serviceFactory, LoomGradleExtension extension) {
+	public void handleDependencies() {
+		if (extension.disableObfuscation()) {
+			handleNoneRemapDependencies();
+		} else {
+			handleRemapDependencies();
+		}
+	}
+
+	private void handleRemapDependencies() {
 		LoomGradleExtension extension = LoomGradleExtension.get(project);
 
 		SourceRemapper sourceRemapper = new SourceRemapper(project, serviceFactory, true);
@@ -46,5 +53,9 @@ public class LoomDependencyManager {
 		if (extension.getInstallerData() == null) {
 			project.getLogger().info("fabric-installer.json not found in dependencies");
 		}
+	}
+
+	private void handleNoneRemapDependencies() {
+		// TODO do we need to do anything?
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/LoomDependencyManager.java
+++ b/src/main/java/net/fabricmc/loom/configuration/LoomDependencyManager.java
@@ -34,7 +34,7 @@ import net.fabricmc.loom.util.service.ServiceFactory;
 public record LoomDependencyManager(Project project, ServiceFactory serviceFactory, LoomGradleExtension extension) {
 	public void handleDependencies() {
 		if (extension.disableObfuscation()) {
-			handleNoneRemapDependencies();
+			handleNonRemapDependencies();
 		} else {
 			handleRemapDependencies();
 		}
@@ -55,7 +55,7 @@ public record LoomDependencyManager(Project project, ServiceFactory serviceFacto
 		}
 	}
 
-	private void handleNoneRemapDependencies() {
-		// TODO do we need to do anything?
+	private void handleNonRemapDependencies() {
+		// TODO debof - do we need to do anything?
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/decompile/DecompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/decompile/DecompileConfiguration.java
@@ -27,7 +27,6 @@ package net.fabricmc.loom.configuration.decompile;
 import org.gradle.api.Project;
 
 import net.fabricmc.loom.LoomGradleExtension;
-import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftJar;
 import net.fabricmc.loom.configuration.providers.minecraft.mapped.MappedMinecraftProvider;
 
@@ -37,13 +36,11 @@ public abstract class DecompileConfiguration<T extends MappedMinecraftProvider> 
 	protected final Project project;
 	protected final T minecraftProvider;
 	protected final LoomGradleExtension extension;
-	protected final MappingConfiguration mappingConfiguration;
 
 	public DecompileConfiguration(Project project, T minecraftProvider) {
 		this.project = project;
 		this.minecraftProvider = minecraftProvider;
 		this.extension = LoomGradleExtension.get(project);
-		this.mappingConfiguration = extension.getMappingConfiguration();
 	}
 
 	public abstract String getTaskName(MinecraftJar.Type type);

--- a/src/main/java/net/fabricmc/loom/configuration/processors/MinecraftJarProcessorManager.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/MinecraftJarProcessorManager.java
@@ -66,7 +66,15 @@ public final class MinecraftJarProcessorManager {
 			processors.add(project.getObjects().newInstance(LegacyJarProcessorWrapper.class, legacyProcessor));
 		}
 
-		return MinecraftJarProcessorManager.create(processors, SpecContextImpl.create(project));
+		SpecContext specContext;
+
+		if (extension.disableObfuscation()) {
+			specContext = SpecContextDebofImpl.create();
+		} else {
+			specContext = SpecContextRemappedImpl.create(project);
+		}
+
+		return MinecraftJarProcessorManager.create(processors, specContext);
 	}
 
 	@Nullable

--- a/src/main/java/net/fabricmc/loom/configuration/processors/SpecContextDebofImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/SpecContextDebofImpl.java
@@ -22,33 +22,27 @@
  * SOFTWARE.
  */
 
-package net.fabricmc.loom.test.integration
+package net.fabricmc.loom.configuration.processors;
 
-import spock.lang.Specification
-import spock.lang.Unroll
+import java.util.List;
 
-import net.fabricmc.loom.test.util.GradleProjectTestTrait
+import net.fabricmc.loom.api.processor.SpecContext;
+import net.fabricmc.loom.util.fmj.FabricModJson;
 
-import static net.fabricmc.loom.test.LoomTestConstants.PRE_RELEASE_GRADLE
-import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+// TODO debof - fixme
+public record SpecContextDebofImpl(List<FabricModJson> modDependencies,
+									List<FabricModJson> localMods) implements SpecContext {
+	public static SpecContext create() {
+		return new SpecContextDebofImpl(List.of(), List.of());
+	}
 
-class NotObfuscatedTest extends Specification implements GradleProjectTestTrait {
-	@Unroll
-	def "Not Obfuscated"() {
-		setup:
-		def gradle = gradleProject(project: "minimalBase", version: PRE_RELEASE_GRADLE)
-		gradle.buildGradle << '''
-				dependencies {
-					minecraft 'com.mojang:minecraft:1.21.10'
-                    api "net.fabricmc.fabric-api:fabric-api:0.134.1+1.21.10"
-                }
-		'''
-		gradle.getGradleProperties() << "fabric.loom.disableObfuscation=true"
+	@Override
+	public List<FabricModJson> modDependenciesCompileRuntime() {
+		return List.of();
+	}
 
-		when:
-		def result = gradle.run(task: "build")
-
-		then:
-		result.task(":build").outcome == SUCCESS
+	@Override
+	public List<FabricModJson> modDependenciesCompileRuntimeClient() {
+		return List.of();
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/processors/SpecContextRemappedImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/SpecContextRemappedImpl.java
@@ -56,18 +56,18 @@ import net.fabricmc.loom.util.fmj.FabricModJsonHelpers;
  * @param localMods Mods found in the current project.
  * @param compileRuntimeMods Dependent mods found in both the compile and runtime classpath.
  */
-public record SpecContextImpl(
+public record SpecContextRemappedImpl(
 		List<FabricModJson> modDependencies,
 		List<FabricModJson> localMods,
 		List<ModHolder> compileRuntimeMods) implements SpecContext {
-	public static SpecContextImpl create(Project project) {
+	public static SpecContextRemappedImpl create(Project project) {
 		return create(new SpecContextProjectView.Impl(project, LoomGradleExtension.get(project)));
 	}
 
 	@VisibleForTesting
-	public static SpecContextImpl create(SpecContextProjectView projectView) {
+	public static SpecContextRemappedImpl create(SpecContextProjectView projectView) {
 		AsyncCache<List<FabricModJson>> fmjCache = new AsyncCache<>();
-		return new SpecContextImpl(
+		return new SpecContextRemappedImpl(
 				getDependentMods(projectView, fmjCache),
 				projectView.getMods(),
 				getCompileRuntimeMods(projectView, fmjCache)

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/AbstractMappedMinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/AbstractMappedMinecraftProvider.java
@@ -173,15 +173,17 @@ public abstract class AbstractMappedMinecraftProvider<M extends MinecraftProvide
 	}
 
 	protected String getName(MinecraftJar.Type type) {
-		final String intermediateName = extension.getIntermediateMappingsProvider().getName();
-
 		var sj = new StringJoiner("-");
 		sj.add("minecraft");
 		sj.add(type.toString());
 
-		// Include the intermediate mapping name if it's not the default intermediary
-		if (!intermediateName.equals(IntermediaryMappingsProvider.NAME)) {
-			sj.add(intermediateName);
+		if (!extension.disableObfuscation()) {
+			// Include the intermediate mapping name if it's not the default intermediary
+			final String intermediateName = extension.getIntermediateMappingsProvider().getName();
+
+			if (!intermediateName.equals(IntermediaryMappingsProvider.NAME)) {
+				sj.add(intermediateName);
+			}
 		}
 
 		if (getTargetNamespace() != MappingsNamespace.NAMED) {
@@ -192,6 +194,10 @@ public abstract class AbstractMappedMinecraftProvider<M extends MinecraftProvide
 	}
 
 	protected String getVersion() {
+		if (extension.disableObfuscation()) {
+			return extension.getMinecraftProvider().minecraftVersion();
+		}
+
 		return "%s-%s".formatted(extension.getMinecraftProvider().minecraftVersion(), extension.getMappingConfiguration().mappingsIdentifier());
 	}
 
@@ -237,7 +243,15 @@ public abstract class AbstractMappedMinecraftProvider<M extends MinecraftProvide
 		}
 	}
 
-	private void remapJar(RemappedJars remappedJars, ConfigContext configContext) throws IOException {
+	protected void remapJar(RemappedJars remappedJars, ConfigContext configContext) throws IOException {
+		if (extension.disableObfuscation()) {
+			// TODO debof - can we skip this?
+			Files.createDirectories(remappedJars.outputJarPath().getParent());
+			Files.copy(remappedJars.inputJar(), remappedJars.outputJarPath(), StandardCopyOption.REPLACE_EXISTING);
+			getMavenHelper(remappedJars.type()).savePom();
+			return;
+		}
+
 		final MappingConfiguration mappingConfiguration = extension.getMappingConfiguration();
 		final String fromM = remappedJars.sourceNamespace().toString();
 		final String toM = getTargetNamespace().toString();

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/AbstractMappedMinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/AbstractMappedMinecraftProvider.java
@@ -184,6 +184,8 @@ public abstract class AbstractMappedMinecraftProvider<M extends MinecraftProvide
 			if (!intermediateName.equals(IntermediaryMappingsProvider.NAME)) {
 				sj.add(intermediateName);
 			}
+		} else {
+			sj.add("deobf");
 		}
 
 		if (getTargetNamespace() != MappingsNamespace.NAMED) {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/IntermediaryMinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/IntermediaryMinecraftProvider.java
@@ -41,6 +41,10 @@ import net.fabricmc.tinyremapper.TinyRemapper;
 public abstract sealed class IntermediaryMinecraftProvider<M extends MinecraftProvider> extends AbstractMappedMinecraftProvider<M> permits IntermediaryMinecraftProvider.MergedImpl, IntermediaryMinecraftProvider.LegacyMergedImpl, IntermediaryMinecraftProvider.SingleJarImpl, IntermediaryMinecraftProvider.SplitImpl {
 	public IntermediaryMinecraftProvider(Project project, M minecraftProvider) {
 		super(project, minecraftProvider);
+
+		if (extension.disableObfuscation()) {
+			throw new UnsupportedOperationException("Intermediary Minecraft providers cannot be used when obfuscation is disabled");
+		}
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -239,7 +239,7 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	@Override
 	public Dependency officialMojangMappings() {
 		if (notObfuscated()) {
-			throw new UnsupportedOperationException("Cannot use Mojang mappings in a none obfuscated environment");
+			throw new UnsupportedOperationException("Cannot use Mojang mappings in a non-obfuscated environment");
 		}
 
 		if (layeredSpecBuilderScope.get()) {
@@ -252,7 +252,7 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	@Override
 	public Dependency layered(Action<LayeredMappingSpecBuilder> action) {
 		if (notObfuscated()) {
-			throw new UnsupportedOperationException("Cannot configure layered mappings in a none obfuscated environment");
+			throw new UnsupportedOperationException("Cannot configure layered mappings in a non-obfuscated environment");
 		}
 
 		if (hasEvaluatedLayeredMappings) {
@@ -303,7 +303,7 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	@Override
 	public SetProperty<String> getKnownIndyBsms() {
 		if (notObfuscated()) {
-			throw new UnsupportedOperationException("Cannot configure known indyBsms in a none obfuscated environment");
+			throw new UnsupportedOperationException("Cannot configure known indyBsms in a non-obfuscated environment");
 		}
 
 		return knownIndyBsms;
@@ -342,7 +342,7 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	@Override
 	public IntermediateMappingsProvider getIntermediateMappingsProvider() {
 		if (LoomGradleExtension.get(getProject()).disableObfuscation()) {
-			throw new UnsupportedOperationException("Cannot get intermediate mappings provider in a none obfuscated environment");
+			throw new UnsupportedOperationException("Cannot get intermediate mappings provider in a non-obfuscated environment");
 		}
 
 		return intermediateMappingsProvider.get();
@@ -364,7 +364,7 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	@Override
 	public File getMappingsFile() {
 		if (notObfuscated()) {
-			throw new UnsupportedOperationException("Cannot get mappings file in a none obfuscated environment");
+			throw new UnsupportedOperationException("Cannot get mappings file in a non-obfuscated environment");
 		}
 
 		return LoomGradleExtension.get(getProject()).getMappingConfiguration().tinyMappings.toFile();
@@ -442,7 +442,7 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	@Override
 	public NamedDomainObjectList<RemapConfigurationSettings> getRemapConfigurations() {
 		if (notObfuscated()) {
-			throw new UnsupportedOperationException("Cannot get remap configurations in a none obfuscated environment");
+			throw new UnsupportedOperationException("Cannot get remap configurations in a non-obfuscated environment");
 		}
 
 		return remapConfigurations;
@@ -451,7 +451,7 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	@Override
 	public RemapConfigurationSettings addRemapConfiguration(String name, Action<RemapConfigurationSettings> action) {
 		if (notObfuscated()) {
-			throw new UnsupportedOperationException("Cannot add remap configuration in a none obfuscated environment");
+			throw new UnsupportedOperationException("Cannot add remap configuration in a non-obfuscated environment");
 		}
 
 		final RemapConfigurationSettings configurationSettings = getProject().getObjects().newInstance(RemapConfigurationSettings.class, name);
@@ -469,7 +469,7 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	@Override
 	public void createRemapConfigurations(SourceSet sourceSet) {
 		if (notObfuscated()) {
-			throw new UnsupportedOperationException("Cannot create remap configurations in a none obfuscated environment");
+			throw new UnsupportedOperationException("Cannot create remap configurations in a non-obfuscated environment");
 		}
 
 		RemapConfigurations.setupForSourceSet(getProject(), sourceSet);
@@ -478,7 +478,7 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	@Override
 	public <T extends RemapperParameters> void addRemapperExtension(Class<? extends RemapperExtension<T>> remapperExtensionClass, Class<T> parametersClass, Action<T> parameterAction) {
 		if (notObfuscated()) {
-			throw new UnsupportedOperationException("Cannot add remapper extension in a none obfuscated environment");
+			throw new UnsupportedOperationException("Cannot add remapper extension in a non-obfuscated environment");
 		}
 
 		final ObjectFactory objectFactory = getProject().getObjects();

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -238,6 +238,10 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 
 	@Override
 	public Dependency officialMojangMappings() {
+		if (notObfuscated()) {
+			throw new UnsupportedOperationException("Cannot use Mojang mappings in a none obfuscated environment");
+		}
+
 		if (layeredSpecBuilderScope.get()) {
 			throw new IllegalStateException("Use `officialMojangMappings()` when configuring layered mappings, not the extension method `loom.officialMojangMappings()`");
 		}
@@ -247,6 +251,10 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 
 	@Override
 	public Dependency layered(Action<LayeredMappingSpecBuilder> action) {
+		if (notObfuscated()) {
+			throw new UnsupportedOperationException("Cannot configure layered mappings in a none obfuscated environment");
+		}
+
 		if (hasEvaluatedLayeredMappings) {
 			throw new IllegalStateException("Layered mappings have already been evaluated");
 		}
@@ -294,6 +302,10 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 
 	@Override
 	public SetProperty<String> getKnownIndyBsms() {
+		if (notObfuscated()) {
+			throw new UnsupportedOperationException("Cannot configure known indyBsms in a none obfuscated environment");
+		}
+
 		return knownIndyBsms;
 	}
 
@@ -329,6 +341,10 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 
 	@Override
 	public IntermediateMappingsProvider getIntermediateMappingsProvider() {
+		if (LoomGradleExtension.get(getProject()).disableObfuscation()) {
+			throw new UnsupportedOperationException("Cannot get intermediate mappings provider in a none obfuscated environment");
+		}
+
 		return intermediateMappingsProvider.get();
 	}
 
@@ -342,11 +358,15 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 		T provider = getProject().getObjects().newInstance(clazz);
 		configureIntermediateMappingsProviderInternal(provider);
 		action.execute(provider);
-		intermediateMappingsProvider.set(provider);
+		setIntermediateMappingsProvider(provider);
 	}
 
 	@Override
 	public File getMappingsFile() {
+		if (notObfuscated()) {
+			throw new UnsupportedOperationException("Cannot get mappings file in a none obfuscated environment");
+		}
+
 		return LoomGradleExtension.get(getProject()).getMappingConfiguration().tinyMappings.toFile();
 	}
 
@@ -421,11 +441,19 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 
 	@Override
 	public NamedDomainObjectList<RemapConfigurationSettings> getRemapConfigurations() {
+		if (notObfuscated()) {
+			throw new UnsupportedOperationException("Cannot get remap configurations in a none obfuscated environment");
+		}
+
 		return remapConfigurations;
 	}
 
 	@Override
 	public RemapConfigurationSettings addRemapConfiguration(String name, Action<RemapConfigurationSettings> action) {
+		if (notObfuscated()) {
+			throw new UnsupportedOperationException("Cannot add remap configuration in a none obfuscated environment");
+		}
+
 		final RemapConfigurationSettings configurationSettings = getProject().getObjects().newInstance(RemapConfigurationSettings.class, name);
 
 		// TODO remove in 2.0, this is a fallback to mimic the previous (Broken) behaviour
@@ -440,11 +468,19 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 
 	@Override
 	public void createRemapConfigurations(SourceSet sourceSet) {
+		if (notObfuscated()) {
+			throw new UnsupportedOperationException("Cannot create remap configurations in a none obfuscated environment");
+		}
+
 		RemapConfigurations.setupForSourceSet(getProject(), sourceSet);
 	}
 
 	@Override
 	public <T extends RemapperParameters> void addRemapperExtension(Class<? extends RemapperExtension<T>> remapperExtensionClass, Class<T> parametersClass, Action<T> parameterAction) {
+		if (notObfuscated()) {
+			throw new UnsupportedOperationException("Cannot add remapper extension in a none obfuscated environment");
+		}
+
 		final ObjectFactory objectFactory = getProject().getObjects();
 		final RemapperExtensionHolder holder;
 
@@ -470,6 +506,10 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 		final ConfigurableFileCollection jars = getProject().getObjects().fileCollection();
 		jars.from(getProject().provider(() -> LoomGradleExtension.get(getProject()).getMinecraftJars(MappingsNamespace.NAMED)));
 		return jars;
+	}
+
+	private boolean notObfuscated() {
+		return LoomGradleExtension.get(getProject()).disableObfuscation();
 	}
 
 	// This is here to ensure that LoomGradleExtensionApiImpl compiles without any unimplemented methods

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
@@ -164,7 +164,7 @@ public abstract class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl
 	@Override
 	public MappingConfiguration getMappingConfiguration() {
 		if (disableObfuscation()) {
-			throw new UnsupportedOperationException("Cannot get mappings configuration in a none obfuscated environment");
+			throw new UnsupportedOperationException("Cannot get mappings configuration in a non-obfuscated environment");
 		}
 
 		return Objects.requireNonNull(mappingConfiguration, "Cannot get MappingsProvider before it has been setup");
@@ -173,7 +173,7 @@ public abstract class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl
 	@Override
 	public void setMappingConfiguration(MappingConfiguration mappingConfiguration) {
 		if (disableObfuscation()) {
-			throw new UnsupportedOperationException("Cannot set mappings configuration in a none obfuscated environment");
+			throw new UnsupportedOperationException("Cannot set mappings configuration in a non-obfuscated environment");
 		}
 
 		this.mappingConfiguration = mappingConfiguration;
@@ -290,7 +290,7 @@ public abstract class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl
 	@Override
 	public Collection<LayeredMappingsFactory> getLayeredMappingFactories() {
 		if (disableObfuscation()) {
-			throw new UnsupportedOperationException("Cannot get layered mapping factories in a none obfuscated environment");
+			throw new UnsupportedOperationException("Cannot get layered mapping factories in a non-obfuscated environment");
 		}
 
 		hasEvaluatedLayeredMappings = true;

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
@@ -39,6 +39,7 @@ import org.gradle.api.configuration.BuildFeatures;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.mappings.intermediate.IntermediateMappingsProvider;
@@ -55,8 +56,10 @@ import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.library.LibraryProcessorManager;
 import net.fabricmc.loom.configuration.providers.minecraft.mapped.IntermediaryMinecraftProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.mapped.NamedMinecraftProvider;
+import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.download.Download;
 import net.fabricmc.loom.util.download.DownloadBuilder;
+import net.fabricmc.loom.util.gradle.GradleUtils;
 
 public abstract class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl implements LoomGradleExtension {
 	private final Project project;
@@ -78,6 +81,8 @@ public abstract class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl
 	private final boolean configurationCacheActive;
 	private final boolean isolatedProjectsActive;
 	private final boolean isCollectingDependencyVerificationMetadata;
+	private final Property<Boolean> disableObfuscation;
+	private final Property<Boolean> dontRemap;
 
 	@Inject
 	protected abstract BuildFeatures getBuildFeatures();
@@ -108,6 +113,14 @@ public abstract class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl
 		configurationCacheActive = getBuildFeatures().getConfigurationCache().getActive().get();
 		isolatedProjectsActive = getBuildFeatures().getIsolatedProjects().getActive().get();
 		isCollectingDependencyVerificationMetadata = !project.getGradle().getStartParameter().getWriteDependencyVerifications().isEmpty();
+		disableObfuscation = project.getObjects().property(Boolean.class);
+		dontRemap = project.getObjects().property(Boolean.class);
+
+		disableObfuscation.set(project.provider(() -> GradleUtils.getBooleanProperty(getProject(), Constants.Properties.DISABLE_OBFUSCATION)));
+		disableObfuscation.finalizeValueOnRead();
+
+		dontRemap.set(disableObfuscation.map(notObfuscated -> notObfuscated || GradleUtils.getBooleanProperty(getProject(), Constants.Properties.DONT_REMAP)));
+		dontRemap.finalizeValueOnRead();
 
 		if (refreshDeps) {
 			project.getLogger().lifecycle("Refresh dependencies is in use, loom will be significantly slower.");
@@ -126,16 +139,6 @@ public abstract class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl
 	@Override
 	public LoomFiles getFiles() {
 		return loomFiles;
-	}
-
-	@Override
-	public void setDependencyManager(LoomDependencyManager dependencyManager) {
-		this.dependencyManager = dependencyManager;
-	}
-
-	@Override
-	public LoomDependencyManager getDependencyManager() {
-		return Objects.requireNonNull(dependencyManager, "Cannot get LoomDependencyManager before it has been setup");
 	}
 
 	@Override
@@ -160,11 +163,19 @@ public abstract class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl
 
 	@Override
 	public MappingConfiguration getMappingConfiguration() {
+		if (disableObfuscation()) {
+			throw new UnsupportedOperationException("Cannot get mappings configuration in a none obfuscated environment");
+		}
+
 		return Objects.requireNonNull(mappingConfiguration, "Cannot get MappingsProvider before it has been setup");
 	}
 
 	@Override
 	public void setMappingConfiguration(MappingConfiguration mappingConfiguration) {
+		if (disableObfuscation()) {
+			throw new UnsupportedOperationException("Cannot set mappings configuration in a none obfuscated environment");
+		}
+
 		this.mappingConfiguration = mappingConfiguration;
 	}
 
@@ -278,6 +289,10 @@ public abstract class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl
 
 	@Override
 	public Collection<LayeredMappingsFactory> getLayeredMappingFactories() {
+		if (disableObfuscation()) {
+			throw new UnsupportedOperationException("Cannot get layered mapping factories in a none obfuscated environment");
+		}
+
 		hasEvaluatedLayeredMappings = true;
 		return Collections.unmodifiableCollection(layeredMappingsDependencyMap.values());
 	}
@@ -307,5 +322,15 @@ public abstract class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl
 	@Override
 	public boolean isCollectingDependencyVerificationMetadata() {
 		return isCollectingDependencyVerificationMetadata;
+	}
+
+	@Override
+	public boolean dontRemapOutputs() {
+		return dontRemap.get();
+	}
+
+	@Override
+	public boolean disableObfuscation() {
+		return disableObfuscation.get();
 	}
 }

--- a/src/main/java/net/fabricmc/loom/task/RemapTaskConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapTaskConfiguration.java
@@ -67,7 +67,7 @@ public abstract class RemapTaskConfiguration implements Runnable {
 
 		SyncTaskBuildService.register(getProject());
 
-		if (GradleUtils.getBooleanProperty(getProject(), Constants.Properties.DONT_REMAP)) {
+		if (extension.dontRemapOutputs()) {
 			extension.getUnmappedModCollection().from(getTasks().getByName(JavaPlugin.JAR_TASK_NAME));
 			return;
 		}

--- a/src/main/java/net/fabricmc/loom/task/prod/AbstractProductionRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/prod/AbstractProductionRunTask.java
@@ -61,7 +61,6 @@ import net.fabricmc.loom.configuration.InstallerData;
 import net.fabricmc.loom.task.AbstractLoomTask;
 import net.fabricmc.loom.task.RemapTaskConfiguration;
 import net.fabricmc.loom.util.Constants;
-import net.fabricmc.loom.util.gradle.GradleUtils;
 
 /**
  * This is the base task for running the game in a "production" like environment. Using intermediary names, and not enabling development only features.
@@ -129,7 +128,7 @@ public abstract sealed class AbstractProductionRunTask extends AbstractLoomTask 
 		getJavaLauncher().convention(getJavaToolchainService().launcherFor(defaultToolchain));
 		getRunDir().convention(getProject().getLayout().getProjectDirectory().dir("run"));
 
-		if (!GradleUtils.getBooleanProperty(getProject(), Constants.Properties.DONT_REMAP)) {
+		if (!getExtension().dontRemapOutputs()) {
 			getMods().from(getProject().getTasks().named(RemapTaskConfiguration.REMAP_JAR_TASK_NAME));
 		}
 

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -142,6 +142,7 @@ public class Constants {
 
 	public static final class Properties {
 		public static final String DONT_REMAP = "fabric.loom.dontRemap";
+		public static final String DISABLE_OBFUSCATION = "fabric.loom.disableObfuscation";
 		public static final String DISABLE_REMAPPED_VARIANTS = "fabric.loom.disableRemappedVariants";
 		public static final String DISABLE_PROJECT_DEPENDENT_MODS = "fabric.loom.disableProjectDependentMods";
 		public static final String LIBRARY_PROCESSORS = "fabric.loom.libraryProcessors";

--- a/src/test/groovy/net/fabricmc/loom/test/integration/NotObfuscatedTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/NotObfuscatedTest.groovy
@@ -1,0 +1,30 @@
+package net.fabricmc.loom.test.integration
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import net.fabricmc.loom.test.util.GradleProjectTestTrait
+
+import static net.fabricmc.loom.test.LoomTestConstants.PRE_RELEASE_GRADLE
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class NotObfuscatedTest extends Specification implements GradleProjectTestTrait {
+	@Unroll
+	def "Not Obfuscated"() {
+		setup:
+		def gradle = gradleProject(project: "minimalBase", version: PRE_RELEASE_GRADLE)
+		gradle.buildGradle << '''
+				dependencies {
+					minecraft 'com.mojang:minecraft:1.21.10'
+                    api "net.fabricmc.fabric-api:fabric-api:0.134.1+1.21.10"
+                }
+		'''
+		gradle.getGradleProperties() << "fabric.loom.disableObfuscation=true"
+
+		when:
+		def result = gradle.run(task: "build")
+
+		then:
+		result.task(":build").outcome == SUCCESS
+	}
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/SpecContextTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/SpecContextTest.groovy
@@ -39,8 +39,8 @@ import spock.lang.TempDir
 import net.fabricmc.loom.LoomGradleExtension
 import net.fabricmc.loom.api.RemapConfigurationSettings
 import net.fabricmc.loom.api.fmj.FabricModJsonV1Spec
-import net.fabricmc.loom.configuration.processors.SpecContextImpl
 import net.fabricmc.loom.configuration.processors.SpecContextProjectView
+import net.fabricmc.loom.configuration.processors.SpecContextRemappedImpl
 import net.fabricmc.loom.test.util.GradleTestUtil
 import net.fabricmc.loom.util.ZipUtils
 import net.fabricmc.loom.util.fmj.gen.FabricModJsonV1Generator
@@ -98,7 +98,7 @@ class SpecContextTest extends Specification {
 				)
 
 		when:
-		def specContext = SpecContextImpl.create(projectView)
+		def specContext = SpecContextRemappedImpl.create(projectView)
 
 		then:
 		specContext.modDependencies().size() == 0
@@ -117,7 +117,7 @@ class SpecContextTest extends Specification {
 				)
 
 		when:
-		def specContext = SpecContextImpl.create(projectView)
+		def specContext = SpecContextRemappedImpl.create(projectView)
 
 		then:
 		specContext.modDependencies().size() == 1
@@ -136,7 +136,7 @@ class SpecContextTest extends Specification {
 				)
 
 		when:
-		def specContext = SpecContextImpl.create(projectView)
+		def specContext = SpecContextRemappedImpl.create(projectView)
 
 		then:
 		specContext.modDependencies().size() == 1
@@ -155,7 +155,7 @@ class SpecContextTest extends Specification {
 				)
 
 		when:
-		def specContext = SpecContextImpl.create(projectView)
+		def specContext = SpecContextRemappedImpl.create(projectView)
 
 		then:
 		specContext.modDependencies().size() == 1
@@ -175,7 +175,7 @@ class SpecContextTest extends Specification {
 				)
 
 		when:
-		def specContext = SpecContextImpl.create(projectView)
+		def specContext = SpecContextRemappedImpl.create(projectView)
 
 		then:
 		specContext.modDependencies().size() == 1


### PR DESCRIPTION
The idea of this property is to provide the same functionality of what a minimal/lightweight future version of Loom may offer without require a vast refactor. 