### PR TITLE
Skip synthetic parameter fixes on obfuscated classes.

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftJarMerger.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftJarMerger.java
@@ -183,7 +183,6 @@ public class MinecraftJarMerger implements AutoCloseable {
 		List<Entry> entries = entriesAll.parallelStream().map((entry) -> {
 			boolean isClass = entry.endsWith(".class");
 			boolean isMinecraft = entriesClient.containsKey(entry) || entry.startsWith("net/minecraft") || !entry.contains("/");
-			boolean isUnobfuscated = entry.startsWith("net/minecraft") || entry.contains("/");
 			Entry result;
 			String side = null;
 
@@ -227,7 +226,7 @@ public class MinecraftJarMerger implements AutoCloseable {
 						visitor = new SnowmanClassVisitor(Constants.ASM_VERSION, visitor);
 					}
 
-					if (offsetSyntheticsParams && !isUnobfuscated) {
+					if (offsetSyntheticsParams && !entry.contains("/")) {
 						visitor = new SyntheticParameterClassVisitor(Constants.ASM_VERSION, visitor);
 					}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftJarMerger.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftJarMerger.java
@@ -183,6 +183,7 @@ public class MinecraftJarMerger implements AutoCloseable {
 		List<Entry> entries = entriesAll.parallelStream().map((entry) -> {
 			boolean isClass = entry.endsWith(".class");
 			boolean isMinecraft = entriesClient.containsKey(entry) || entry.startsWith("net/minecraft") || !entry.contains("/");
+			boolean isUnobfuscated = entry.startsWith("net/minecraft") || entry.contains("/");
 			Entry result;
 			String side = null;
 
@@ -226,7 +227,7 @@ public class MinecraftJarMerger implements AutoCloseable {
 						visitor = new SnowmanClassVisitor(Constants.ASM_VERSION, visitor);
 					}
 
-					if (offsetSyntheticsParams) {
+					if (offsetSyntheticsParams && !isUnobfuscated) {
 						visitor = new SyntheticParameterClassVisitor(Constants.ASM_VERSION, visitor);
 					}
 


### PR DESCRIPTION
This only applies to classes that proguard renamed, there is no point in applying it to classes that have already been renamed.

Fixes https://github.com/FabricMC/fabric-loom/issues/1462