### PR TITLE
Adjust plugin IDs to better represent the future.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -235,16 +235,21 @@ codenarc {
 gradlePlugin {
 	plugins {
 		fabricLoom {
+			id = 'net.fabricmc.fabric-loom'
+			implementationClass = 'net.fabricmc.loom.LoomNoRemapGradlePlugin'
+		}
+		fabricLoomRemap {
+			id = 'net.fabricmc.fabric-loom-remap'
+			implementationClass = 'net.fabricmc.loom.LoomRemapGradlePlugin'
+		}
+		fabricLoomLegacy {
+			// Legacy plugin id, remove in 2.0. Use `net.fabricmc.fabric-loom-remap`
 			id = 'fabric-loom'
 			implementationClass = 'net.fabricmc.loom.LoomGradlePlugin'
 		}
 		fabricLoomCompanion {
 			id = 'net.fabricmc.fabric-loom-companion'
 			implementationClass = 'net.fabricmc.loom.LoomCompanionGradlePlugin'
-		}
-		fabricLoomNoRemap {
-			id = 'net.fabricmc.fabric-loom-no-remap'
-			implementationClass = 'net.fabricmc.loom.LoomNoRemapGradlePlugin'
 		}
 	}
 }

--- a/src/main/java/net/fabricmc/loom/LoomRemapGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomRemapGradlePlugin.java
@@ -28,17 +28,13 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
 /**
- * A marker plugin to indicate to the main loom plugin not to setup for remapping.
+ * An alias for `net.fabricmc.fabric-loom-remap` to `fabric-loom`.
  */
-public class LoomNoRemapGradlePlugin implements Plugin<Project> {
-	public static final String NAME = "net.fabricmc.fabric-loom";
+public class LoomRemapGradlePlugin implements Plugin<Project> {
+	public static final String NAME = "net.fabricmc.fabric-loom-remap";
 
 	@Override
 	public void apply(Project target) {
-		if (target.getPluginManager().hasPlugin(LoomGradlePlugin.NAME)) {
-			throw new IllegalStateException(NAME + " must be applied before " + LoomGradlePlugin.NAME);
-		}
-
 		target.getPlugins().apply(LoomGradlePlugin.NAME);
 	}
 }

--- a/src/test/resources/projects/includedJarsNoRemap/build.gradle
+++ b/src/test/resources/projects/includedJarsNoRemap/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'net.fabricmc.fabric-loom-no-remap'
+	id 'net.fabricmc.fabric-loom'
 }
 
 repositories {

--- a/src/test/resources/projects/minimalBase/build.gradle
+++ b/src/test/resources/projects/minimalBase/build.gradle
@@ -1,7 +1,7 @@
 // This is used by a range of tests that append to this file before running the gradle tasks.
 // Can be used for tests that require minimal custom setup
 plugins {
-	id 'fabric-loom'
+	id 'net.fabricmc.fabric-loom-remap'
 	id 'maven-publish'
 }
 

--- a/src/test/resources/projects/minimalBaseNoRemap/build.gradle
+++ b/src/test/resources/projects/minimalBaseNoRemap/build.gradle
@@ -1,7 +1,7 @@
 // This is used by a range of tests that append to this file before running the gradle tasks.
 // Can be used for tests that require minimal custom setup
 plugins {
-	id 'net.fabricmc.fabric-loom-no-remap'
+	id 'net.fabricmc.fabric-loom'
 	id 'maven-publish'
 }
 


### PR DESCRIPTION
This PR adjusts the plugin IDs to better represent how we mean to go on in the future. This will allow for a smoother upgrade path to a Loom 2.0 in the future.

- `fabric-loom` - same as before, full remapping support, backwards compatible - Deprecated for removal in 2.0
- `net.fabricmc.fabric-loom` - unobf/no remapping support (As we mean to go on)
- `net.fabricmc.fabric-loom-remap` - full remapping support, same as `fabric-loom`
- `net.fabricmc.fabric-loom-companion` - unchanged, works with both unobf and remap

In other words:
- Projects targeting obfuscated Minecraft versions should move to `net.fabricmc.fabric-loom-remap`
- Projects targetting the new debof Minecraft versions should use `net.fabricmc.fabric-loom`
- Existing projects using `fabric-loom` wont break

This fixes https://github.com/FabricMC/fabric-loom/issues/284