### PR TITLE
Add loom.defaultMixinRemapType

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -38,7 +38,6 @@ import net.fabricmc.loom.api.LoomGradleExtensionAPI;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.configuration.InstallerData;
 import net.fabricmc.loom.configuration.accesswidener.AccessWidenerFile;
-import net.fabricmc.loom.configuration.mods.ArtifactMetadata;
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsFactory;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftMetadataProvider;
@@ -84,10 +83,6 @@ public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 	void setNamedMinecraftProvider(NamedMinecraftProvider<?> namedMinecraftProvider);
 
 	void setIntermediaryMinecraftProvider(IntermediaryMinecraftProvider<?> intermediaryMinecraftProvider);
-
-	MappingsNamespace getProductionNamespaceEnum();
-
-	ArtifactMetadata.MixinRemapType getDefaultMixinRemapTypeEnum();
 
 	default List<Path> getMinecraftJars(MappingsNamespace mappingsNamespace) {
 		return switch (mappingsNamespace) {

--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -38,6 +38,7 @@ import net.fabricmc.loom.api.LoomGradleExtensionAPI;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.configuration.InstallerData;
 import net.fabricmc.loom.configuration.accesswidener.AccessWidenerFile;
+import net.fabricmc.loom.configuration.mods.ArtifactMetadata;
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsFactory;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftMetadataProvider;
@@ -85,6 +86,8 @@ public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 	void setIntermediaryMinecraftProvider(IntermediaryMinecraftProvider<?> intermediaryMinecraftProvider);
 
 	MappingsNamespace getProductionNamespaceEnum();
+
+	ArtifactMetadata.MixinRemapType getDefaultMixinRemapTypeEnum();
 
 	default List<Path> getMinecraftJars(MappingsNamespace mappingsNamespace) {
 		return switch (mappingsNamespace) {

--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -47,11 +47,13 @@ import org.jetbrains.annotations.ApiStatus;
 import net.fabricmc.loom.api.decompilers.DecompilerOptions;
 import net.fabricmc.loom.api.manifest.VersionsManifestsAPI;
 import net.fabricmc.loom.api.mappings.intermediate.IntermediateMappingsProvider;
+import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.api.mappings.layered.spec.LayeredMappingSpecBuilder;
 import net.fabricmc.loom.api.processor.MinecraftJarProcessor;
 import net.fabricmc.loom.api.remapping.RemapperExtension;
 import net.fabricmc.loom.api.remapping.RemapperParameters;
 import net.fabricmc.loom.configuration.ide.RunConfigSettings;
+import net.fabricmc.loom.configuration.mods.ArtifactMetadata;
 import net.fabricmc.loom.configuration.processors.JarProcessor;
 import net.fabricmc.loom.configuration.providers.minecraft.ManifestLocations;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftJarConfiguration;
@@ -245,7 +247,7 @@ public interface LoomGradleExtensionAPI {
 	/**
 	 * @return the production namespace
 	 */
-	Property<String> getProductionNamespace();
+	Property<MappingsNamespace> getProductionNamespace();
 
 	/**
 	 * @return whether to use intermediate mappings
@@ -255,7 +257,7 @@ public interface LoomGradleExtensionAPI {
 	/**
 	 * @return the default mixin remap type
 	 */
-	Property<String> getDefaultMixinRemapType();
+	Property<ArtifactMetadata.MixinRemapType> getDefaultMixinRemapType();
 
 	@ApiStatus.Experimental
 	Property<MinecraftJarConfiguration<?, ?, ?>> getMinecraftJarConfiguration();

--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -247,6 +247,11 @@ public interface LoomGradleExtensionAPI {
 	 */
 	Property<String> getProductionNamespace();
 
+	/**
+	 * @return the default mixin remap type
+	 */
+	Property<String> getDefaultMixinRemapType();
+
 	@ApiStatus.Experimental
 	Property<MinecraftJarConfiguration<?, ?, ?>> getMinecraftJarConfiguration();
 

--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -62,6 +62,7 @@ import net.fabricmc.loom.build.mixin.KaptApInvoker;
 import net.fabricmc.loom.build.mixin.ScalaApInvoker;
 import net.fabricmc.loom.configuration.accesswidener.AccessWidenerJarProcessor;
 import net.fabricmc.loom.configuration.ifaceinject.InterfaceInjectionProcessor;
+import net.fabricmc.loom.configuration.mods.ArtifactMetadata;
 import net.fabricmc.loom.configuration.processors.JsrAnnotationRemapperProcessor;
 import net.fabricmc.loom.configuration.processors.MinecraftJarProcessorManager;
 import net.fabricmc.loom.configuration.processors.ModJavadocProcessor;
@@ -178,11 +179,14 @@ public abstract class CompileConfiguration implements Runnable {
 
 		if (metadataProvider.getVersionMeta().isVersionOrNewer(Constants.RELEASE_TIME_1_21_11_UNOBFUSCATED_SNAPSHOTS) && !metadataProvider.getVersionMeta().downloads().containsKey("client_mappings")) {
 			extension.getProductionNamespace().convention(MappingsNamespace.OFFICIAL.toString());
+			extension.getDefaultMixinRemapType().convention(ArtifactMetadata.MixinRemapType.STATIC.name());
 		} else {
 			extension.getProductionNamespace().convention(MappingsNamespace.INTERMEDIARY.toString());
+			extension.getDefaultMixinRemapType().convention(ArtifactMetadata.MixinRemapType.MIXIN.name());
 		}
 
 		extension.getProductionNamespace().finalizeValue();
+		extension.getDefaultMixinRemapType().finalizeValue();
 
 		var jarConfiguration = extension.getMinecraftJarConfiguration().get();
 

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactMetadata.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactMetadata.java
@@ -44,11 +44,11 @@ import net.fabricmc.loom.util.FileSystemUtil;
 import net.fabricmc.loom.util.fmj.FabricModJsonFactory;
 
 public record ArtifactMetadata(boolean isFabricMod, RemapRequirements remapRequirements, @Nullable InstallerData installerData, MixinRemapType mixinRemapType, List<String> knownIdyBsms) {
-	public static ArtifactMetadata create(ArtifactRef artifact, String currentLoomVersion) throws IOException {
+	public static ArtifactMetadata create(ArtifactRef artifact, String currentLoomVersion, MixinRemapType defaultMixinRemapType) throws IOException {
 		boolean isFabricMod;
 		RemapRequirements remapRequirements = RemapRequirements.DEFAULT;
 		InstallerData installerData = null;
-		MixinRemapType refmapRemapType = MixinRemapType.MIXIN;
+		MixinRemapType refmapRemapType = defaultMixinRemapType;
 		List<String> knownIndyBsms = new ArrayList<>();
 
 		try (FileSystemUtil.Delegate fs = FileSystemUtil.getJarFileSystem(artifact.path())) {

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
@@ -164,7 +164,7 @@ public class ModConfigurationRemapper {
 			 */
 			final Configuration clientRemappedConfig = clientConfigsToRemap.get(sourceConfig);
 			List<ArtifactRef> artifactRefs = resolveArtifacts(project, sourceConfig);
-			Map<ArtifactRef, ArtifactMetadata> metadataMap = getMetadata(artifactRefs, metaCache, extension.getDefaultMixinRemapTypeEnum());
+			Map<ArtifactRef, ArtifactMetadata> metadataMap = getMetadata(artifactRefs, metaCache, extension.getDefaultMixinRemapType().get());
 			final List<ModDependency> modDependencies = new ArrayList<>();
 
 			for (ArtifactRef artifact : artifactRefs) {

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
@@ -164,7 +164,7 @@ public class ModConfigurationRemapper {
 			 */
 			final Configuration clientRemappedConfig = clientConfigsToRemap.get(sourceConfig);
 			List<ArtifactRef> artifactRefs = resolveArtifacts(project, sourceConfig);
-			Map<ArtifactRef, ArtifactMetadata> metadataMap = getMetadata(artifactRefs, metaCache);
+			Map<ArtifactRef, ArtifactMetadata> metadataMap = getMetadata(artifactRefs, metaCache, extension.getDefaultMixinRemapTypeEnum());
 			final List<ModDependency> modDependencies = new ArrayList<>();
 
 			for (ArtifactRef artifact : artifactRefs) {
@@ -232,13 +232,13 @@ public class ModConfigurationRemapper {
 		});
 	}
 
-	private static Map<ArtifactRef, ArtifactMetadata> getMetadata(List<ArtifactRef> artifacts, AsyncCache<ArtifactMetadata> cache) {
+	private static Map<ArtifactRef, ArtifactMetadata> getMetadata(List<ArtifactRef> artifacts, AsyncCache<ArtifactMetadata> cache, ArtifactMetadata.MixinRemapType defaultMixinRemapType) {
 		var futures = new HashMap<ArtifactRef, CompletableFuture<ArtifactMetadata>>();
 
 		for (ArtifactRef artifact : artifacts) {
 			CompletableFuture<ArtifactMetadata> future = cache.get(artifact, () -> {
 				try {
-					return ArtifactMetadata.create(artifact, LoomGradlePlugin.LOOM_VERSION);
+					return ArtifactMetadata.create(artifact, LoomGradlePlugin.LOOM_VERSION, defaultMixinRemapType);
 				} catch (IOException e) {
 					throw ExceptionUtil.createDescriptiveWrapper(UncheckedIOException::new, "Failed to read metadata from " + artifact.path(), e);
 				}

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModProcessor.java
@@ -139,7 +139,7 @@ public class ModProcessor {
 		final LoomGradleExtension extension = LoomGradleExtension.get(project);
 		final MappingConfiguration mappingConfiguration = extension.getMappingConfiguration();
 
-		MappingsNamespace productionNamespace = extension.getProductionNamespaceEnum();
+		MappingsNamespace productionNamespace = extension.getProductionNamespace().get();
 
 		Set<String> knownIndyBsms = new HashSet<>(extension.getKnownIndyBsms().get());
 

--- a/src/main/java/net/fabricmc/loom/configuration/processors/MappingProcessorContextImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/MappingProcessorContextImpl.java
@@ -38,6 +38,6 @@ public record MappingProcessorContextImpl(ConfigContext configContext) implement
 
 	@Override
 	public MappingsNamespace getProductionNamespace() {
-		return configContext().extension().getProductionNamespaceEnum();
+		return configContext().extension().getProductionNamespace().get();
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/processors/ProcessorContextImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/ProcessorContextImpl.java
@@ -73,6 +73,6 @@ public record ProcessorContextImpl(ConfigContext configContext, MinecraftJar min
 
 	@Override
 	public MappingsNamespace getProductionNamespace() {
-		return configContext().extension().getProductionNamespaceEnum();
+		return configContext().extension().getProductionNamespace().get();
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/processors/speccontext/RemappedProjectView.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/speccontext/RemappedProjectView.java
@@ -83,7 +83,7 @@ public interface RemappedProjectView extends ProjectView {
 
 		@Override
 		public MappingsNamespace getProductionNamespace() {
-			return extension.getProductionNamespaceEnum();
+			return extension.getProductionNamespace().get();
 		}
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/GradleMappingContext.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/GradleMappingContext.java
@@ -97,7 +97,7 @@ public class GradleMappingContext implements MappingContext {
 
 	@Override
 	public String productionNamespace() {
-		return extension.getProductionNamespaceEnum().toString();
+		return extension.getProductionNamespace().get().toString();
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -96,9 +96,9 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	protected final Property<Boolean> modProvidedJavadoc;
 	protected final Property<String> intermediary;
 	protected final Property<IntermediateMappingsProvider> intermediateMappingsProvider;
-	private final Property<String> productionNamespace;
+	private final Property<MappingsNamespace> productionNamespace;
 	private final Property<Boolean> useIntermediateMappings;
-	private final Property<String> defaultMixinRemapType;
+	private final Property<ArtifactMetadata.MixinRemapType> defaultMixinRemapType;
 	private final Property<Boolean> remapJsrAnnotationsToJetBrains;
 	private final Property<Boolean> runtimeOnlyLog4j;
 	private final Property<Boolean> splitModDependencies;
@@ -144,14 +144,14 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 		this.modProvidedJavadoc.finalizeValueOnRead();
 		this.intermediary = project.getObjects().property(String.class)
 				.convention(DEFAULT_INTERMEDIARY_URL);
-		this.productionNamespace = project.getObjects().property(String.class);
-		this.productionNamespace.convention(project.provider(() -> LoomGradleExtension.get(project).getMetadataProvider().isUnobfuscated() ? MappingsNamespace.OFFICIAL.toString() : MappingsNamespace.INTERMEDIARY.toString()));
+		this.productionNamespace = project.getObjects().property(MappingsNamespace.class);
+		this.productionNamespace.convention(project.provider(() -> LoomGradleExtension.get(project).getMetadataProvider().isUnobfuscated() ? MappingsNamespace.OFFICIAL : MappingsNamespace.INTERMEDIARY));
 		this.productionNamespace.finalizeValueOnRead();
 		this.useIntermediateMappings = project.getObjects().property(Boolean.class);
 		this.useIntermediateMappings.convention(project.provider(() -> !LoomGradleExtension.get(project).getMetadataProvider().isUnobfuscated()));
 		this.useIntermediateMappings.finalizeValueOnRead();
-		this.defaultMixinRemapType = project.getObjects().property(String.class);
-		this.defaultMixinRemapType.convention(project.provider(() -> LoomGradleExtension.get(project).getMetadataProvider().isUnobfuscated() ? ArtifactMetadata.MixinRemapType.STATIC.name() : ArtifactMetadata.MixinRemapType.MIXIN.name()));
+		this.defaultMixinRemapType = project.getObjects().property(ArtifactMetadata.MixinRemapType.class);
+		this.defaultMixinRemapType.convention(project.provider(() -> LoomGradleExtension.get(project).getMetadataProvider().isUnobfuscated() ? ArtifactMetadata.MixinRemapType.STATIC : ArtifactMetadata.MixinRemapType.MIXIN));
 		this.defaultMixinRemapType.finalizeValueOnRead();
 
 		this.intermediateMappingsProvider = project.getObjects().property(IntermediateMappingsProvider.class);
@@ -359,7 +359,7 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	}
 
 	@Override
-	public Property<String> getProductionNamespace() {
+	public Property<MappingsNamespace> getProductionNamespace() {
 		return productionNamespace;
 	}
 
@@ -369,7 +369,7 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	}
 
 	@Override
-	public Property<String> getDefaultMixinRemapType() {
+	public Property<ArtifactMetadata.MixinRemapType> getDefaultMixinRemapType() {
 		return defaultMixinRemapType;
 	}
 

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -96,6 +96,7 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	protected final Property<String> intermediary;
 	protected final Property<IntermediateMappingsProvider> intermediateMappingsProvider;
 	private final Property<String> productionNamespace;
+	private final Property<String> defaultMixinRemapType;
 	private final Property<Boolean> remapJsrAnnotationsToJetBrains;
 	private final Property<Boolean> runtimeOnlyLog4j;
 	private final Property<Boolean> splitModDependencies;
@@ -143,6 +144,8 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 				.convention(DEFAULT_INTERMEDIARY_URL);
 		this.productionNamespace = project.getObjects().property(String.class);
 		this.productionNamespace.finalizeValueOnRead();
+		this.defaultMixinRemapType = project.getObjects().property(String.class);
+		this.defaultMixinRemapType.finalizeValueOnRead();
 
 		this.intermediateMappingsProvider = project.getObjects().property(IntermediateMappingsProvider.class);
 		this.intermediateMappingsProvider.finalizeValueOnRead();
@@ -351,6 +354,11 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	@Override
 	public Property<String> getProductionNamespace() {
 		return productionNamespace;
+	}
+
+	@Override
+	public Property<String> getDefaultMixinRemapType() {
+		return defaultMixinRemapType;
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
@@ -50,7 +50,6 @@ import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.configuration.InstallerData;
 import net.fabricmc.loom.configuration.LoomDependencyManager;
 import net.fabricmc.loom.configuration.accesswidener.AccessWidenerFile;
-import net.fabricmc.loom.configuration.mods.ArtifactMetadata;
 import net.fabricmc.loom.configuration.providers.mappings.IntermediaryMappingsProvider;
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsFactory;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
@@ -343,16 +342,6 @@ public abstract class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl
 	@Override
 	public boolean disableObfuscation() {
 		return disableObfuscation.get();
-	}
-
-	@Override
-	public MappingsNamespace getProductionNamespaceEnum() {
-		return Objects.requireNonNull(MappingsNamespace.of(getProductionNamespace().get()), "Invalid production namespace");
-	}
-
-	@Override
-	public ArtifactMetadata.MixinRemapType getDefaultMixinRemapTypeEnum() {
-		return ArtifactMetadata.MixinRemapType.valueOf(getDefaultMixinRemapType().get());
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
@@ -50,6 +50,7 @@ import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.configuration.InstallerData;
 import net.fabricmc.loom.configuration.LoomDependencyManager;
 import net.fabricmc.loom.configuration.accesswidener.AccessWidenerFile;
+import net.fabricmc.loom.configuration.mods.ArtifactMetadata;
 import net.fabricmc.loom.configuration.providers.mappings.IntermediaryMappingsProvider;
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsFactory;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
@@ -348,6 +349,11 @@ public abstract class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl
 	@Override
 	public MappingsNamespace getProductionNamespaceEnum() {
 		return Objects.requireNonNull(MappingsNamespace.of(getProductionNamespace().get()), "Invalid production namespace");
+	}
+
+	@Override
+	public ArtifactMetadata.MixinRemapType getDefaultMixinRemapTypeEnum() {
+		return ArtifactMetadata.MixinRemapType.valueOf(getDefaultMixinRemapType().get());
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/extension/MixinExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/MixinExtensionApiImpl.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.LoomGradleExtensionAPI;
 import net.fabricmc.loom.api.MixinExtensionAPI;
+import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 
 public abstract class MixinExtensionApiImpl implements MixinExtensionAPI {
 	private static final String MIXIN_AP_DISABLED_ERROR = "The mixin annotation is no longer enabled by default, you should remove any loom.mixin configuration. If you wish to continue to use the mixin AP you can set useLegacyMixinAp = true.";
@@ -59,7 +60,7 @@ public abstract class MixinExtensionApiImpl implements MixinExtensionAPI {
 				.convention(false);
 
 		this.refmapTargetNamespace = project.getObjects().property(String.class);
-		this.refmapTargetNamespace.convention(project.provider(() -> LoomGradleExtension.get(project)).flatMap(LoomGradleExtensionAPI::getProductionNamespace));
+		this.refmapTargetNamespace.convention(project.provider(() -> LoomGradleExtension.get(project)).flatMap(LoomGradleExtensionAPI::getProductionNamespace).map(MappingsNamespace::toString));
 		this.refmapTargetNamespace.finalizeValueOnRead();
 
 		this.messages = project.getObjects().mapProperty(String.class, String.class);

--- a/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
@@ -55,6 +55,7 @@ import net.fabricmc.classtweaker.api.ClassTweakerReader;
 import net.fabricmc.classtweaker.api.ClassTweakerWriter;
 import net.fabricmc.classtweaker.visitors.ClassTweakerRemapperVisitor;
 import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.build.nesting.JarNester;
 import net.fabricmc.loom.build.nesting.NestableJarGenerationTask;
 import net.fabricmc.loom.configuration.accesswidener.AccessWidenerFile;
@@ -105,7 +106,7 @@ public abstract class RemapJarTask extends AbstractRemapJarTask {
 		getAddNestedDependencies().convention(true).finalizeValueOnRead();
 		getOptimizeFabricModJson().convention(false).finalizeValueOnRead();
 
-		getTargetNamespace().set(extension.getProductionNamespace());
+		getTargetNamespace().set(extension.getProductionNamespace().map(MappingsNamespace::toString));
 
 		TaskProvider<NestableJarGenerationTask> processIncludeJars = getProject().getTasks().named(Constants.Task.PROCESS_INCLUDE_JARS, NestableJarGenerationTask.class);
 		getNestedJars().from(processIncludeJars.map(task -> getProject().fileTree(task.getOutputDirectory())));

--- a/src/main/java/net/fabricmc/loom/task/launch/GenerateDLIConfigTask.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/GenerateDLIConfigTask.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
@@ -91,6 +92,9 @@ public abstract class GenerateDLIConfigTask extends AbstractLoomTask {
 	@Input
 	protected abstract Property<String> getProductionNamespace();
 
+	@Input
+	protected abstract Property<String> getDefaultMixinRemapType();
+
 	@InputFile
 	@Optional
 	public abstract RegularFileProperty getRemapClasspathFile();
@@ -120,6 +124,7 @@ public abstract class GenerateDLIConfigTask extends AbstractLoomTask {
 		getNativesDirectoryPath().set(getExtension().getFiles().getNativesDirectory(getProject()).getAbsolutePath());
 		getDevLauncherConfig().set(getExtension().getFiles().getDevLauncherConfig());
 		getProductionNamespace().set(getExtension().getProductionNamespaceEnum().toString());
+		getDefaultMixinRemapType().set(getExtension().getDefaultMixinRemapTypeEnum().toString().toLowerCase(Locale.ROOT));
 	}
 
 	@TaskAction
@@ -136,6 +141,7 @@ public abstract class GenerateDLIConfigTask extends AbstractLoomTask {
 				.property("log4j.configurationFile", getLog4jConfigPaths().get())
 				.property("log4j2.formatMsgNoLookups", "true")
 				.property("fabric.defaultModDistributionNamespace", getProductionNamespace().get())
+				.property("fabric.defaultMixinRemapType", getDefaultMixinRemapType().get())
 
 				.argument("client", "--assetIndex")
 				.argument("client", versionInfo.assetIndex().fabricId(getMinecraftVersion().get()))

--- a/src/main/java/net/fabricmc/loom/task/launch/GenerateDLIConfigTask.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/GenerateDLIConfigTask.java
@@ -50,6 +50,7 @@ import org.gradle.api.tasks.TaskAction;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.LoomGradlePlugin;
+import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftVersionMeta;
 import net.fabricmc.loom.configuration.providers.minecraft.mapped.MappedMinecraftProvider;
 import net.fabricmc.loom.task.AbstractLoomTask;
@@ -123,8 +124,8 @@ public abstract class GenerateDLIConfigTask extends AbstractLoomTask {
 		getAssetsDirectoryPath().set(new File(getExtension().getFiles().getUserCache(), "assets").getAbsolutePath());
 		getNativesDirectoryPath().set(getExtension().getFiles().getNativesDirectory(getProject()).getAbsolutePath());
 		getDevLauncherConfig().set(getExtension().getFiles().getDevLauncherConfig());
-		getProductionNamespace().set(getExtension().getProductionNamespaceEnum().toString());
-		getDefaultMixinRemapType().set(getExtension().getDefaultMixinRemapTypeEnum().toString().toLowerCase(Locale.ROOT));
+		getProductionNamespace().set(getExtension().getProductionNamespace().map(MappingsNamespace::toString));
+		getDefaultMixinRemapType().set(getExtension().getDefaultMixinRemapType().map(remapType -> remapType.toString().toLowerCase(Locale.ROOT)));
 	}
 
 	@TaskAction

--- a/src/main/java/net/fabricmc/loom/task/launch/GenerateRemapClasspathTask.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/GenerateRemapClasspathTask.java
@@ -59,7 +59,7 @@ public abstract class GenerateRemapClasspathTask extends AbstractLoomTask {
 				.map(configurations::named)
 				.forEach(getRemapClasspath()::from);
 
-		for (Path minecraftJar : getExtension().getMinecraftJars(getExtension().getProductionNamespaceEnum())) {
+		for (Path minecraftJar : getExtension().getMinecraftJars(getExtension().getProductionNamespace().get())) {
 			getRemapClasspath().from(minecraftJar.toFile());
 		}
 

--- a/src/main/java/net/fabricmc/loom/task/prod/ClientProductionRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/prod/ClientProductionRunTask.java
@@ -101,7 +101,7 @@ public abstract non-sealed class ClientProductionRunTask extends AbstractProduct
 		getClasspath().from(getExtension().getMinecraftProvider().getMinecraftClientJar());
 		getClasspath().from(detachedConfigurationProvider("net.fabricmc:fabric-loader:%s", getProjectLoaderVersion()));
 
-		if (getExtension().getProductionNamespaceEnum() == MappingsNamespace.INTERMEDIARY) {
+		if (getExtension().getProductionNamespace().get() == MappingsNamespace.INTERMEDIARY) {
 			getClasspath().from(detachedConfigurationProvider("net.fabricmc:intermediary:%s", getExtension().getMinecraftVersion()));
 		}
 

--- a/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
+++ b/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
@@ -163,11 +163,12 @@ public class SourceRemapper {
 		LoomGradleExtension extension = LoomGradleExtension.get(project);
 		MappingConfiguration mappingConfiguration = extension.getMappingConfiguration();
 
+		MappingsNamespace prodNamespace = extension.getProductionNamespace().get();
 		LorenzMappingService lorenzMappingService = serviceFactory.get(LorenzMappingService.createOptions(
 				project,
 				mappingConfiguration,
-				toNamed ? extension.getProductionNamespaceEnum() : MappingsNamespace.NAMED,
-				toNamed ? MappingsNamespace.NAMED : extension.getProductionNamespaceEnum()));
+				toNamed ? prodNamespace : MappingsNamespace.NAMED,
+				toNamed ? MappingsNamespace.NAMED : prodNamespace));
 		MappingSet mappings = lorenzMappingService.getMappings();
 
 		Mercury mercury = createMercuryWithClassPath(project, toNamed);
@@ -182,7 +183,7 @@ public class SourceRemapper {
 			}
 		}
 
-		for (Path productionJar : extension.getMinecraftJars(extension.getProductionNamespaceEnum())) {
+		for (Path productionJar : extension.getMinecraftJars(extension.getProductionNamespace().get())) {
 			mercury.getClassPath().add(productionJar);
 		}
 

--- a/src/test/groovy/net/fabricmc/loom/test/unit/ArtifactMetadataTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/ArtifactMetadataTest.groovy
@@ -237,7 +237,7 @@ class ArtifactMetadataTest extends Specification {
 	}
 
 	private static ArtifactMetadata createMetadata(Path zip, String loomVersion = "1.4") {
-		return ArtifactMetadata.create(createArtifact(zip), loomVersion)
+		return ArtifactMetadata.create(createArtifact(zip), loomVersion, ArtifactMetadata.MixinRemapType.MIXIN)
 	}
 
 	private static ArtifactRef createArtifact(Path zip) {


### PR DESCRIPTION
This PR adds `loom.defaultMixinRemapType` to newer unobfuscated versions to use `static` as a mixin remap type by default. 

Currently it autodetects unobfuscated versions because in all cases it is `static` for mods without remapping. The decision can be manually overridden just in case. 

Depends on FabricMC/fabric-loader#1106