### PR TITLE
Include source mapping hash in decompiler cache key

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2016-2022 FabricMC
+ * Copyright (c) 2016-2025 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -405,6 +405,13 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 		if (usingUnpick()) {
 			UnpickService unpick = serviceFactory.get(getUnpickOptions());
 			sj.add(unpick.getUnpickCacheKey());
+		}
+
+		SourceMappingsService mappingsService = serviceFactory.get(getMappings());
+		String mappingsHash = mappingsService.getMappingsHash();
+
+		if (mappingsHash != null) {
+			sj.add(mappingsHash);
 		}
 
 		getLogger().info("Decompile cache data: {}", sj);

--- a/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
@@ -408,7 +408,7 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 		}
 
 		SourceMappingsService mappingsService = serviceFactory.get(getMappings());
-		String mappingsHash = mappingsService.getMappingsHash();
+		String mappingsHash = mappingsService.getProcessorHash();
 
 		if (mappingsHash != null) {
 			sj.add(mappingsHash);

--- a/src/main/java/net/fabricmc/loom/task/service/SourceMappingsService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/SourceMappingsService.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2024 FabricMC
+ * Copyright (c) 2024-2025 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,8 +34,11 @@ import java.nio.file.Path;
 
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,17 +64,22 @@ public class SourceMappingsService extends Service<SourceMappingsService.Options
 	public interface Options extends Service.Options {
 		@InputFiles
 		ConfigurableFileCollection getMappings(); // Only a single file
+
+		@Input
+		Property<String> getHash();
 	}
 
 	public static Provider<Options> create(Project project) {
-		final Path mappings = getMappings(project);
+		final Property<String> hash = project.getObjects().property(String.class);
+		final Path mappings = getMappings(project, hash);
 
 		return TYPE.create(project, options -> {
 			options.getMappings().from(project.file(mappings));
+			options.getHash().set(hash);
 		});
 	}
 
-	private static Path getMappings(Project project) {
+	private static Path getMappings(Project project, Property<String> hashProperty) {
 		final LoomGradleExtension extension = LoomGradleExtension.get(project);
 		final MinecraftJarProcessorManager jarProcessor = MinecraftJarProcessorManager.create(project);
 
@@ -80,8 +88,11 @@ public class SourceMappingsService extends Service<SourceMappingsService.Options
 			return extension.getMappingConfiguration().tinyMappings;
 		}
 
+		final String hash = jarProcessor.getSourceMappingsHash();
+		hashProperty.set(hash);
+
 		final Path dir = extension.getFiles().getProjectPersistentCache().toPath().resolve("source_mappings");
-		final Path path = dir.resolve(jarProcessor.getSourceMappingsHash() + ".tiny");
+		final Path path = dir.resolve(hash + ".tiny");
 
 		if (Files.exists(path) && !extension.refreshDeps()) {
 			LOGGER.debug("Using cached source mappings");
@@ -137,5 +148,9 @@ public class SourceMappingsService extends Service<SourceMappingsService.Options
 
 	public Path getMappingsFile() {
 		return getOptions().getMappings().getSingleFile().toPath();
+	}
+
+	public @Nullable String getMappingsHash() {
+		return getOptions().getHash().getOrNull();
 	}
 }

--- a/src/main/java/net/fabricmc/loom/task/service/SourceMappingsService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/SourceMappingsService.java
@@ -38,6 +38,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Optional;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,7 +67,8 @@ public class SourceMappingsService extends Service<SourceMappingsService.Options
 		ConfigurableFileCollection getMappings(); // Only a single file
 
 		@Input
-		Property<String> getHash();
+		@Optional
+		Property<String> getProcessorHash(); // the hash of the processors applied to the mappings
 	}
 
 	public static Provider<Options> create(Project project) {
@@ -75,7 +77,7 @@ public class SourceMappingsService extends Service<SourceMappingsService.Options
 
 		return TYPE.create(project, options -> {
 			options.getMappings().from(project.file(mappings));
-			options.getHash().set(hash);
+			options.getProcessorHash().set(hash);
 		});
 	}
 
@@ -150,7 +152,7 @@ public class SourceMappingsService extends Service<SourceMappingsService.Options
 		return getOptions().getMappings().getSingleFile().toPath();
 	}
 
-	public @Nullable String getMappingsHash() {
-		return getOptions().getHash().getOrNull();
+	public @Nullable String getProcessorHash() {
+		return getOptions().getProcessorHash().getOrNull();
 	}
 }


### PR DESCRIPTION
Closes #1410. Fixes mod-provided javadoc not being considered in the config cache. Previously, it could leak through the cache to projects without MPJ, or not appear in projects that should have MPJ.