### PR TITLE
Allow native access when running Java 25 or later.

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
@@ -156,6 +156,11 @@ public class RunConfig {
 		runConfig.projectName = project.getName();
 		runConfig.folderName = settings.getIdeConfigFolder().getOrNull();
 
+		if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_25)) {
+			runConfig.vmArgs.add("--sun-misc-unsafe-memory-access=allow");
+			runConfig.vmArgs.add("--enable-native-access=ALL-UNNAMED");
+		}
+
 		return runConfig;
 	}
 


### PR DESCRIPTION
Fixes a warning (and future error) when running on Java 25. Same arguments used in the Minecraft metadata.