### PR TITLE
JSpecify, package-info's and misc null fixes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -416,3 +416,4 @@ abstract class PrintActionsTestName extends DefaultTask {
 }
 
 apply from: rootProject.file('gradle/versions.gradle')
+apply from: rootProject.file('gradle/package-info.gradle')

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -74,6 +74,9 @@
 			<property name="option" value="top"/>
 			<property name="sortStaticImportsAlphabetically" value="true"/>
 		</module>
+        <module name="IllegalImport">
+            <property name="illegalClasses" value="org.jspecify.annotations.Nullable"/>
+        </module>
 
 		<!-- Ensures braces are at the end of a line -->
 		<module name="LeftCurly"/>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -75,7 +75,8 @@
 			<property name="sortStaticImportsAlphabetically" value="true"/>
 		</module>
         <module name="IllegalImport">
-            <property name="illegalClasses" value="org.jspecify.annotations.Nullable"/>
+            <property name="illegalClasses" value="org.jetbrains.annotations.NotNull"/>
+            <property name="illegalClasses" value="org.jetbrains.annotations.Nullable"/>
         </module>
 
 		<!-- Ensures braces are at the end of a line -->

--- a/gradle/package-info.gradle
+++ b/gradle/package-info.gradle
@@ -1,17 +1,20 @@
 import java.nio.file.Files
 
