### PR TITLE
Apply ClassTweaker and injected interfaces async

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/accesswidener/AccessWidenerTransformer.java
+++ b/src/main/java/net/fabricmc/loom/configuration/accesswidener/AccessWidenerTransformer.java
@@ -57,7 +57,7 @@ final class AccessWidenerTransformer {
 	void apply(Path jarFile) {
 		try {
 			Set<String> targets = accessWidener.getTargets();
-			int transformed = ZipUtils.transform(jarFile, getTransformers(targets));
+			int transformed = ZipUtils.transformAsync(jarFile, getTransformers(targets));
 
 			LOGGER.debug("Applied access wideners to {} classes in {}", transformed, jarFile);
 

--- a/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
@@ -114,7 +114,7 @@ public abstract class InterfaceInjectionProcessor implements MinecraftJarProcess
 		List<InjectedInterface> injectedInterfaces = getInjectedInterfaces(spec, context);
 
 		try {
-			ZipUtils.transform(jar, getTransformers(injectedInterfaces));
+			ZipUtils.transformAsync(jar, getTransformers(injectedInterfaces));
 		} catch (IOException e) {
 			throw new RuntimeException("Failed to apply interface injections to " + jar, e);
 		}

--- a/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
@@ -240,7 +240,7 @@ public abstract class RemapJarTask extends AbstractRemapJarTask {
 							(ZipUtils.AsmClassOperator) classVisitor -> SidedClassVisitor.CLIENT.insertApplyVisitor(null, classVisitor)
 					));
 
-			ZipUtils.transform(outputFile, tranformers);
+			ZipUtils.transformAsync(outputFile, tranformers);
 		}
 
 		private void remapAccessWidener() throws IOException {

--- a/src/main/java/net/fabricmc/loom/util/ZipUtils.java
+++ b/src/main/java/net/fabricmc/loom/util/ZipUtils.java
@@ -40,7 +40,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.jspecify.annotations.Nullable;
@@ -246,7 +250,7 @@ public class ZipUtils {
 			for (Map.Entry<String, UnsafeUnaryOperator<byte[]>> entry : transforms.entrySet()) {
 				Path fsPath = fs.get().getPath(entry.getKey());
 
-				if (Files.exists(fsPath) && entry.getValue() != null) {
+				if (Files.exists(fsPath)) {
 					Files.write(fsPath, entry.getValue().apply(Files.readAllBytes(fsPath)), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
 					replacedCount++;
 				}
@@ -254,6 +258,46 @@ public class ZipUtils {
 		}
 
 		return replacedCount;
+	}
+
+	public static int transformAsync(Path zip, Collection<Pair<String, UnsafeUnaryOperator<byte[]>>> transforms) throws IOException {
+		return transformAsync(zip, Executors::newWorkStealingPool, transforms.stream());
+	}
+
+	public static int transformAsync(Path zip, Stream<Pair<String, UnsafeUnaryOperator<byte[]>>> transforms) throws IOException {
+		return transformAsync(zip, Executors::newWorkStealingPool, collectTransformersStream(transforms));
+	}
+
+	public static int transformAsync(Path zip, Supplier<ExecutorService> executorSupplier, Collection<Pair<String, UnsafeUnaryOperator<byte[]>>> transforms) throws IOException {
+		return transformAsync(zip, executorSupplier, transforms.stream());
+	}
+
+	public static int transformAsync(Path zip, Supplier<ExecutorService> executorSupplier, Stream<Pair<String, UnsafeUnaryOperator<byte[]>>> transforms) throws IOException {
+		return transformAsync(zip, executorSupplier, collectTransformersStream(transforms));
+	}
+
+	public static int transformAsync(Path zip, Supplier<ExecutorService> executorSupplier, Map<String, UnsafeUnaryOperator<byte[]>> transforms) throws IOException {
+		final AtomicInteger replacedCount = new AtomicInteger(0);
+
+		try (FileSystemUtil.Delegate fs = FileSystemUtil.getJarFileSystem(zip, false);
+				ExecutorService service = executorSupplier.get()) {
+			for (Map.Entry<String, UnsafeUnaryOperator<byte[]>> entry : transforms.entrySet()) {
+				service.submit(() -> {
+					Path fsPath = fs.get().getPath(entry.getKey());
+
+					if (Files.exists(fsPath)) {
+						try {
+							Files.write(fsPath, entry.getValue().apply(Files.readAllBytes(fsPath)), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+							replacedCount.incrementAndGet();
+						} catch (IOException ioe) {
+							throw new UncheckedIOException("Failed to apply transformation to " + fsPath, ioe);
+						}
+					}
+				});
+			}
+		}
+
+		return replacedCount.get();
 	}
 
 	@FunctionalInterface

--- a/src/test/groovy/net/fabricmc/loom/test/unit/ZipUtilsTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/ZipUtilsTest.groovy
@@ -258,4 +258,34 @@ class ZipUtilsTest extends Specification {
 		ZipUtils.unpack(zip, "text.txt") == "hello world".bytes
 		Checksum.of(zip).sha1().hex() == "e699fa52a520553241aac798f72255ac0a912b05"
 	}
+
+	def "transform async"() {
+		given:
+		def dir = File.createTempDir()
+		def zip = File.createTempFile("loom-zip-test", ".zip").toPath()
+		new File(dir, "a.txt").text = "one"
+		new File(dir, "b.txt").text = "two"
+
+		when:
+		ZipUtils.pack(dir.toPath(), zip)
+		def transformed = ZipUtils.transformAsync(zip, [
+			new Pair<String, ZipUtils.UnsafeUnaryOperator<byte[]>>("a.txt", new ZipUtils.UnsafeUnaryOperator<byte[]>() {
+				@Override
+				byte[] apply(byte[] arg) throws IOException {
+					return new String(arg, StandardCharsets.UTF_8).toUpperCase().getBytes(StandardCharsets.UTF_8)
+				}
+			}),
+			new Pair<String, ZipUtils.UnsafeUnaryOperator<byte[]>>("b.txt", new ZipUtils.UnsafeUnaryOperator<byte[]>() {
+				@Override
+				byte[] apply(byte[] arg) throws IOException {
+					return new String(arg, StandardCharsets.UTF_8).toUpperCase().getBytes(StandardCharsets.UTF_8)
+				}
+			})
+		])
+
+		then:
+		transformed == 2
+		new String(ZipUtils.unpack(zip, "a.txt"), StandardCharsets.UTF_8) == "ONE"
+		new String(ZipUtils.unpack(zip, "b.txt"), StandardCharsets.UTF_8) == "TWO"
+	}
 }


### PR DESCRIPTION
Another small speed improvement, the MinecraftJarProcessor API is badly designed as ideally the jar processors should be able to share the same thread when being applied to the jar, this is better than nothing though.