### PR TITLE
Fix a couple of errors on IDE import when using Isolated Projects and Loom in a subproject

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/ide/idea/IdeaSyncTask.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/idea/IdeaSyncTask.java
@@ -45,6 +45,7 @@ import javax.xml.transform.stream.StreamResult;
 
 import org.gradle.api.Project;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.project.IsolatedProject;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
@@ -86,10 +87,10 @@ public abstract class IdeaSyncTask extends AbstractLoomTask {
 
 	// See: https://github.com/FabricMC/fabric-loom/pull/206#issuecomment-986054254 for the reason why XML's are still used to provide the run configs
 	private List<IntelijRunConfig> getRunConfigs() throws IOException {
-		Project rootProject = getProject().getRootProject();
+		IsolatedProject rootProject = getProject().getIsolated().getRootProject();
 		LoomGradleExtension extension = LoomGradleExtension.get(getProject());
-		String projectPath = getProject() == rootProject ? "" : getProject().getPath().replace(':', '_');
-		File runConfigsDir = new File(rootProject.file(".idea"), "runConfigurations");
+		String projectPath = getProject().getPath().equals(rootProject.getPath()) ? "" : getProject().getPath().replace(':', '_');
+		File runConfigsDir = new File(rootProject.getProjectDirectory().file(".idea").getAsFile(), "runConfigurations");
 
 		List<IntelijRunConfig> configs = new ArrayList<>();
 

--- a/src/main/java/net/fabricmc/loom/configuration/ide/idea/IdeaSyncTask.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/idea/IdeaSyncTask.java
@@ -43,7 +43,6 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import org.gradle.api.Project;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.project.IsolatedProject;
 import org.gradle.api.provider.ListProperty;

--- a/src/main/java/net/fabricmc/loom/task/GenVsCodeProjectTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenVsCodeProjectTask.java
@@ -73,7 +73,7 @@ public abstract class GenVsCodeProjectTask extends AbstractLoomTask {
 	public GenVsCodeProjectTask() {
 		setGroup(Constants.TaskGroup.IDE);
 		getLaunchConfigurations().set(getProject().provider(this::getConfigurations));
-		getLaunchJson().convention(getProject().getRootProject().getLayout().getProjectDirectory().file(".vscode/launch.json"));
+		getLaunchJson().convention(getProject().getIsolated().getRootProject().getProjectDirectory().file(".vscode/launch.json"));
 	}
 
 	private List<VsCodeConfiguration> getConfigurations() {


### PR DESCRIPTION
Access root project path through `#getIsolatedProject` instead of directly off the project.

[Log file](https://gist.github.com/dexman545/48ac7bf47ecb01800431c4fe12f5efc1)