### PR TITLE
Improve multithreading logic of MinecraftJarMerger

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftJarMerger.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftJarMerger.java
@@ -26,6 +26,7 @@ package net.fabricmc.loom.configuration.providers.minecraft;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -36,37 +37,28 @@ import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
+import org.jspecify.annotations.Nullable;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.FileSystemUtil;
+import net.fabricmc.loom.util.Lazy;
 import net.fabricmc.loom.util.SnowmanClassVisitor;
 import net.fabricmc.loom.util.SyntheticParameterClassVisitor;
 
 public class MinecraftJarMerger implements AutoCloseable {
-	public static class Entry {
-		public final Path path;
-		public final BasicFileAttributes metadata;
-		public final byte[] data;
-
-		public Entry(Path path, BasicFileAttributes metadata, byte[] data) {
-			this.path = path;
-			this.metadata = metadata;
-			this.data = data;
-		}
-	}
-
 	private final MinecraftClassMerger classMerger = new MinecraftClassMerger();
 	private final FileSystemUtil.Delegate inputClientFs, inputServerFs, outputFs;
 	private final Path inputClient, inputServer;
@@ -128,123 +120,170 @@ public class MinecraftJarMerger implements AutoCloseable {
 								}
 							}
 
-							map.put(path.toString().substring(1), new Entry(path, attr, null));
+							map.put(path.toString().substring(1), new Entry(path, attr));
 						}
 
 						return FileVisitResult.CONTINUE;
 					}
 
-					byte[] output = Files.readAllBytes(path);
-					map.put(path.toString().substring(1), new Entry(path, attr, output));
+					map.put(path.toString().substring(1), new Entry(path, attr, Lazy.of(() -> {
+						try {
+							return Files.readAllBytes(path);
+						} catch (IOException e) {
+							throw new UncheckedIOException("Failed to read " + path, e);
+						}
+					})));
+
 					return FileVisitResult.CONTINUE;
 				}
 			});
 		} catch (IOException e) {
-			e.printStackTrace();
+			throw new UncheckedIOException("Failed to read", e);
 		}
 	}
 