-sourceSets.configureEach { sourceSet ->
+for (def sourceSet in [
+		sourceSets.main,
+		sourceSets.test
+]) {
 	def sourceSetName = sourceSet.name
 	def taskName = sourceSet.getTaskName('generate', 'PackageInfos')
 	tasks.register(taskName, GeneratePackageInfos) {
 		description = "Generates package-info files for $sourceSetName packages."
-		sourceRoot = sourceSet.java.srcDirs.first()
+		sourceRoot = file("src/$sourceSetName/java")
 		header = rootProject.file('HEADER')
 	}
 
 	def checkTask = tasks.register(sourceSet.getTaskName('check', 'PackageInfos'), CheckPackageInfos) {
 		description = "Checks that all $sourceSetName packages have package-info files."
-		sourceRoot = sourceSet.java.srcDirs.first()
+		sourceRoot = file("src/$sourceSetName/java")
 	}
 	tasks.check.dependsOn checkTask
 }
@@ -42,6 +45,7 @@ abstract class GeneratePackageInfos extends DefaultTask {
 
 			def relativePath = root.relativize(it)
 			def packageName = relativePath.toString().replace(File.separator, '.')
+			String year = Calendar.getInstance().get(Calendar.YEAR).toString()
 
 			it.resolve('package-info.java').withWriter {
 				it.write("""$headerText
@@ -49,7 +53,7 @@ abstract class GeneratePackageInfos extends DefaultTask {
 						|package $packageName;
 						|
 						|import org.jspecify.annotations.NullMarked;
-						|""".stripMargin())
+						|""".replace("\$YEAR", year).stripMargin())
 			}
 		}
 	}

--- a/gradle/package-info.gradle
+++ b/gradle/package-info.gradle
@@ -1,0 +1,87 @@
+import java.nio.file.Files
+
+sourceSets.configureEach { sourceSet ->
+	def sourceSetName = sourceSet.name
+	def taskName = sourceSet.getTaskName('generate', 'PackageInfos')
+	tasks.register(taskName, GeneratePackageInfos) {
+		description = "Generates package-info files for $sourceSetName packages."
+		sourceRoot = sourceSet.java.srcDirs.first()
+		header = rootProject.file('HEADER')
+	}
+
+	def checkTask = tasks.register(sourceSet.getTaskName('check', 'PackageInfos'), CheckPackageInfos) {
+		description = "Checks that all $sourceSetName packages have package-info files."
+		sourceRoot = sourceSet.java.srcDirs.first()
+	}
+	tasks.check.dependsOn checkTask
+}
+
+abstract class GeneratePackageInfos extends DefaultTask {
+	@InputFile
+	File header
+
+	@InputDirectory
+	abstract DirectoryProperty getSourceRoot()
+
+	GeneratePackageInfos() {
+	}
+
+	@TaskAction
+	def run() {
+		def headerText = header.readLines().join("\n") // normalize line endings
+		def root = sourceRoot.get().asFile.toPath()
+
+		root.eachDirRecurse {
+			def containsJava = Files.list(it).any {
+				Files.isRegularFile(it) && it.fileName.toString().endsWith('.java')
+			}
+
+			if (!containsJava) {
+				return
+			}
+
+			def relativePath = root.relativize(it)
+			def packageName = relativePath.toString().replace(File.separator, '.')
+
+			it.resolve('package-info.java').withWriter {
+				it.write("""$headerText
+						|@NullMarked
+						|package $packageName;
+						|
+						|import org.jspecify.annotations.NullMarked;
+						|""".stripMargin())
+			}
+		}
+	}
+}
+
+abstract class CheckPackageInfos extends DefaultTask {
+	@InputDirectory
+	abstract DirectoryProperty getSourceRoot()
+
+	@TaskAction
+	def run() {
+		def root = sourceRoot.get().asFile.toPath()
+		def errors = []
+
+		root.eachDirRecurse {
+			def containsJava = Files.list(it).any {
+				Files.isRegularFile(it) && it.fileName.toString().endsWith('.java')
+			}
+
+			if (!containsJava) {
+				return
+			}
+
+			def packageInfoPath = it.resolve('package-info.java')
+			if (!Files.exists(packageInfoPath)) {
+				errors << "Missing package-info.java in package: " + root.relativize(it).toString().replace(File.separator, '.')
+				return
+			}
+		}
+
+		if (!errors.isEmpty()) {
+			throw new GradleException("Package info check failed:\n" + errors.join("\n"))
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/LoomCompanionGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomCompanionGradlePlugin.java
@@ -26,7 +26,6 @@ package net.fabricmc.loom;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.jetbrains.annotations.NotNull;
 
 import net.fabricmc.loom.configuration.LoomConfigurations;
 import net.fabricmc.loom.task.launch.ExportClasspathTask;
@@ -36,7 +35,7 @@ public class LoomCompanionGradlePlugin implements Plugin<Project> {
 	public static final String NAME = "net.fabricmc.fabric-loom-companion";
 
 	@Override
-	public void apply(@NotNull Project project) {
+	public void apply(Project project) {
 		var exportClassPathTask = project.getTasks().register(Constants.Task.EXPORT_CLASSPATH, ExportClasspathTask.class);
 		project.getConfigurations().register(Constants.Configurations.EXPORTED_CLASSPATH, LoomConfigurations.Role.CONSUMABLE::apply);
 		project.artifacts(artifactHandler -> artifactHandler.add(Constants.Configurations.EXPORTED_CLASSPATH, exportClassPathTask));

--- a/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
@@ -34,14 +34,13 @@ import org.gradle.api.initialization.Settings;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.PluginAware;
-import org.jetbrains.annotations.NotNull;
 
 import net.fabricmc.loom.extension.LoomFiles;
 import net.fabricmc.loom.util.MirrorUtil;
 
 public class LoomRepositoryPlugin implements Plugin<PluginAware> {
 	@Override
-	public void apply(@NotNull PluginAware target) {
+	public void apply(PluginAware target) {
 		if (target instanceof Settings settings) {
 			declareRepositories(settings.getDependencyResolutionManagement().getRepositories(), LoomFiles.create(settings), settings);
 

--- a/src/main/java/net/fabricmc/loom/api/RemapConfigurationSettings.java
+++ b/src/main/java/net/fabricmc/loom/api/RemapConfigurationSettings.java
@@ -38,7 +38,6 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.SourceSet;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftSourceSets;
 
@@ -62,7 +61,7 @@ public abstract class RemapConfigurationSettings implements Named {
 	}
 
 	@Override
-	public @NotNull String getName() {
+	public String getName() {
 		return name;
 	}
 

--- a/src/main/java/net/fabricmc/loom/api/decompilers/package-info.java
+++ b/src/main/java/net/fabricmc/loom/api/decompilers/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.api.decompilers;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/api/fabricapi/package-info.java
+++ b/src/main/java/net/fabricmc/loom/api/fabricapi/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.api.fabricapi;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/api/fmj/package-info.java
+++ b/src/main/java/net/fabricmc/loom/api/fmj/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.api.fmj;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/api/manifest/package-info.java
+++ b/src/main/java/net/fabricmc/loom/api/manifest/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.api.manifest;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/api/mappings/intermediate/package-info.java
+++ b/src/main/java/net/fabricmc/loom/api/mappings/intermediate/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.api.mappings.intermediate;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/api/mappings/layered/MappingsNamespace.java
+++ b/src/main/java/net/fabricmc/loom/api/mappings/layered/MappingsNamespace.java
@@ -26,7 +26,7 @@ package net.fabricmc.loom.api.mappings.layered;
 
 import java.util.Locale;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The standard namespaces used by loom.

--- a/src/main/java/net/fabricmc/loom/api/mappings/layered/package-info.java
+++ b/src/main/java/net/fabricmc/loom/api/mappings/layered/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.api.mappings.layered;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/package-info.java
+++ b/src/main/java/net/fabricmc/loom/api/mappings/layered/spec/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.api.mappings.layered.spec;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/api/package-info.java
+++ b/src/main/java/net/fabricmc/loom/api/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.api;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/api/processor/MinecraftJarProcessor.java
+++ b/src/main/java/net/fabricmc/loom/api/processor/MinecraftJarProcessor.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.gradle.api.Named;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
 

--- a/src/main/java/net/fabricmc/loom/api/processor/package-info.java
+++ b/src/main/java/net/fabricmc/loom/api/processor/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.api.processor;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/api/remapping/TinyRemapperExtension.java
+++ b/src/main/java/net/fabricmc/loom/api/remapping/TinyRemapperExtension.java
@@ -25,7 +25,7 @@
 package net.fabricmc.loom.api.remapping;
 
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.tinyremapper.TinyRemapper;
 
@@ -41,8 +41,7 @@ public interface TinyRemapperExtension {
 	 *
 	 * @return A {@link TinyRemapper.AnalyzeVisitorProvider} or {@code null}.
 	 */
-	@Nullable
-	default TinyRemapper.AnalyzeVisitorProvider getAnalyzeVisitorProvider(Context context) {
+	default TinyRemapper.@Nullable AnalyzeVisitorProvider getAnalyzeVisitorProvider(Context context) {
 		return getAnalyzeVisitorProvider();
 	}
 
@@ -51,8 +50,7 @@ public interface TinyRemapperExtension {
 	 *
 	 * @return A {@link TinyRemapper.ApplyVisitorProvider} or {@code null}.
 	 */
-	@Nullable
-	default TinyRemapper.ApplyVisitorProvider getPreApplyVisitor(Context context) {
+	default TinyRemapper.@Nullable ApplyVisitorProvider getPreApplyVisitor(Context context) {
 		return getPreApplyVisitor();
 	}
 
@@ -61,8 +59,7 @@ public interface TinyRemapperExtension {
 	 *
 	 * @return A {@link TinyRemapper.ApplyVisitorProvider} or {@code null}.
 	 */
-	@Nullable
-	default TinyRemapper.ApplyVisitorProvider getPostApplyVisitor(Context context) {
+	default TinyRemapper.@Nullable ApplyVisitorProvider getPostApplyVisitor(Context context) {
 		return getPostApplyVisitor();
 	}
 
@@ -84,8 +81,7 @@ public interface TinyRemapperExtension {
 	 * @deprecated Use {@link #getAnalyzeVisitorProvider(Context)} instead.
 	 */
 	@Deprecated(forRemoval = true)
-	@Nullable
-	default TinyRemapper.AnalyzeVisitorProvider getAnalyzeVisitorProvider() {
+	default TinyRemapper.@Nullable AnalyzeVisitorProvider getAnalyzeVisitorProvider() {
 		return null;
 	}
 
@@ -93,8 +89,7 @@ public interface TinyRemapperExtension {
 	 * @deprecated Use {@link #getPreApplyVisitor(Context)} instead.
 	 */
 	@Deprecated(forRemoval = true)
-	@Nullable
-	default TinyRemapper.ApplyVisitorProvider getPreApplyVisitor() {
+	default TinyRemapper.@Nullable ApplyVisitorProvider getPreApplyVisitor() {
 		return null;
 	}
 
@@ -102,8 +97,7 @@ public interface TinyRemapperExtension {
 	 * @deprecated Use {@link #getPostApplyVisitor(Context)} instead.
 	 */
 	@Deprecated(forRemoval = true)
-	@Nullable
-	default TinyRemapper.ApplyVisitorProvider getPostApplyVisitor() {
+	default TinyRemapper.@Nullable ApplyVisitorProvider getPostApplyVisitor() {
 		return null;
 	}
 }

--- a/src/main/java/net/fabricmc/loom/api/remapping/package-info.java
+++ b/src/main/java/net/fabricmc/loom/api/remapping/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.api.remapping;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/build/mixin/package-info.java
+++ b/src/main/java/net/fabricmc/loom/build/mixin/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.build.mixin;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/build/nesting/NestableJarGenerationTask.java
+++ b/src/main/java/net/fabricmc/loom/build/nesting/NestableJarGenerationTask.java
@@ -54,7 +54,7 @@ import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/net/fabricmc/loom/build/nesting/package-info.java
+++ b/src/main/java/net/fabricmc/loom/build/nesting/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.build.nesting;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -51,7 +51,6 @@ import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.api.tasks.testing.Test;
-import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.InterfaceInjectionExtensionAPI;
@@ -195,7 +194,7 @@ public abstract class CompileConfiguration implements Runnable {
 		}
 
 		// Provide the remapped mc jars
-		@Nullable IntermediaryMinecraftProvider<?> intermediaryMinecraftProvider = extension.disableObfuscation() ? null : jarConfiguration.createIntermediaryMinecraftProvider(project);
+		IntermediaryMinecraftProvider<?> intermediaryMinecraftProvider = extension.disableObfuscation() ? null : jarConfiguration.createIntermediaryMinecraftProvider(project);
 		NamedMinecraftProvider<?> namedMinecraftProvider = jarConfiguration.createNamedMinecraftProvider(project);
 
 		registerGameProcessors(configContext);

--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -51,7 +51,7 @@ import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.api.tasks.testing.Test;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.InterfaceInjectionExtensionAPI;

--- a/src/main/java/net/fabricmc/loom/configuration/DebofInstallerData.java
+++ b/src/main/java/net/fabricmc/loom/configuration/DebofInstallerData.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/net/fabricmc/loom/configuration/accesswidener/AccessWidenerEntry.java
+++ b/src/main/java/net/fabricmc/loom/configuration/accesswidener/AccessWidenerEntry.java
@@ -26,7 +26,7 @@ package net.fabricmc.loom.configuration.accesswidener;
 
 import java.io.IOException;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.classtweaker.api.visitor.ClassTweakerVisitor;
 import net.fabricmc.loom.util.LazyCloseable;

--- a/src/main/java/net/fabricmc/loom/configuration/accesswidener/AccessWidenerJarProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/accesswidener/AccessWidenerJarProcessor.java
@@ -36,7 +36,7 @@ import java.util.List;
 import javax.inject.Inject;
 
 import org.gradle.api.file.RegularFileProperty;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.classtweaker.api.ClassTweaker;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
@@ -61,7 +61,7 @@ public class AccessWidenerJarProcessor implements MinecraftJarProcessor<AccessWi
 	}
 
 	@Override
-	public @Nullable AccessWidenerJarProcessor.Spec buildSpec(SpecContext context) {
+	public AccessWidenerJarProcessor.@Nullable Spec buildSpec(SpecContext context) {
 		List<AccessWidenerEntry> accessWideners = new ArrayList<>();
 
 		if (localAccessWidenerProperty.isPresent()) {

--- a/src/main/java/net/fabricmc/loom/configuration/accesswidener/LocalAccessWidenerEntry.java
+++ b/src/main/java/net/fabricmc/loom/configuration/accesswidener/LocalAccessWidenerEntry.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.classtweaker.api.ClassTweakerReader;
 import net.fabricmc.classtweaker.api.visitor.ClassTweakerVisitor;

--- a/src/main/java/net/fabricmc/loom/configuration/accesswidener/ModAccessWidenerEntry.java
+++ b/src/main/java/net/fabricmc/loom/configuration/accesswidener/ModAccessWidenerEntry.java
@@ -30,7 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.classtweaker.api.ClassTweakerReader;
 import net.fabricmc.classtweaker.api.visitor.ClassTweakerVisitor;

--- a/src/main/java/net/fabricmc/loom/configuration/accesswidener/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/accesswidener/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.accesswidener;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/classpathgroups/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/classpathgroups/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.classpathgroups;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/decompile/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/decompile/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.decompile;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/fabricapi/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/fabricapi/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.fabricapi;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/ide/idea/DownloadSourcesHook.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/idea/DownloadSourcesHook.java
@@ -34,7 +34,7 @@ import java.util.regex.Pattern;
 
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,8 +121,7 @@ record DownloadSourcesHook(Project project, Task task) {
 	}
 
 	// Return the jar type, or null when this jar isnt used by the project
-	@Nullable
-	private MinecraftJar.Type getJarType(String name) {
+	private MinecraftJar.@Nullable Type getJarType(String name) {
 		final LoomGradleExtension extension = LoomGradleExtension.get(project);
 		final NamedMinecraftProvider<?> minecraftProvider = extension.getNamedMinecraftProvider();
 		final List<MinecraftJar.Type> dependencyTypes = minecraftProvider.getDependencyTypes();

--- a/src/main/java/net/fabricmc/loom/configuration/ide/idea/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/idea/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.ide.idea;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/ide/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.ide;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
@@ -41,7 +41,7 @@ import javax.inject.Inject;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -84,7 +84,7 @@ public abstract class InterfaceInjectionProcessor implements MinecraftJarProcess
 	}
 
 	@Override
-	public @Nullable InterfaceInjectionProcessor.Spec buildSpec(SpecContext context) {
+	public InterfaceInjectionProcessor.@Nullable Spec buildSpec(SpecContext context) {
 		List<InjectedInterface> injectedInterfaces = new ArrayList<>();
 
 		injectedInterfaces.addAll(InjectedInterface.fromMods(context.localMods()));

--- a/src/main/java/net/fabricmc/loom/configuration/ifaceinject/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ifaceinject/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.ifaceinject;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactMetadata.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactMetadata.java
@@ -36,7 +36,7 @@ import java.util.function.Predicate;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.configuration.InstallerData;
 import net.fabricmc.loom.util.Constants;

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactRef.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactRef.java
@@ -35,7 +35,7 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.util.Checksum;
 

--- a/src/main/java/net/fabricmc/loom/configuration/mods/JarSplitter.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/JarSplitter.java
@@ -41,7 +41,7 @@ import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import java.util.stream.Stream;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.FileSystemUtil;

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
@@ -58,7 +58,7 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.jvm.JvmLibrary;
 import org.gradle.language.base.artifact.SourcesArtifact;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
@@ -278,7 +278,7 @@ public class ModConfigurationRemapper {
 		Map<ResolvedArtifact, Path> sourcesMap = downloadAllSources(project, resolvedArtifacts);
 
 		for (ResolvedArtifact artifact : resolvedArtifacts) {
-			@Nullable Path sources = sourcesMap.get(artifact);
+			Path sources = sourcesMap.get(artifact);
 			artifacts.add(new ArtifactRef.ResolvedArtifactRef(artifact, sources));
 		}
 

--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/LocalMavenHelper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/LocalMavenHelper.java
@@ -32,7 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public record LocalMavenHelper(String group, String name, String version, @Nullable String baseClassifier, Path root, @Nullable String snapshotVersion) {
 	public LocalMavenHelper(String group, String name, String version, @Nullable String baseClassifier, Path root) {

--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/ModDependency.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/ModDependency.java
@@ -30,7 +30,7 @@ import java.nio.file.Path;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenUniqueSnapshotComponentIdentifier;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.configuration.mods.ArtifactMetadata;

--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/ModDependencyFactory.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/ModDependencyFactory.java
@@ -30,7 +30,7 @@ import java.util.Optional;
 
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.configuration.mods.ArtifactMetadata;

--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SimpleModDependency.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SimpleModDependency.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.configuration.mods.ArtifactMetadata;
 import net.fabricmc.loom.configuration.mods.ArtifactRef;

--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SplitModDependency.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SplitModDependency.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.ModSettings;

--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.mods.dependency;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/refmap/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/refmap/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.mods.dependency.refmap;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/mods/extension/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/extension/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.mods.extension;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/mods/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.mods;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/processors/LegacyJarProcessorWrapper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/LegacyJarProcessorWrapper.java
@@ -30,7 +30,7 @@ import java.nio.file.Path;
 import javax.inject.Inject;
 
 import org.gradle.api.Project;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.api.processor.MinecraftJarProcessor;
 import net.fabricmc.loom.api.processor.ProcessorContext;
@@ -56,7 +56,7 @@ public abstract class LegacyJarProcessorWrapper implements MinecraftJarProcessor
 	}
 
 	@Override
-	public @Nullable LegacyJarProcessorWrapper.Spec buildSpec(SpecContext context) {
+	public LegacyJarProcessorWrapper.@Nullable Spec buildSpec(SpecContext context) {
 		delegate.setup();
 		return new Spec(delegate.getId());
 	}

--- a/src/main/java/net/fabricmc/loom/configuration/processors/MinecraftJarProcessorManager.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/MinecraftJarProcessorManager.java
@@ -36,7 +36,7 @@ import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 import org.gradle.api.Project;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -162,7 +162,7 @@ public final class MinecraftJarProcessorManager {
 		return transformed;
 	}
 
-	record ProcessorEntry<S extends MinecraftJarProcessor.Spec>(S spec, MinecraftJarProcessor<S> processor, @Nullable MinecraftJarProcessor.MappingsProcessor<S> mappingsProcessor) {
+	record ProcessorEntry<S extends MinecraftJarProcessor.Spec>(S spec, MinecraftJarProcessor<S> processor, MinecraftJarProcessor.@Nullable MappingsProcessor<S> mappingsProcessor) {
 		@SuppressWarnings("unchecked")
 		ProcessorEntry(MinecraftJarProcessor<?> processor, MinecraftJarProcessor.Spec spec) {
 			this((S) Objects.requireNonNull(spec), (MinecraftJarProcessor<S>) processor, (MinecraftJarProcessor.MappingsProcessor<S>) processor.processMappings());

--- a/src/main/java/net/fabricmc/loom/configuration/processors/ModJavadocProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/ModJavadocProcessor.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 import javax.inject.Inject;
 
 import com.google.gson.JsonElement;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,7 +76,7 @@ public abstract class ModJavadocProcessor implements MinecraftJarProcessor<ModJa
 	}
 
 	@Override
-	public @Nullable ModJavadocProcessor.Spec buildSpec(SpecContext context) {
+	public ModJavadocProcessor.@Nullable Spec buildSpec(SpecContext context) {
 		List<ModJavadoc> javadocs = new ArrayList<>();
 
 		for (FabricModJson fabricModJson : context.allMods()) {

--- a/src/main/java/net/fabricmc/loom/configuration/processors/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.processors;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/processors/speccontext/RemappedSpecContext.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/speccontext/RemappedSpecContext.java
@@ -39,7 +39,7 @@ import java.util.stream.Stream;
 
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaPlugin;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import net.fabricmc.loom.api.RemapConfigurationSettings;

--- a/src/main/java/net/fabricmc/loom/configuration/processors/speccontext/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/speccontext/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.processors.speccontext;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/BundleMetadata.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/BundleMetadata.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.gradle.api.Project;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.util.AttributeHelper;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/IntermediaryMappingsProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/IntermediaryMappingsProvider.java
@@ -41,7 +41,6 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.dsl.DependencyFactory;
 import org.gradle.api.provider.Property;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -108,7 +107,7 @@ public abstract class IntermediaryMappingsProvider extends IntermediateMappingsP
 	}
 
 	@Override
-	public @NotNull String getName() {
+	public String getName() {
 		final String encodedMcVersion = URLEncoder.encode(getMinecraftVersion().get(), StandardCharsets.UTF_8);
 		final String urlRaw = getIntermediaryUrl().get();
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/IntermediaryMappingsProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/IntermediaryMappingsProvider.java
@@ -42,7 +42,7 @@ import org.gradle.api.artifacts.dsl.DependencyFactory;
 import org.gradle.api.provider.Property;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/IntermediateMappingsProviderInternal.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/IntermediateMappingsProviderInternal.java
@@ -29,7 +29,7 @@ import java.nio.file.Path;
 
 import org.gradle.api.Project;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.api.mappings.intermediate.IntermediateMappingsProvider;
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsProcessor.java
@@ -32,7 +32,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.api.mappings.layered.MappingContext;
 import net.fabricmc.loom.api.mappings.layered.MappingLayer;
@@ -152,8 +152,7 @@ public class LayeredMappingsProcessor {
 		return Collections.unmodifiableMap(signatureFixes);
 	}
 
-	@Nullable
-	public UnpickLayer.UnpickData getUnpickData(List<MappingLayer> layers) throws IOException {
+	public UnpickLayer.@Nullable UnpickData getUnpickData(List<MappingLayer> layers) throws IOException {
 		List<UnpickLayer.UnpickData> unpickDataList = new ArrayList<>();
 
 		for (MappingLayer layer : layers) {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
@@ -42,7 +42,7 @@ import java.util.Objects;
 import org.apache.tools.ant.util.StringUtils;
 import org.gradle.api.Project;
 import org.gradle.api.provider.Provider;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/NoOpIntermediateMappingsProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/NoOpIntermediateMappingsProvider.java
@@ -29,8 +29,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.jetbrains.annotations.NotNull;
-
 import net.fabricmc.loom.api.mappings.intermediate.IntermediateMappingsProvider;
 
 /**
@@ -46,7 +44,7 @@ public abstract class NoOpIntermediateMappingsProvider extends IntermediateMappi
 	}
 
 	@Override
-	public @NotNull String getName() {
+	public String getName() {
 		return "empty-intermediate";
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/TinyMappingsService.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/TinyMappingsService.java
@@ -37,7 +37,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.util.FileSystemUtil;
 import net.fabricmc.loom.util.Lazy;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/annotations/AnnotationNodeSerializer.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/annotations/AnnotationNodeSerializer.java
@@ -36,7 +36,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.tree.AnnotationNode;
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/annotations/AnnotationsData.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/annotations/AnnotationsData.java
@@ -41,7 +41,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import org.gradle.api.Project;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.TypeAnnotationNode;
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/annotations/AnnotationsLayer.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/annotations/AnnotationsLayer.java
@@ -27,7 +27,7 @@ package net.fabricmc.loom.configuration.providers.mappings.extras.annotations;
 import java.io.IOException;
 
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @ApiStatus.Experimental
 public interface AnnotationsLayer {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/annotations/ClassAnnotationData.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/annotations/ClassAnnotationData.java
@@ -33,7 +33,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.gson.annotations.SerializedName;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.TypeAnnotationNode;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/annotations/TypeAnnotationKey.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/annotations/TypeAnnotationKey.java
@@ -24,7 +24,7 @@
 
 package net.fabricmc.loom.configuration.providers.mappings.extras.annotations;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.tinyremapper.TinyRemapper;
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/annotations/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/annotations/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.providers.mappings.extras.annotations;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/annotations/validate/AnnotationsDataValidator.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/annotations/validate/AnnotationsDataValidator.java
@@ -35,7 +35,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/annotations/validate/TypePathCheckerVisitor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/annotations/validate/TypePathCheckerVisitor.java
@@ -27,7 +27,7 @@ package net.fabricmc.loom.configuration.providers.mappings.extras.annotations.va
 import java.util.ArrayDeque;
 import java.util.Deque;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.objectweb.asm.TypePath;
 import org.objectweb.asm.signature.SignatureVisitor;
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/annotations/validate/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/annotations/validate/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.providers.mappings.extras.annotations.validate;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/signatures/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/signatures/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.providers.mappings.extras.signatures;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/unpick/UnpickLayer.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/unpick/UnpickLayer.java
@@ -29,7 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.configuration.providers.mappings.unpick.UnpickMetadata;
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/unpick/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/unpick/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.providers.mappings.extras.unpick;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsLayer.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsLayer.java
@@ -31,7 +31,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.api.mappings.layered.MappingLayer;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.providers.mappings.file;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/intermediary/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/intermediary/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.providers.mappings.intermediary;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/mojmap/MojangMappingLayer.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/mojmap/MojangMappingLayer.java
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import org.gradle.api.logging.Logger;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.api.mappings.layered.MappingLayer;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/mojmap/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/mojmap/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.providers.mappings.mojmap;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.providers.mappings;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/parchment/ParchmentTreeV1.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/parchment/ParchmentTreeV1.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingVisitor;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/parchment/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/parchment/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.providers.mappings.parchment;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/tiny/UnobfuscatedMappingNsCompleter.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/tiny/UnobfuscatedMappingNsCompleter.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingVisitor;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/tiny/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/tiny/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.providers.mappings.tiny;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/unpick/UnpickMetadata.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/unpick/UnpickMetadata.java
@@ -30,7 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import com.google.gson.JsonObject;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradlePlugin;
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/unpick/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/unpick/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.providers.mappings.unpick;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/utils/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/utils/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.providers.mappings.utils;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/AnnotationsApplyVisitor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/AnnotationsApplyVisitor.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
@@ -33,7 +33,7 @@ import java.util.function.Function;
 
 import org.gradle.api.Project;
 import org.gradle.api.provider.Property;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.LoomGradlePlugin;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftProvider.java
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftVersionMeta.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftVersionMeta.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.Platform;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/VersionsManifest.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/VersionsManifest.java
@@ -27,7 +27,7 @@ package net.fabricmc.loom.configuration.providers.minecraft;
 import java.util.List;
 import java.util.Map;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public record VersionsManifest(List<Version> versions, Map<String, String> latest) {
 	public static class Version {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/assets/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/assets/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.providers.minecraft.assets;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/Library.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/Library.java
@@ -24,7 +24,7 @@
 
 package net.fabricmc.loom.configuration.providers.minecraft.library;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public record Library(String group, String name, String version, @Nullable String classifier, Target target) {
 	public enum Target {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.providers.minecraft.library;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/processors/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/processors/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.providers.minecraft.library.processors;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.providers.minecraft.mapped;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.providers.minecraft;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/verify/CertificateChain.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/verify/CertificateChain.java
@@ -35,7 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A node in the certificate chain.
@@ -142,7 +142,7 @@ public interface CertificateChain {
 
 	class Impl implements CertificateChain {
 		X509Certificate certificate;
-		@Nullable CertificateChain.Impl issuer;
+		CertificateChain.@Nullable Impl issuer;
 		List<CertificateChain> children = new ArrayList<>();
 
 		private Impl() {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/verify/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/verify/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.providers.minecraft.verify;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.providers;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/configuration/sandbox/package-info.java
+++ b/src/main/java/net/fabricmc/loom/configuration/sandbox/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.configuration.sandbox;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/decompilers/ClassLineNumbers.java
+++ b/src/main/java/net/fabricmc/loom/decompilers/ClassLineNumbers.java
@@ -34,7 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public record ClassLineNumbers(Map<String, ClassLineNumbers.Entry> lineMap) {
 	public ClassLineNumbers {

--- a/src/main/java/net/fabricmc/loom/decompilers/cache/CachedData.java
+++ b/src/main/java/net/fabricmc/loom/decompilers/cache/CachedData.java
@@ -39,7 +39,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Objects;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +48,7 @@ import net.fabricmc.loom.decompilers.ClassLineNumbers;
 // Serialised data for a class entry in the cache
 // Uses the RIFF format, allows for appending the line numbers to the end of the file
 // Stores the source code and line numbers for the class
-public record CachedData(String className, String sources, @Nullable ClassLineNumbers.Entry lineNumbers) {
+public record CachedData(String className, String sources, ClassLineNumbers.@Nullable Entry lineNumbers) {
 	public static final CachedFileStore.EntrySerializer<CachedData> SERIALIZER = new EntrySerializer();
 
 	private static final String HEADER_ID = "LOOM";

--- a/src/main/java/net/fabricmc/loom/decompilers/cache/CachedFileStore.java
+++ b/src/main/java/net/fabricmc/loom/decompilers/cache/CachedFileStore.java
@@ -27,7 +27,7 @@ package net.fabricmc.loom.decompilers.cache;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public interface CachedFileStore<T> {
 	@Nullable T getEntry(String key) throws IOException;

--- a/src/main/java/net/fabricmc/loom/decompilers/cache/CachedFileStoreImpl.java
+++ b/src/main/java/net/fabricmc/loom/decompilers/cache/CachedFileStoreImpl.java
@@ -38,7 +38,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public record CachedFileStoreImpl<T>(Path root, EntrySerializer<T> entrySerializer, CacheRules cacheRules) implements CachedFileStore<T> {
 	public CachedFileStoreImpl {

--- a/src/main/java/net/fabricmc/loom/decompilers/cache/CachedJarProcessor.java
+++ b/src/main/java/net/fabricmc/loom/decompilers/cache/CachedJarProcessor.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/net/fabricmc/loom/decompilers/cache/package-info.java
+++ b/src/main/java/net/fabricmc/loom/decompilers/cache/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.decompilers.cache;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/decompilers/package-info.java
+++ b/src/main/java/net/fabricmc/loom/decompilers/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.decompilers;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/extension/MixinExtension.java
+++ b/src/main/java/net/fabricmc/loom/extension/MixinExtension.java
@@ -41,7 +41,7 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.util.PatternSet;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.api.MixinExtensionAPI;
 

--- a/src/main/java/net/fabricmc/loom/extension/MixinExtension.java
+++ b/src/main/java/net/fabricmc/loom/extension/MixinExtension.java
@@ -40,7 +40,6 @@ import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.util.PatternSet;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.api.MixinExtensionAPI;
@@ -76,16 +75,12 @@ public interface MixinExtension extends MixinExtensionAPI {
 		extra.set(MIXIN_INFORMATION_CONTAINER, container);
 	}
 
-	@NotNull
 	Stream<SourceSet> getMixinSourceSetsStream();
 
-	@NotNull
 	Stream<Configuration> getApConfigurationsStream(Function<SourceSet, String> getApConfigNameFunc);
 
-	@NotNull
 	<T extends Task> Stream<Map.Entry<SourceSet, TaskProvider<T>>> getInvokerTasksStream(String compileTaskLanguage, Class<T> taskType);
 
-	@NotNull
 	@Input
 	Collection<SourceSet> getMixinSourceSets();
 

--- a/src/main/java/net/fabricmc/loom/extension/MixinExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/MixinExtensionImpl.java
@@ -47,7 +47,6 @@ import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.util.PatternSet;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 public class MixinExtensionImpl extends MixinExtensionApiImpl implements MixinExtension {
 	private boolean isDefault;
@@ -92,21 +91,18 @@ public class MixinExtensionImpl extends MixinExtensionApiImpl implements MixinEx
 	}
 
 	@Override
-	@NotNull
 	public Stream<SourceSet> getMixinSourceSetsStream() {
 		return project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets().stream()
 				.filter(sourceSet -> MixinExtension.getMixinInformationContainer(sourceSet) != null);
 	}
 
 	@Override
-	@NotNull
 	public Stream<Configuration> getApConfigurationsStream(Function<SourceSet, String> getApConfigNameFunc) {
 		return getMixinSourceSetsStream()
 				.map(sourceSet -> project.getConfigurations().getByName(getApConfigNameFunc.apply(sourceSet)));
 	}
 
 	@Override
-	@NotNull
 	public <T extends Task> Stream<Map.Entry<SourceSet, TaskProvider<T>>> getInvokerTasksStream(String compileTaskLanguage, Class<T> taskType) {
 		return getMixinSourceSetsStream()
 				.flatMap(sourceSet -> {
@@ -120,7 +116,6 @@ public class MixinExtensionImpl extends MixinExtensionApiImpl implements MixinEx
 	}
 
 	@Override
-	@NotNull
 	@Input
 	public Collection<SourceSet> getMixinSourceSets() {
 		return getMixinSourceSetsStream().collect(Collectors.toList());

--- a/src/main/java/net/fabricmc/loom/extension/RemapperExtensionHolder.java
+++ b/src/main/java/net/fabricmc/loom/extension/RemapperExtensionHolder.java
@@ -31,7 +31,7 @@ import javax.inject.Inject;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.commons.Remapper;
 

--- a/src/main/java/net/fabricmc/loom/extension/package-info.java
+++ b/src/main/java/net/fabricmc/loom/extension/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.extension;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/package-info.java
+++ b/src/main/java/net/fabricmc/loom/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
@@ -51,7 +51,6 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.process.ExecOperations;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -242,13 +241,13 @@ public abstract class AbstractRunTask extends JavaExec {
 	}
 
 	// https://github.com/JetBrains/intellij-community/blob/295dd68385a458bdfde638152e36d19bed18b666/platform/util/base/src/com/intellij/openapi/util/text/Strings.java#L100-L118
-	public static boolean containsAnyChar(final @NotNull String value, final @NotNull String chars) {
+	public static boolean containsAnyChar(final String value, final String chars) {
 		return chars.length() > value.length()
 				? containsAnyChar(value, chars, 0, value.length())
 				: containsAnyChar(chars, value, 0, chars.length());
 	}
 
-	public static boolean containsAnyChar(final @NotNull String value, final @NotNull String chars, final int start, final int end) {
+	public static boolean containsAnyChar(final String value, final String chars, final int start, final int end) {
 		for (int i = start; i < end; i++) {
 			if (chars.indexOf(value.charAt(i)) >= 0) {
 				return true;
@@ -259,19 +258,19 @@ public abstract class AbstractRunTask extends JavaExec {
 	}
 
 	@Override
-	public @NotNull JavaExec setClasspath(@NotNull FileCollection classpath) {
+	public JavaExec setClasspath(FileCollection classpath) {
 		this.getInternalClasspath().setFrom(classpath);
 		return this;
 	}
 
 	@Override
-	public @NotNull JavaExec classpath(Object @NotNull... paths) {
+	public JavaExec classpath(Object... paths) {
 		this.getInternalClasspath().from(paths);
 		return this;
 	}
 
 	@Override
-	public @NotNull FileCollection getClasspath() {
+	public FileCollection getClasspath() {
 		return this.getInternalClasspath();
 	}
 

--- a/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
@@ -68,7 +68,7 @@ import org.gradle.workers.WorkQueue;
 import org.gradle.workers.WorkerExecutor;
 import org.gradle.workers.internal.WorkerDaemonClientsManager;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.decompilers.DecompilationMetadata;

--- a/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
@@ -316,7 +316,7 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 
 		if (job instanceof CachedJarProcessor.WorkToDoJob workToDoJob) {
 			Path workInputJar = workToDoJob.incomplete();
-			@Nullable Path existingClasses = (job instanceof CachedJarProcessor.PartialWorkJob partialWorkJob) ? partialWorkJob.existingClasses() : null;
+			Path existingClasses = (job instanceof CachedJarProcessor.PartialWorkJob partialWorkJob) ? partialWorkJob.existingClasses() : null;
 
 			if (usingUnpick()) {
 				try (var timer = new Timer("Unpick")) {

--- a/src/main/java/net/fabricmc/loom/task/LoomTasks.java
+++ b/src/main/java/net/fabricmc/loom/task/LoomTasks.java
@@ -37,7 +37,6 @@ import org.gradle.api.tasks.Sync;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskOutputs;
 import org.gradle.api.tasks.TaskProvider;
-import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.configuration.ide.RunConfigSettings;
@@ -72,7 +71,7 @@ public abstract class LoomTasks implements Runnable {
 			t.setDescription("Generate the log4j config file");
 		});
 
-		@Nullable TaskProvider<GenerateRemapClasspathTask> generateRemapClasspath = null;
+		TaskProvider<GenerateRemapClasspathTask> generateRemapClasspath = null;
 
 		if (!extension.disableObfuscation()) {
 			generateRemapClasspath = getTasks().register("generateRemapClasspath", GenerateRemapClasspathTask.class, t -> {
@@ -81,7 +80,7 @@ public abstract class LoomTasks implements Runnable {
 		}
 
 		// Make the lambda happy
-		final @Nullable TaskProvider<GenerateRemapClasspathTask> generateRemapClasspathTask = generateRemapClasspath;
+		final TaskProvider<GenerateRemapClasspathTask> generateRemapClasspathTask = generateRemapClasspath;
 
 		getTasks().register("generateDLIConfig", GenerateDLIConfigTask.class, t -> {
 			t.setDescription("Generate the DevLaunchInjector config file");

--- a/src/main/java/net/fabricmc/loom/task/LoomTasks.java
+++ b/src/main/java/net/fabricmc/loom/task/LoomTasks.java
@@ -37,7 +37,7 @@ import org.gradle.api.tasks.Sync;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskOutputs;
 import org.gradle.api.tasks.TaskProvider;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.configuration.ide.RunConfigSettings;

--- a/src/main/java/net/fabricmc/loom/task/ManifestModificationAction.java
+++ b/src/main/java/net/fabricmc/loom/task/ManifestModificationAction.java
@@ -39,7 +39,6 @@ import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.provider.Provider;
 import org.gradle.jvm.tasks.Jar;
-import org.jetbrains.annotations.NotNull;
 
 import net.fabricmc.loom.task.service.JarManifestService;
 import net.fabricmc.loom.util.Check;
@@ -68,7 +67,7 @@ public class ManifestModificationAction implements Action<Task>, Serializable {
 	}
 
 	@Override
-	public void execute(@NotNull Task t) {
+	public void execute(Task t) {
 		final Jar jarTask = (Jar) t;
 		final File jarFile = jarTask.getArchiveFile().get().getAsFile();
 

--- a/src/main/java/net/fabricmc/loom/task/NestJarsAction.java
+++ b/src/main/java/net/fabricmc/loom/task/NestJarsAction.java
@@ -41,7 +41,6 @@ import org.gradle.workers.WorkAction;
 import org.gradle.workers.WorkParameters;
 import org.gradle.workers.WorkQueue;
 import org.gradle.workers.WorkerExecutor;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +66,7 @@ public abstract class NestJarsAction implements Action<Task>, Serializable {
 	}
 
 	@Override
-	public void execute(@NotNull Task t) {
+	public void execute(Task t) {
 		final Jar jarTask = (Jar) t;
 
 		final WorkQueue workQueue = getWorkerExecutor().noIsolation();

--- a/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
@@ -47,7 +47,7 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/net/fabricmc/loom/task/ValidateMixinNameTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ValidateMixinNameTask.java
@@ -47,7 +47,7 @@ import org.gradle.workers.WorkAction;
 import org.gradle.workers.WorkParameters;
 import org.gradle.workers.WorkQueue;
 import org.gradle.workers.WorkerExecutor;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassReader;

--- a/src/main/java/net/fabricmc/loom/task/launch/package-info.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.task.launch;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/task/package-info.java
+++ b/src/main/java/net/fabricmc/loom/task/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.task;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/task/prod/package-info.java
+++ b/src/main/java/net/fabricmc/loom/task/prod/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.task.prod;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/task/service/MixinAPMappingService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/MixinAPMappingService.java
@@ -42,7 +42,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.SourceSet;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/net/fabricmc/loom/task/service/SourceMappingsService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/SourceMappingsService.java
@@ -39,7 +39,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/net/fabricmc/loom/task/service/TinyRemapperService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/TinyRemapperService.java
@@ -49,7 +49,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;

--- a/src/main/java/net/fabricmc/loom/task/service/UnpickService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/UnpickService.java
@@ -54,7 +54,7 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.tree.ClassNode;

--- a/src/main/java/net/fabricmc/loom/task/service/package-info.java
+++ b/src/main/java/net/fabricmc/loom/task/service/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.task.service;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/task/tool/package-info.java
+++ b/src/main/java/net/fabricmc/loom/task/tool/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.task.tool;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/util/Checksum.java
+++ b/src/main/java/net/fabricmc/loom/util/Checksum.java
@@ -39,7 +39,6 @@ import java.util.List;
 
 import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
-import org.jetbrains.annotations.NotNull;
 
 public final class Checksum {
 	public static Checksum of(byte[] data) {
@@ -152,7 +151,7 @@ public final class Checksum {
 		}
 
 		@Override
-		public void write(byte @NotNull[] b, int off, int len) {
+		public void write(byte[] b, int off, int len) {
 			digest.update(b, off, len);
 		}
 

--- a/src/main/java/net/fabricmc/loom/util/Lazy.java
+++ b/src/main/java/net/fabricmc/loom/util/Lazy.java
@@ -26,7 +26,7 @@ package net.fabricmc.loom.util;
 
 import java.util.function.Supplier;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 // Can be replaced by Lazy Constants (https://openjdk.org/jeps/526) once available.
 public final class Lazy {

--- a/src/main/java/net/fabricmc/loom/util/ZipUtils.java
+++ b/src/main/java/net/fabricmc/loom/util/ZipUtils.java
@@ -43,7 +43,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;

--- a/src/main/java/net/fabricmc/loom/util/download/GradleDownloadProgressListener.java
+++ b/src/main/java/net/fabricmc/loom/util/download/GradleDownloadProgressListener.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import org.gradle.internal.logging.progress.ProgressLogger;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public class GradleDownloadProgressListener implements DownloadProgressListener {
 	private final String name;

--- a/src/main/java/net/fabricmc/loom/util/download/package-info.java
+++ b/src/main/java/net/fabricmc/loom/util/download/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.util.download;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/util/fmj/FabricModJson.java
+++ b/src/main/java/net/fabricmc/loom/util/fmj/FabricModJson.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 
 public abstract sealed class FabricModJson permits FabricModJsonV0, FabricModJsonV1, FabricModJsonV2, FabricModJson.Mockable {

--- a/src/main/java/net/fabricmc/loom/util/fmj/FabricModJsonFactory.java
+++ b/src/main/java/net/fabricmc/loom/util/fmj/FabricModJsonFactory.java
@@ -39,7 +39,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.SourceSet;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/net/fabricmc/loom/util/fmj/FabricModJsonV0.java
+++ b/src/main/java/net/fabricmc/loom/util/fmj/FabricModJsonV0.java
@@ -33,7 +33,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @Deprecated
 public final class FabricModJsonV0 extends FabricModJson {

--- a/src/main/java/net/fabricmc/loom/util/fmj/FabricModJsonV1.java
+++ b/src/main/java/net/fabricmc/loom/util/fmj/FabricModJsonV1.java
@@ -36,7 +36,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public final class FabricModJsonV1 extends FabricModJson {
 	FabricModJsonV1(JsonObject jsonObject, FabricModJsonSource source) {

--- a/src/main/java/net/fabricmc/loom/util/fmj/FabricModJsonV2.java
+++ b/src/main/java/net/fabricmc/loom/util/fmj/FabricModJsonV2.java
@@ -34,7 +34,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.util.Pair;
 

--- a/src/main/java/net/fabricmc/loom/util/fmj/gen/package-info.java
+++ b/src/main/java/net/fabricmc/loom/util/fmj/gen/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.util.fmj.gen;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/util/fmj/mixin/MixinConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/util/fmj/mixin/MixinConfiguration.java
@@ -29,7 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.gson.JsonObject;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradlePlugin;
 import net.fabricmc.loom.util.fmj.FabricModJson;

--- a/src/main/java/net/fabricmc/loom/util/fmj/mixin/package-info.java
+++ b/src/main/java/net/fabricmc/loom/util/fmj/mixin/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.util.fmj.mixin;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/util/fmj/package-info.java
+++ b/src/main/java/net/fabricmc/loom/util/fmj/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.util.fmj;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/util/gradle/SourceSetHelper.java
+++ b/src/main/java/net/fabricmc/loom/util/gradle/SourceSetHelper.java
@@ -48,7 +48,7 @@ import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.SourceSetOutput;
 import org.intellij.lang.annotations.Language;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.xml.sax.InputSource;
 

--- a/src/main/java/net/fabricmc/loom/util/gradle/daemon/DaemonUtils.java
+++ b/src/main/java/net/fabricmc/loom/util/gradle/daemon/DaemonUtils.java
@@ -47,7 +47,7 @@ import org.gradle.launcher.daemon.registry.DaemonInfo;
 import org.gradle.launcher.daemon.registry.DaemonRegistry;
 import org.gradle.launcher.daemon.registry.PersistentDaemonRegistry;
 import org.gradle.util.GradleVersion;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/net/fabricmc/loom/util/gradle/daemon/package-info.java
+++ b/src/main/java/net/fabricmc/loom/util/gradle/daemon/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.util.gradle.daemon;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/util/gradle/package-info.java
+++ b/src/main/java/net/fabricmc/loom/util/gradle/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.util.gradle;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/util/ipc/package-info.java
+++ b/src/main/java/net/fabricmc/loom/util/ipc/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.util.ipc;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/util/kotlin/package-info.java
+++ b/src/main/java/net/fabricmc/loom/util/kotlin/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.util.kotlin;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/util/package-info.java
+++ b/src/main/java/net/fabricmc/loom/util/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.util;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/util/service/ServiceFactory.java
+++ b/src/main/java/net/fabricmc/loom/util/service/ServiceFactory.java
@@ -25,7 +25,7 @@
 package net.fabricmc.loom.util.service;
 
 import org.gradle.api.provider.Provider;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A factory for creating {@link Service} instances.

--- a/src/main/java/net/fabricmc/loom/util/service/package-info.java
+++ b/src/main/java/net/fabricmc/loom/util/service/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.util.service;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/test/groovy/net/fabricmc/loom/test/unit/processor/AnnotationsApplyTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/processor/AnnotationsApplyTest.groovy
@@ -159,7 +159,7 @@ class AnnotationsApplyTest extends Specification {
 				},
 				"field2:Ljava/lang/String;": {
 					"remove": [
-						"org/jetbrains/annotations/Nullable"
+						"org/jspecify/annotations/Nullable"
 					],
 					"add": [
 						{
@@ -184,7 +184,7 @@ class AnnotationsApplyTest extends Specification {
 					"parameters": {
 						"0": {
 							"remove": [
-								"org/jetbrains/annotations/NotNull"
+								"org/jspecify/annotations/NotNull"
 							],
 							"add": [
 								{
@@ -263,7 +263,7 @@ public class net/fabricmc/loom/test/unit/processor/AnnotationsApplyTest$ExampleC
   private Ljava/lang/String; field2
   @Ljava/lang/Deprecated;() // invisible
   @Lorg/jetbrains/annotations/ApiStatus$Internal;() // invisible
-  @Lorg/jetbrains/annotations/Nullable;() : FIELD, null // invisible
+  @Lorg/jspecify/annotations/Nullable;() : FIELD, null
 '''
 
 	private static final String EXPECTED_METHOD1 = '''
@@ -272,6 +272,7 @@ public class net/fabricmc/loom/test/unit/processor/AnnotationsApplyTest$ExampleC
   @Lorg/jetbrains/annotations/ApiStatus$OverrideOnly;() // invisible
   @Lorg/jetbrains/annotations/NotNull;() : METHOD_FORMAL_PARAMETER 0, null // invisible
     // annotable parameter count: 1 (invisible)
+    @Lorg/jetbrains/annotations/NotNull;() // invisible, parameter 0
     @Lorg/jetbrains/annotations/UnknownNullability;() // invisible, parameter 0
 '''
 

--- a/src/test/groovy/net/fabricmc/loom/test/unit/processor/AnnotationsApplyTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/processor/AnnotationsApplyTest.groovy
@@ -28,7 +28,7 @@ import groovy.transform.CompileStatic
 import org.intellij.lang.annotations.Language
 import org.jetbrains.annotations.ApiStatus
 import org.jetbrains.annotations.NotNull
-import org.jetbrains.annotations.Nullable
+import org.jspecify.annotations.Nullable
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.FieldNode

--- a/src/test/groovy/net/fabricmc/loom/test/unit/processor/TypePathCheckerVisitorTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/processor/TypePathCheckerVisitorTest.groovy
@@ -24,7 +24,7 @@
 
 package net.fabricmc.loom.test.unit.processor
 
-import org.jetbrains.annotations.Nullable
+import org.jspecify.annotations.Nullable
 import org.objectweb.asm.TypePath
 import org.objectweb.asm.signature.SignatureReader
 import spock.lang.Specification

--- a/src/test/groovy/net/fabricmc/loom/test/util/GradleTestUtil.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/util/GradleTestUtil.groovy
@@ -37,7 +37,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.util.PatternFilterable
-import org.jetbrains.annotations.Nullable
+import org.jspecify.annotations.Nullable
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 

--- a/src/test/java/net/fabricmc/loom/test/unit/package-info.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) $YEAR FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.test.unit;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/net/fabricmc/loom/test/unit/processor/classes/package-info.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/processor/classes/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) $YEAR FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.test.unit.processor.classes;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/net/fabricmc/loom/test/unit/sandbox/package-info.java
+++ b/src/test/java/net/fabricmc/loom/test/unit/sandbox/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) $YEAR FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.test.unit.sandbox;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
Im not super keen on having so many package-infos, but it seems the only way to do it in such a way that idea picks it up. (FAPI has an issue where it doesn't work in a FAPI dev env)