### PR TITLE
Add MCP support

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/decompile/SingleJarDecompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/decompile/SingleJarDecompileConfiguration.java
@@ -24,6 +24,7 @@
 
 package net.fabricmc.loom.configuration.decompile;
 
+import java.io.File;
 import java.util.List;
 
 import org.gradle.api.Project;
@@ -32,6 +33,7 @@ import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftJar;
 import net.fabricmc.loom.configuration.providers.minecraft.mapped.MappedMinecraftProvider;
 import net.fabricmc.loom.task.GenerateSourcesTask;
+import net.fabricmc.loom.task.mcp.MCPServerTask;
 import net.fabricmc.loom.util.Constants;
 
 public class SingleJarDecompileConfiguration extends DecompileConfiguration<MappedMinecraftProvider> {
@@ -51,13 +53,15 @@ public class SingleJarDecompileConfiguration extends DecompileConfiguration<Mapp
 		final MinecraftJar minecraftJar = minecraftJars.get(0);
 		final String taskBaseName = getTaskName(minecraftJar.getType());
 
+		final File sourcesJar = GenerateSourcesTask.getJarFileWithSuffix("-sources.jar", minecraftJar.getPath());
+
 		LoomGradleExtension.get(project).getDecompilerOptions().forEach(options -> {
 			final String decompilerName = options.getFormattedName();
 			String taskName = "%sWith%s".formatted(taskBaseName, decompilerName);
 			// Decompiler will be passed to the constructor of GenerateSourcesTask
 			project.getTasks().register(taskName, GenerateSourcesTask.class, options).configure(task -> {
 				task.getInputJarName().set(minecraftJar.getName());
-				task.getSourcesOutputJar().fileValue(GenerateSourcesTask.getJarFileWithSuffix("-sources.jar", minecraftJar.getPath()));
+				task.getSourcesOutputJar().fileValue(sourcesJar);
 
 				task.dependsOn(project.getTasks().named("validateAccessWidener"));
 				task.setDescription("Decompile minecraft using %s.".formatted(decompilerName));
@@ -70,6 +74,10 @@ public class SingleJarDecompileConfiguration extends DecompileConfiguration<Mapp
 			task.setGroup(Constants.TaskGroup.FABRIC);
 
 			task.dependsOn(project.getTasks().named("genSourcesWith" + DecompileConfiguration.DEFAULT_DECOMPILER));
+		});
+
+		project.getTasks().withType(MCPServerTask.class, task -> {
+			task.getSourceJars().from(sourcesJar);
 		});
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/decompile/SplitDecompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/decompile/SplitDecompileConfiguration.java
@@ -24,6 +24,8 @@
 
 package net.fabricmc.loom.configuration.decompile;
 
+import java.io.File;
+
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -33,6 +35,7 @@ import net.fabricmc.loom.api.decompilers.DecompilerOptions;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftJar;
 import net.fabricmc.loom.configuration.providers.minecraft.mapped.MappedMinecraftProvider;
 import net.fabricmc.loom.task.GenerateSourcesTask;
+import net.fabricmc.loom.task.mcp.MCPServerTask;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.Strings;
 
@@ -51,14 +54,17 @@ public final class SplitDecompileConfiguration extends DecompileConfiguration<Ma
 		final MinecraftJar commonJar = minecraftProvider.getCommonJar();
 		final MinecraftJar clientOnlyJar = minecraftProvider.getClientOnlyJar();
 
+		final File commonSourcesJar = GenerateSourcesTask.getJarFileWithSuffix("-sources.jar", commonJar.getPath());
+		final File clientOnlySourcesJar = GenerateSourcesTask.getJarFileWithSuffix("-sources.jar", clientOnlyJar.getPath());
+
 		final TaskProvider<Task> commonDecompileTask = createDecompileTasks("Common", task -> {
 			task.getInputJarName().set(commonJar.getName());
-			task.getSourcesOutputJar().fileValue(GenerateSourcesTask.getJarFileWithSuffix("-sources.jar", commonJar.getPath()));
+			task.getSourcesOutputJar().fileValue(commonSourcesJar);
 		});
 
 		final TaskProvider<Task> clientOnlyDecompileTask = createDecompileTasks("ClientOnly", task -> {
 			task.getInputJarName().set(clientOnlyJar.getName());
-			task.getSourcesOutputJar().fileValue(GenerateSourcesTask.getJarFileWithSuffix("-sources.jar", clientOnlyJar.getPath()));
+			task.getSourcesOutputJar().fileValue(clientOnlySourcesJar);
 
 			// Don't allow them to run at the same time.
 			task.mustRunAfter(commonDecompileTask);
@@ -89,6 +95,10 @@ public final class SplitDecompileConfiguration extends DecompileConfiguration<Ma
 
 			task.dependsOn(commonDecompileTask);
 			task.dependsOn(clientOnlyDecompileTask);
+		});
+
+		project.getTasks().withType(MCPServerTask.class, task -> {
+			task.getSourceJars().from(commonSourcesJar, clientOnlySourcesJar);
 		});
 	}
 

--- a/src/main/java/net/fabricmc/loom/task/LoomTasks.java
+++ b/src/main/java/net/fabricmc/loom/task/LoomTasks.java
@@ -45,6 +45,7 @@ import net.fabricmc.loom.configuration.providers.minecraft.MinecraftVersionMeta;
 import net.fabricmc.loom.task.launch.GenerateDLIConfigTask;
 import net.fabricmc.loom.task.launch.GenerateLog4jConfigTask;
 import net.fabricmc.loom.task.launch.GenerateRemapClasspathTask;
+import net.fabricmc.loom.task.mcp.MCPServerTask;
 import net.fabricmc.loom.util.Check;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.LoomVersions;
@@ -114,6 +115,7 @@ public abstract class LoomTasks implements Runnable {
 		});
 
 		getTasks().named("check").configure(task -> task.dependsOn(validateAccessWidener));
+		getTasks().register("runMCPServer", MCPServerTask.class);
 
 		registerIDETasks();
 		registerRunTasks();

--- a/src/main/java/net/fabricmc/loom/task/mcp/MCPServerTask.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/MCPServerTask.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Path;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import com.sun.net.httpserver.HttpServer;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.TaskAction;
+import org.jetbrains.annotations.VisibleForTesting;
+
+import net.fabricmc.loom.LoomGradleExtension;
+
+public abstract class MCPServerTask extends DefaultTask {
+	@Input
+	public abstract Property<Integer> getPort();
+
+	@InputFiles
+	public abstract ConfigurableFileCollection getSourceJars();
+
+	@Input
+	protected abstract Property<String> getMinecraftVersion();
+
+	@Inject
+	public MCPServerTask() {
+		LoomGradleExtension extension = LoomGradleExtension.get(getProject());
+
+		getPort().convention(8080);
+		setGroup("fabric");
+		setDescription("Starts the fabric-loom MCP server");
+
+		getMinecraftVersion().set(extension.getMinecraftVersion());
+		getMinecraftVersion().finalizeValue();
+	}
+
+	@TaskAction
+	public void startServer() throws IOException {
+		final int port = getPort().get();
+		getLogger().lifecycle("Starting HTTP server on port {}...", port);
+		HttpServer server = createAndStartServer(port, new TaskProjectContext());
+
+		getLogger().lifecycle("MCP server started successfully on http://localhost:{}", port);
+		getLogger().lifecycle("Press Ctrl+C to stop");
+
+		try {
+			Thread.currentThread().join();
+		} catch (InterruptedException e) {
+			server.stop(0);
+		}
+	}
+
+	private final class TaskProjectContext implements ProjectContext {
+		@Override
+		public String minecraftVersion() {
+			return getMinecraftVersion().get();
+		}
+
+		@Override
+		public List<Path> minecraftSourcesJars() {
+			return getSourceJars().getFiles().stream().map(File::toPath).toList();
+		}
+	}
+
+	@VisibleForTesting
+	public static HttpServer createAndStartServer(int port, ProjectContext context) throws IOException {
+		HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", port), 0);
+		server.createContext("/", new McpHttpHandler(context));
+		server.setExecutor(null);
+		server.start();
+		return server;
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/McpConstants.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/McpConstants.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp;
+
+public class McpConstants {
+	public static final String JSON_RPC_VERSION = "2.0";
+
+	public static final int ERROR_INVALID_REQUEST = -32600;
+	public static final int ERROR_METHOD_NOT_FOUND = -32601;
+	public static final int ERROR_INTERNAL_ERROR = -32603;
+	public static final int ERROR_PARSE_ERROR = -32700;
+	public static final int ERROR_INVALID_PARAMS = -32602;
+
+	public static final String JAVA_MIME_TYPE = "text/x-java-source";
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/McpException.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/McpException.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp;
+
+public class McpException extends Exception {
+	private final int errorCode;
+	private final Object requestId;
+
+	public McpException(Object requestId, int errorCode, String message) {
+		super(message);
+		this.requestId = requestId;
+		this.errorCode = errorCode;
+	}
+
+	public McpException(Object requestId, int errorCode, String message, Throwable cause) {
+		super(message, cause);
+		this.requestId = requestId;
+		this.errorCode = errorCode;
+	}
+
+	public int getErrorCode() {
+		return errorCode;
+	}
+
+	public Object getRequestId() {
+		return requestId;
+	}
+}
+

--- a/src/main/java/net/fabricmc/loom/task/mcp/McpHttpHandler.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/McpHttpHandler.java
@@ -1,0 +1,135 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.fabricmc.loom.task.mcp.methods.McpMethod;
+import net.fabricmc.loom.task.mcp.methods.McpMethods;
+
+public class McpHttpHandler implements HttpHandler {
+	private static final Gson GSON = new GsonBuilder()
+			.setPrettyPrinting()
+			.create();
+	private static final Logger LOGGER = LoggerFactory.getLogger(McpHttpHandler.class);
+
+	private final Map<String, McpMethod> methods;
+
+	public McpHttpHandler(ProjectContext context) {
+		this.methods = McpMethods.getMethods(context);
+	}
+
+	@Override
+	public void handle(HttpExchange exchange) throws IOException {
+		LOGGER.info("Received MCP request: {} {}", exchange.getRequestMethod(), exchange.getRequestURI());
+
+		if ("OPTIONS".equalsIgnoreCase(exchange.getRequestMethod())) {
+			exchange.sendResponseHeaders(204, -1);
+			return;
+		}
+
+		try {
+			if ("GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+				exchange.sendResponseHeaders(405, -1);
+				return;
+			}
+
+			if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+				throw new McpException(null, McpConstants.ERROR_INVALID_REQUEST, "Invalid Request: Only POST method is supported");
+			}
+
+			McpRequest request = parseRequest(exchange);
+			validateRequest(request);
+			handleMcpRequest(exchange, request);
+		} catch (McpException e) {
+			LOGGER.error("MCP Error (code {}): {}", e.getErrorCode(), e.getMessage(), e);
+
+			McpResponse response = McpResponse.error(e.getRequestId(), e.getErrorCode(), e.getMessage());
+			sendJsonResponse(exchange, response);
+		}
+	}
+
+	private McpRequest parseRequest(HttpExchange exchange) throws McpException {
+		try (InputStreamReader reader = new InputStreamReader(exchange.getRequestBody(), StandardCharsets.UTF_8)) {
+			return GSON.fromJson(reader, McpRequest.class);
+		} catch (JsonSyntaxException e) {
+			throw new McpException(null, McpConstants.ERROR_PARSE_ERROR, "Parse error: " + e.getMessage(), e);
+		} catch (IOException e) {
+			throw new McpException(null, McpConstants.ERROR_INTERNAL_ERROR, "Failed to read request body: " + e.getMessage(), e);
+		}
+	}
+
+	private void validateRequest(McpRequest request) throws McpException {
+		if (request == null || request.jsonrpc() == null || !request.jsonrpc().equals(McpConstants.JSON_RPC_VERSION)) {
+			throw new McpException(null, McpConstants.ERROR_INVALID_REQUEST, "Invalid Request: jsonrpc must be: " + McpConstants.JSON_RPC_VERSION);
+		}
+
+		if (request.method() == null || request.method().isEmpty()) {
+			throw new McpException(request.id(), McpConstants.ERROR_INVALID_REQUEST, "Invalid Request: method is required");
+		}
+	}
+
+	private void handleMcpRequest(HttpExchange exchange, McpRequest request) throws McpException {
+		McpMethod method = methods.get(request.method());
+
+		if (method == null) {
+			throw new McpException(request.id(), McpConstants.ERROR_METHOD_NOT_FOUND, "Method not found: " + request.method());
+		}
+
+		try {
+			McpResult result = method.handle(request);
+			McpResponse response = McpResponse.success(request.id(), result);
+			sendJsonResponse(exchange, response);
+		} catch (Exception e) {
+			throw new McpException(request.id(), McpConstants.ERROR_INTERNAL_ERROR, "Internal error: " + e.getMessage(), e);
+		}
+	}
+
+	private static void sendJsonResponse(HttpExchange exchange, Object response) throws IOException {
+		String json = GSON.toJson(response);
+		byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+
+		LOGGER.debug("Sending MCP response: {}", json);
+
+		exchange.getResponseHeaders().set("Content-Type", "application/json");
+		exchange.sendResponseHeaders(200, bytes.length);
+
+		try (OutputStream os = exchange.getResponseBody()) {
+			os.write(bytes);
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/McpRequest.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/McpRequest.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp;
+
+import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
+
+public record McpRequest(
+		String jsonrpc,
+		@Nullable Object id,
+		String method,
+		@Nullable Map<String, Object> params
+) { }
+

--- a/src/main/java/net/fabricmc/loom/task/mcp/McpResponse.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/McpResponse.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp;
+
+import org.jspecify.annotations.Nullable;
+
+public record McpResponse(
+		String jsonrpc,
+		@Nullable Object id,
+		@Nullable McpResult result,
+		@Nullable McpError error
+) {
+	public static McpResponse success(Object id, McpResult result) {
+		return new McpResponse(McpConstants.JSON_RPC_VERSION, id, result, null);
+	}
+
+	public static McpResponse error(Object id, int code, String message) {
+		return new McpResponse(McpConstants.JSON_RPC_VERSION, id, null, new McpError(code, message));
+	}
+
+	public record McpError(int code, String message) { }
+}
+

--- a/src/main/java/net/fabricmc/loom/task/mcp/McpResult.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/McpResult.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp;
+
+public interface McpResult {
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/ProjectContext.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/ProjectContext.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp;
+
+import java.nio.file.Path;
+import java.util.List;
+
+public interface ProjectContext {
+	String minecraftVersion();
+
+	List<Path> minecraftSourcesJars();
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/Resource.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/Resource.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp;
+
+import java.net.URI;
+import java.util.List;
+
+public record Resource(URI uri, String name, String title, String description, String mimeType, Annotations annotations) {
+	public record Annotations(List<String> audience, float priority) { }
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/methods/InitializeMethod.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/methods/InitializeMethod.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp.methods;
+
+import net.fabricmc.loom.LoomGradlePlugin;
+import net.fabricmc.loom.task.mcp.McpRequest;
+import net.fabricmc.loom.task.mcp.McpResult;
+
+public class InitializeMethod implements McpMethod {
+	private static final String INSTRUCTIONS = "This server provides read-only access to Minecraft's java source files. Prioritise using the provided resources for accessing Minecraft classes.";
+
+	@Override
+	public InitializeResponse handle(McpRequest request) {
+		return new InitializeResponse(
+				"2025-03-26",
+				new Capabilities(
+						new ResourceCapability(
+								false,
+								false
+						),
+						new ToolCapability(
+								false
+						)
+				),
+				new ServerInfo(
+						"Fabric Loom",
+						LoomGradlePlugin.LOOM_VERSION
+				),
+				INSTRUCTIONS
+		);
+	}
+
+	public record InitializeResponse(String protocolVersion, Capabilities capabilities, ServerInfo serverInfo, String instructions) implements McpResult { }
+
+	private record Capabilities(ResourceCapability resources, ToolCapability tools) { }
+
+	private record ResourceCapability(
+			boolean subscribe,
+			boolean listChanged
+	) { }
+
+	private record ToolCapability(boolean listChanged) { }
+
+	private record ServerInfo(
+			String name,
+			String version
+	) { }
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/methods/McpMethod.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/methods/McpMethod.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp.methods;
+
+import net.fabricmc.loom.task.mcp.McpException;
+import net.fabricmc.loom.task.mcp.McpRequest;
+import net.fabricmc.loom.task.mcp.McpResult;
+
+public interface McpMethod {
+	McpResult handle(McpRequest request) throws McpException;
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/methods/McpMethods.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/methods/McpMethods.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp.methods;
+
+import java.util.Map;
+
+import net.fabricmc.loom.task.mcp.ProjectContext;
+import net.fabricmc.loom.task.mcp.methods.notifications.CancelledMethod;
+import net.fabricmc.loom.task.mcp.methods.notifications.InitializedMethod;
+import net.fabricmc.loom.task.mcp.methods.prompts.ListPromptsMethod;
+import net.fabricmc.loom.task.mcp.methods.resources.ListResourceTemplatesMethod;
+import net.fabricmc.loom.task.mcp.methods.resources.ListResourcesMethod;
+import net.fabricmc.loom.task.mcp.methods.resources.ReadResourceMethod;
+import net.fabricmc.loom.task.mcp.methods.tools.CallToolMethod;
+import net.fabricmc.loom.task.mcp.methods.tools.ListToolsMethod;
+import net.fabricmc.loom.task.mcp.tools.McpTool;
+import net.fabricmc.loom.task.mcp.tools.McpTools;
+
+public final class McpMethods {
+	private McpMethods() {
+	}
+
+	public static Map<String, McpMethod> getMethods(ProjectContext context) {
+		Map<String, McpTool> tools = McpTools.getTools(context);
+
+		return Map.of(
+				"initialize", new InitializeMethod(),
+				"notifications/initialized", new InitializedMethod(),
+				"notifications/cancelled", new CancelledMethod(),
+				"resources/list", new ListResourcesMethod(context),
+				"resources/read", new ReadResourceMethod(context),
+				"resources/templates/list", new ListResourceTemplatesMethod(),
+				"tools/list", new ListToolsMethod(tools),
+				"tools/call", new CallToolMethod(tools),
+				"prompts/list", new ListPromptsMethod()
+		);
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/methods/notifications/CancelledMethod.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/methods/notifications/CancelledMethod.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp.methods.notifications;
+
+import net.fabricmc.loom.task.mcp.McpException;
+import net.fabricmc.loom.task.mcp.McpRequest;
+import net.fabricmc.loom.task.mcp.McpResult;
+import net.fabricmc.loom.task.mcp.methods.McpMethod;
+
+public class CancelledMethod implements McpMethod {
+	@Override
+	public McpResult handle(McpRequest request) throws McpException {
+		return null;
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/methods/notifications/InitializedMethod.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/methods/notifications/InitializedMethod.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp.methods.notifications;
+
+import net.fabricmc.loom.task.mcp.methods.McpMethod;
+import net.fabricmc.loom.task.mcp.McpRequest;
+import net.fabricmc.loom.task.mcp.McpResult;
+
+public class InitializedMethod implements McpMethod {
+	@Override
+	public McpResult handle(McpRequest request) {
+		return null;
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/methods/notifications/package-info.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/methods/notifications/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.task.mcp.methods.notifications;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/task/mcp/methods/package-info.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/methods/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.task.mcp.methods;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/task/mcp/methods/prompts/ListPromptsMethod.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/methods/prompts/ListPromptsMethod.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp.methods.prompts;
+
+import java.util.List;
+
+import net.fabricmc.loom.task.mcp.McpRequest;
+import net.fabricmc.loom.task.mcp.McpResult;
+import net.fabricmc.loom.task.mcp.methods.McpMethod;
+
+// https://modelcontextprotocol.io/specification/2025-06-18/server/prompts#listing-prompts
+public class ListPromptsMethod implements McpMethod {
+	@Override
+	public ListResponse handle(McpRequest request) {
+		return new ListResponse(List.of());
+	}
+
+	public record ListResponse(List<Object> prompts) implements McpResult {
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/methods/prompts/package-info.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/methods/prompts/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.task.mcp.methods.prompts;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/task/mcp/methods/resources/ListResourceTemplatesMethod.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/methods/resources/ListResourceTemplatesMethod.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp.methods.resources;
+
+import java.util.List;
+
+import net.fabricmc.loom.task.mcp.McpRequest;
+import net.fabricmc.loom.task.mcp.McpResult;
+import net.fabricmc.loom.task.mcp.methods.McpMethod;
+
+// https://modelcontextprotocol.io/specification/2025-06-18/server/resources#resource-templates
+public class ListResourceTemplatesMethod implements McpMethod {
+	@Override
+	public ListResponse handle(McpRequest request) {
+		return new ListResponse(List.of());
+	}
+
+	public record ListResponse(List<Object> resourceTemplates) implements McpResult {
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/methods/resources/ListResourcesMethod.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/methods/resources/ListResourcesMethod.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp.methods.resources;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import net.fabricmc.loom.task.mcp.McpConstants;
+import net.fabricmc.loom.task.mcp.McpRequest;
+import net.fabricmc.loom.task.mcp.McpResult;
+import net.fabricmc.loom.task.mcp.ProjectContext;
+import net.fabricmc.loom.task.mcp.Resource;
+import net.fabricmc.loom.task.mcp.methods.McpMethod;
+import net.fabricmc.loom.util.FileSystemUtil;
+import net.fabricmc.loom.util.Lazy;
+
+// https://modelcontextprotocol.io/specification/2025-06-18/server/resources#listing-resources
+public final class ListResourcesMethod implements McpMethod {
+	private final ProjectContext context;
+
+	private final Supplier<ListResponse> cachedResponse = Lazy.of(this::buildResponse);
+
+	public ListResourcesMethod(ProjectContext context) {
+		this.context = context;
+	}
+
+	@Override
+	public ListResponse handle(McpRequest request) {
+		return cachedResponse.get();
+	}
+
+	private ListResponse buildResponse() {
+		List<Resource> resources = new ArrayList<>();
+
+		for (Path jar : context.minecraftSourcesJars()) {
+			List<String> sourceFiles;
+
+			try {
+				sourceFiles = getSourceFiles(jar);
+			} catch (IOException e) {
+				throw new UncheckedIOException("Failed to read sources jar: " + jar, e);
+			}
+
+			for (String file : sourceFiles) {
+				if (file.contains("package-info")) {
+					continue;
+				}
+
+				resources.add(classFilenameToResource(file));
+			}
+		}
+
+		return new ListResponse(resources);
+	}
+
+	public static Resource classFilenameToResource(String file) {
+		String fullName = file.replace(".java", "").substring(1);
+		String className = fullName.substring(fullName.lastIndexOf('/') + 1);
+
+		return new Resource(
+				URI.create("file://%s".formatted(file)),
+				className,
+				"Minecraft java source file: " + fullName,
+				"Minecraft class: " + fullName.replace("/", "."),
+				McpConstants.JAVA_MIME_TYPE,
+				new Resource.Annotations(
+						List.of("user", "assistant"),
+						0.8F
+				)
+		);
+	}
+
+	private static List<String> getSourceFiles(Path zip) throws IOException {
+		List<String> entries = new ArrayList<>();
+
+		try (FileSystemUtil.Delegate fs = FileSystemUtil.getJarFileSystem(zip, false);
+				Stream<Path> walk = Files.walk(fs.getRoot())) {
+			Iterator<Path> iterator = walk.iterator();
+
+			while (iterator.hasNext()) {
+				Path fsPath = iterator.next();
+
+				if (!Files.isRegularFile(fsPath)) {
+					continue;
+				}
+
+				String entryPath = fsPath.toString().replace('\\', '/');
+				entries.add(entryPath);
+			}
+		}
+
+		return entries;
+	}
+
+	public record ListResponse(List<Resource> resources) implements McpResult {
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/methods/resources/ReadResourceMethod.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/methods/resources/ReadResourceMethod.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp.methods.resources;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+
+import net.fabricmc.loom.task.mcp.McpConstants;
+import net.fabricmc.loom.task.mcp.McpException;
+import net.fabricmc.loom.task.mcp.McpRequest;
+import net.fabricmc.loom.task.mcp.McpResult;
+import net.fabricmc.loom.task.mcp.ProjectContext;
+import net.fabricmc.loom.task.mcp.methods.McpMethod;
+import net.fabricmc.loom.util.ZipUtils;
+
+// https://modelcontextprotocol.io/specification/2025-06-18/server/resources#reading-resources
+public class ReadResourceMethod implements McpMethod {
+	private final ProjectContext context;
+
+	public ReadResourceMethod(ProjectContext context) {
+		this.context = context;
+	}
+
+	@Override
+	public ContentsResult handle(McpRequest request) throws McpException {
+		Object uriObj = request.params().get("uri");
+
+		if (!(uriObj instanceof String uriStr)) {
+			throw new McpException(request.id(), McpConstants.ERROR_INVALID_REQUEST, "Missing or invalid 'uri' parameter");
+		}
+
+		URI uri = URI.create(uriStr);
+		String path = uri.getPath();
+
+		for (Path jar : context.minecraftSourcesJars()) {
+			byte[] bytes;
+
+			try {
+				bytes = ZipUtils.unpackNullable(jar, path);
+			} catch (IOException e) {
+				throw new UncheckedIOException("Failed to read resource from jar: " + jar, e);
+			}
+
+			if (bytes == null) {
+				// Must be in the next jar
+				continue;
+			}
+
+			String text = new String(bytes, StandardCharsets.UTF_8);
+			return new ContentsResult(List.of(new Content(uri, text, McpConstants.JAVA_MIME_TYPE)));
+		}
+
+		throw new McpException(request.id(), McpConstants.ERROR_INVALID_REQUEST, "Resource not found: " + uri);
+	}
+
+	public record ContentsResult(List<Content> contents) implements McpResult { }
+
+	public record Content(URI uri, String text, String mimeType) { }
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/methods/resources/package-info.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/methods/resources/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.task.mcp.methods.resources;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/task/mcp/methods/tools/CallToolMethod.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/methods/tools/CallToolMethod.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp.methods.tools;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import net.fabricmc.loom.task.mcp.McpConstants;
+import net.fabricmc.loom.task.mcp.McpException;
+import net.fabricmc.loom.task.mcp.McpRequest;
+import net.fabricmc.loom.task.mcp.McpResult;
+import net.fabricmc.loom.task.mcp.Resource;
+import net.fabricmc.loom.task.mcp.methods.McpMethod;
+import net.fabricmc.loom.task.mcp.tools.McpTool;
+
+// https://modelcontextprotocol.io/specification/2025-06-18/server/tools#calling-tools
+public class CallToolMethod implements McpMethod {
+	private final Map<String, McpTool> mcpTools;
+
+	public CallToolMethod(Map<String, McpTool> mcpTools) {
+		this.mcpTools = mcpTools;
+	}
+
+	@Override
+	public ToolResult handle(McpRequest request) throws McpException {
+		if (request.params() == null || !(request.params().get("name") instanceof String name)) {
+			throw new McpException(request.id(), McpConstants.ERROR_INVALID_REQUEST, "Missing or invalid 'name' parameter");
+		}
+
+		McpTool tool = mcpTools.get(name);
+
+		if (tool == null) {
+			throw new McpException(request.id(), McpConstants.ERROR_INVALID_PARAMS, "Unknown tool: " + name);
+		}
+
+		@SuppressWarnings("unchecked")
+		Map<String, String> arguments = (Map<String, String>) request.params().get("arguments");
+
+		for (String requiredKey : tool.getRequiredInputProperties().keySet()) {
+			if (arguments == null || !arguments.containsKey(requiredKey)) {
+				throw new McpException(request.id(), McpConstants.ERROR_INVALID_PARAMS, "Missing required argument: " + requiredKey);
+			}
+		}
+
+		List<McpTool.Result> results = tool.invoke(arguments);
+		List<Content> contents = new ArrayList<>();
+
+		for (McpTool.Result result : results) {
+			contents.add(switch (result) {
+			case McpTool.ResourceResult resource -> new ResourceContent("resource_link", resource.resource().uri(), resource.resource().name(), resource.resource().title(), resource.resource().description(), resource.resource().description(), resource.resource().annotations());
+			case McpTool.TextResult text -> new TextContent("text", text.text());
+			});
+		}
+
+		return new ToolResult(contents, false);
+	}
+
+	public record ToolResult(List<Content> content, boolean isError) implements McpResult { }
+
+	public interface Content { }
+
+	public record TextContent(String type, String text) implements Content { }
+
+	public record ResourceContent(String type, URI uri, String name, String title, String description, String mimeType, Resource.Annotations annotations) implements Content { }
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/methods/tools/ListToolsMethod.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/methods/tools/ListToolsMethod.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp.methods.tools;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import net.fabricmc.loom.task.mcp.McpRequest;
+import net.fabricmc.loom.task.mcp.McpResult;
+import net.fabricmc.loom.task.mcp.methods.McpMethod;
+import net.fabricmc.loom.task.mcp.tools.McpTool;
+
+// https://modelcontextprotocol.io/specification/2025-06-18/server/tools#listing-tools
+public class ListToolsMethod implements McpMethod {
+	private final Map<String, McpTool> mcpTools;
+
+	public ListToolsMethod(Map<String, McpTool> mcpTools) {
+		this.mcpTools = mcpTools;
+	}
+
+	@Override
+	public ListResponse handle(McpRequest request) {
+		List<Tool> tools = new ArrayList<>();
+
+		for (Map.Entry<String, McpTool> entry : mcpTools.entrySet()) {
+			McpTool tool = entry.getValue();
+			tools.add(new Tool(entry.getKey(), tool.title(), tool.description(), getInputSchema(tool)));
+		}
+
+		return new ListResponse(tools);
+	}
+
+	private static InputSchema getInputSchema(McpTool tool) {
+		return new InputSchema(
+				"object",
+				tool.getRequiredInputProperties().entrySet()
+						.stream()
+						.collect(Collectors.toMap(Map.Entry::getKey, e -> new Property("string", e.getValue()))
+				),
+				new ArrayList<>(tool.getRequiredInputProperties().keySet())
+		);
+	}
+
+	public record ListResponse(List<Tool> tools) implements McpResult { }
+
+	public record Tool(String name, String title, String description, InputSchema inputSchema) { }
+
+	public record InputSchema(String type, Map<String, Property> properties, List<String> required) { }
+
+	public record Property(String type, String description) { }
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/methods/tools/package-info.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/methods/tools/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.task.mcp.methods.tools;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/task/mcp/package-info.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.task.mcp;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/task/mcp/tools/McpTool.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/tools/McpTool.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp.tools;
+
+import java.util.List;
+import java.util.Map;
+
+import net.fabricmc.loom.task.mcp.Resource;
+
+public interface McpTool {
+	String title();
+	String description();
+
+	// Name -> description
+	default Map<String, String> getRequiredInputProperties() {
+		return Map.of();
+	}
+
+	List<Result> invoke(Map<String, String> arguments);
+
+	sealed interface Result permits TextResult, ResourceResult { }
+
+	// https://modelcontextprotocol.io/specification/2025-06-18/server/tools#text-content
+	record TextResult(String text) implements Result { }
+
+	// https://modelcontextprotocol.io/specification/2025-06-18/server/tools#resource-links
+	record ResourceResult(Resource resource) implements Result { }
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/tools/McpTools.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/tools/McpTools.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp.tools;
+
+import java.util.Map;
+
+import net.fabricmc.loom.task.mcp.ProjectContext;
+
+public class McpTools {
+	public static Map<String, McpTool> getTools(ProjectContext context) {
+		return Map.of(
+			"minecraft_version", new MinecraftVersionTool(context),
+				"minecraft_source", new MinecraftSourceTool(context)
+		);
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/tools/MinecraftSourceTool.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/tools/MinecraftSourceTool.java
@@ -1,0 +1,115 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp.tools;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.fabricmc.loom.task.mcp.ProjectContext;
+import net.fabricmc.loom.task.mcp.methods.resources.ListResourcesMethod;
+import net.fabricmc.loom.util.FileSystemUtil;
+
+public class MinecraftSourceTool implements McpTool {
+	private static final Logger LOGGER = LoggerFactory.getLogger(MinecraftSourceTool.class);
+
+	private final ProjectContext context;
+
+	public MinecraftSourceTool(ProjectContext context) {
+		this.context = context;
+	}
+
+	@Override
+	public String title() {
+		return "Minecraft source code provider";
+	}
+
+	@Override
+	public String description() {
+		return "A tool that provides the decompiled Java source code for a given Minecraft class.";
+	}
+
+	@Override
+	public Map<String, String> getRequiredInputProperties() {
+		return Map.of("name", "A minecraft class name, in one of the following formats: 'ClassName', 'net/minecraft/package/ClassName'");
+	}
+
+	@Override
+	public List<Result> invoke(Map<String, String> arguments) {
+		String name = Objects.requireNonNull(arguments.get("name"));
+
+		List<Result> results = new ArrayList<>();
+
+		for (Path jar : context.minecraftSourcesJars()) {
+			try (FileSystemUtil.Delegate fs = FileSystemUtil.getJarFileSystem(jar, false);
+					Stream<Path> walk = Files.walk(fs.getRoot())) {
+				Iterator<Path> iterator = walk.iterator();
+
+				while (iterator.hasNext()) {
+					Path fsPath = iterator.next();
+
+					if (!Files.isRegularFile(fsPath)) {
+						continue;
+					}
+
+					if (!matchesName(fsPath.toString(), name)) {
+						continue;
+					}
+
+					String file = fsPath.toString().replace('\\', '/');
+					results.add(new ResourceResult(ListResourcesMethod.classFilenameToResource(file)));
+				}
+			} catch (IOException e) {
+				throw new UncheckedIOException("Failed to read sources jar: " + jar, e);
+			}
+		}
+
+		LOGGER.info("Found {} source files matching name '{}'", results.size(), name);
+
+		if (results.isEmpty()) {
+			LOGGER.warn("No source files found matching name '{}'", name);
+		}
+
+		return results;
+	}
+
+	private static boolean matchesName(String path, String name) {
+		String normalizedPath = path.replace('\\', '/');
+		String className = normalizedPath.substring(normalizedPath.lastIndexOf('/') + 1, normalizedPath.length() - ".java".length());
+		String fullName = normalizedPath.substring(1, normalizedPath.length() - ".java".length()).replace('/', '.');
+
+		return className.equals(name) || fullName.equals(name) || fullName.endsWith("." + name);
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/tools/MinecraftVersionTool.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/tools/MinecraftVersionTool.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.mcp.tools;
+
+import java.util.List;
+import java.util.Map;
+
+import net.fabricmc.loom.task.mcp.ProjectContext;
+
+public class MinecraftVersionTool implements McpTool {
+	private final ProjectContext context;
+
+	public MinecraftVersionTool(ProjectContext context) {
+		this.context = context;
+	}
+
+	@Override
+	public String title() {
+		return "Minecraft Version Provider";
+	}
+
+	@Override
+	public String description() {
+		return "Gets the current Minecraft version for the current project";
+	}
+
+	@Override
+	public List<Result> invoke(Map<String, String> arguments) {
+		return List.of(
+				new TextResult("The current Minecraft version is \"%s\"".formatted(context.minecraftVersion()))
+		);
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/mcp/tools/package-info.java
+++ b/src/main/java/net/fabricmc/loom/task/mcp/tools/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.task.mcp.tools;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
**Note:** _This PR is only a suggestion/my experimentation, I am not sure if this is really something we want in loom or not. This is likely a controversial change so please leave any constructive feedback._

This PR adds a new `runMCPServer` task that runs a HTTP providing a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro) server that allows AI tools such as Github Copilot, ChatGPT or a local LLM to request addional information about the decompiled Minecraft source code on your machine. AI tools have a really hard time with Minecraft a number of reasons:
- Its closed source
- Its a large project
- It changes at an extremely rapid pace
- Different mappings or mod loaders confuse it

With an MCP server loom can provide upto date context that is specific to your current project. Meaning it should suck a little bit less, but its never going to be perfect.

This was mostly just be experimenting with MCP servers for the first time, so its quite possible this is tottaly wrong, please let me know if thats the case. For those that are tottaly against AI tools this is something that you must opt-in to use and can tottaly ingore.

## TODO

- [ ] Decide if we want this
- [ ] Add unit tests
- [ ] Add additional tools/resources