-	private void add(Entry entry) throws IOException {
-		Path outPath = outputFs.get().getPath(entry.path.toString());
+	private void add(Entry entry) {
+		try {
+			Path outPath = outputFs.get().getPath(entry.path.toString());
 
-		if (outPath.getParent() != null) {
-			Files.createDirectories(outPath.getParent());
+			if (outPath.getParent() != null) {
+				Files.createDirectories(outPath.getParent());
+			}
+
+			final byte[] data = entry.data();
+
+			if (data != null) {
+				Files.write(outPath, data, StandardOpenOption.CREATE_NEW);
+			} else {
+				Files.copy(entry.path, outPath);
+			}
+
+			Files.getFileAttributeView(outPath, BasicFileAttributeView.class)
+					.setTimes(
+							entry.metadata.creationTime(),
+							entry.metadata.lastAccessTime(),
+							entry.metadata.lastModifiedTime()
+					);
+		} catch (IOException ioe) {
+			throw new UncheckedIOException("Failed to write " + entry.path, ioe);
 		}
-
-		if (entry.data != null) {
-			Files.write(outPath, entry.data, StandardOpenOption.CREATE_NEW);
-		} else {
-			Files.copy(entry.path, outPath);
-		}
-
-		Files.getFileAttributeView(outPath, BasicFileAttributeView.class)
-				.setTimes(
-						entry.metadata.creationTime(),
-						entry.metadata.lastAccessTime(),
-						entry.metadata.lastModifiedTime()
-				);
 	}
 
 	public void merge() throws IOException {
-		ExecutorService service = Executors.newFixedThreadPool(2);
-		service.submit(() -> readToMap(entriesClient, inputClient));
-		service.submit(() -> readToMap(entriesServer, inputServer));
-		service.shutdown();
-
-		try {
-			service.awaitTermination(1, TimeUnit.HOURS);
-		} catch (InterruptedException e) {
-			e.printStackTrace();
+		try (ExecutorService service = Executors.newFixedThreadPool(2)) {
+			service.submit(() -> readToMap(entriesClient, inputClient));
+			service.submit(() -> readToMap(entriesServer, inputServer));
 		}
 
 		entriesAll.addAll(entriesClient.keySet());
 		entriesAll.addAll(entriesServer.keySet());
 
-		List<Entry> entries = entriesAll.parallelStream().map((entry) -> {
-			boolean isClass = entry.endsWith(".class");
-			boolean isMinecraft = entriesClient.containsKey(entry) || entry.startsWith("net/minecraft") || !entry.contains("/");
-			Entry result;
-			String side = null;
-
-			Entry entry1 = entriesClient.get(entry);
-			Entry entry2 = entriesServer.get(entry);
-
-			if (entry1 != null && entry2 != null) {
-				if (Arrays.equals(entry1.data, entry2.data)) {
-					result = entry1;
-				} else {
-					if (isClass) {
-						result = new Entry(entry1.path, entry1.metadata, classMerger.merge(entry1.data, entry2.data));
-					} else {
-						// FIXME: More heuristics?
-						result = entry1;
-					}
-				}
-			} else if ((result = entry1) != null) {
-				side = "CLIENT";
-			} else if ((result = entry2) != null) {
-				side = "SERVER";
+		try (ExecutorService service = Executors.newWorkStealingPool()) {
+			for (String entry : entriesAll) {
+				processEntry(entry, service);
 			}
-
-			if (isClass && !isMinecraft && "SERVER".equals(side)) {
-				// Server bundles libraries, client doesn't - skip them
-				return null;
-			}
-
-			if (result != null) {
-				if (isMinecraft && isClass) {
-					byte[] data = result.data;
-					ClassReader reader = new ClassReader(data);
-					ClassWriter writer = new ClassWriter(0);
-					ClassVisitor visitor = writer;
-
-					if (side != null) {
-						visitor = new MinecraftClassMerger.SidedClassVisitor(Constants.ASM_VERSION, visitor, side);
-					}
-
-					if (removeSnowmen) {
-						visitor = new SnowmanClassVisitor(Constants.ASM_VERSION, visitor);
-					}
-
-					if (offsetSyntheticsParams && !entry.contains("/")) {
-						visitor = new SyntheticParameterClassVisitor(Constants.ASM_VERSION, visitor);
-					}
-
-					if (visitor != writer) {
-						reader.accept(visitor, 0);
-						data = writer.toByteArray();
-						result = new Entry(result.path, result.metadata, data);
-					}
-				}
-
-				return result;
-			} else {
-				return null;
-			}
-		}).filter(Objects::nonNull).toList();
-
-		for (Entry e : entries) {
-			add(e);
 		}
+	}
+
+	private void processEntry(String entry, Executor executor) {
+		boolean isClass = entry.endsWith(".class");
+		boolean isMinecraft = entriesClient.containsKey(entry) || entry.startsWith("net/minecraft") || !entry.contains("/");
+		Result r = getResult(entry, isClass);
+
+		if (isClass && !isMinecraft && "SERVER".equals(r.side())) {
+			// Server bundles libraries, client doesn't - skip them
+			return;
+		}
+
+		if (isMinecraft && isClass) {
+			CompletableFuture.supplyAsync(() -> mergeClass(entry, r), executor)
+					.thenAccept(this::add);
+			return;
+		}
+
+		CompletableFuture.runAsync(() -> add(r.entry), executor);
+	}
+
+	private Result getResult(String entry, boolean isClass) {
+		Entry result;
+		String side = null;
+
+		Entry clientEntry = entriesClient.get(entry);
+		Entry serverEntry = entriesServer.get(entry);
+
+		// Entry is common
+		if (clientEntry != null && serverEntry != null) {
+			byte[] clientData = clientEntry.data();
+			byte[] serverData = serverEntry.data();
+
+			if (Arrays.equals(clientData, serverData)) {
+				result = clientEntry;
+			} else {
+				if (isClass) {
+					Objects.requireNonNull(clientData);
+					Objects.requireNonNull(serverData);
+					result = new Entry(clientEntry.path, clientEntry.metadata, classMerger.merge(clientData, serverData));
+				} else {
+					// FIXME: More heuristics?
+					result = clientEntry;
+				}
+			}
+		} else if ((result = clientEntry) != null) {
+			side = "CLIENT";
+		} else if ((result = serverEntry) != null) {
+			side = "SERVER";
+		}
+
+		return new Result(result, side);
+	}
+
+	private Entry mergeClass(String entry, Result result) {
+		byte[] data = result.entry().data();
+		Objects.requireNonNull(data, "Class data cannot be null");
+		ClassReader reader = new ClassReader(data);
+		ClassWriter writer = new ClassWriter(0);
+		ClassVisitor visitor = writer;
+
+		if (result.side() != null) {
+			visitor = new MinecraftClassMerger.SidedClassVisitor(Constants.ASM_VERSION, visitor, result.side());
+		}
+
+		if (removeSnowmen) {
+			visitor = new SnowmanClassVisitor(Constants.ASM_VERSION, visitor);
+		}
+
+		if (offsetSyntheticsParams && !entry.contains("/")) {
+			visitor = new SyntheticParameterClassVisitor(Constants.ASM_VERSION, visitor);
+		}
+
+		if (visitor != writer) {
+			reader.accept(visitor, 0);
+			data = writer.toByteArray();
+			return new Entry(result.entry().path, result.entry().metadata, data);
+		}
+
+		return result.entry();
+	}
+
+	// Data is null for non-class files, in this case the entry can be copied without uncompressing
+	public record Entry(Path path, BasicFileAttributes metadata, @Nullable Supplier<byte[]> dataSupplier) {
+		public Entry(Path path, BasicFileAttributes metadata, byte @Nullable [] data) {
+			this(path, metadata, () -> data);
+		}
+
+		public Entry(Path path, BasicFileAttributes metadata) {
+			this(path, metadata, (Supplier<byte[]>) null);
+		}
+
+		byte @Nullable [] data() {
+			if (dataSupplier == null) {
+				return null;
+			}
+
+			return dataSupplier.get();
+		}
+	}
+
+	private record Result(Entry entry, @Nullable String side) {
 	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/LoomTestConstants.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/LoomTestConstants.groovy
@@ -48,7 +48,7 @@ class LoomTestConstants {
 	public static final File TEST_DIR = new File("./.gradle/test-files")
 
 	// Try to detect if the debugging agent is enabled.
-	public static final boolean IS_DEBUGGING_ENABLED = ManagementFactory.runtimeMXBean.inputArguments.any { it.startsWith('-agentlib:jdwp') }
+	public static final boolean IS_DEBUGGING_ENABLED = ManagementFactory.runtimeMXBean.inputArguments.any { it.startsWith('-agentlib:jdwp') || it.contains("libasyncProfiler") }
 
 	/**
 	 * Nightly gradle versions get removed after a certain amount of time, lets check to see if its still online before running the tests.


### PR DESCRIPTION
When profiling the new debof setup the jar merger is by far the biggest sink of time, this PR solves that. The previous logic was multithreaded, but did not do multithreaded reads/writes from the zip, most of the time was spent compressing/uncompressing the class zip entries.

- Write jar entries across many threads, previously only single threaded.
- Read class entry in worker thread, instead of a single thread per jar.

This PR will go into 1.15