### PR TITLE
Transitive AW and mod javadoc for using intermediary on unobfuscated versions

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/accesswidener/TransitiveAccessWidenerMappingsProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/accesswidener/TransitiveAccessWidenerMappingsProcessor.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 
+import net.fabricmc.mappingio.tree.MappingTreeView;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,13 +61,15 @@ public final class TransitiveAccessWidenerMappingsProcessor implements Minecraft
 			return false;
 		}
 
-		if (!context.getProductionNamespace().toString().equals(mappings.getSrcNamespace())) {
-			throw new IllegalStateException("Mapping tree must have " + context.getProductionNamespace().toString() + " src mappings not " + mappings.getSrcNamespace());
+		int productionNamespaceId = mappings.getNamespaceId(context.getProductionNamespace().toString());
+
+		if (productionNamespaceId == MappingTreeView.NULL_NAMESPACE_ID) {
+			throw new IllegalStateException("Mapping tree must have namespace %s".formatted(context.getProductionNamespace().toString()));
 		}
 
 		try (LazyCloseable<TinyRemapper> remapper = context.createRemapper(context.getProductionNamespace(), MappingsNamespace.NAMED)) {
 			for (AccessWidenerEntry accessWidener : accessWideners) {
-				var visitor = new MappingCommentClassTweakerVisitor(accessWidener.mappingId(), mappings);
+				var visitor = new MappingCommentClassTweakerVisitor(accessWidener.mappingId(), productionNamespaceId, mappings);
 				accessWidener.read(visitor, remapper, context.getProductionNamespace());
 			}
 		} catch (IOException e) {
@@ -75,7 +79,7 @@ public final class TransitiveAccessWidenerMappingsProcessor implements Minecraft
 		return true;
 	}
 
-	private record MappingCommentClassTweakerVisitor(String modId, MemoryMappingTree mappingTree) implements ClassTweakerVisitor {
+	private record MappingCommentClassTweakerVisitor(String modId, int productionNamespaceId, MemoryMappingTree mappingTree) implements ClassTweakerVisitor {
 		@Override
 		public AccessWidenerVisitor visitAccessWidener(String owner) {
 			return new MappingCommentAccessWidenerVisitor(owner);
@@ -90,7 +94,7 @@ public final class TransitiveAccessWidenerMappingsProcessor implements Minecraft
 
 			@Override
 			public void visitClass(AccessType access, boolean transitive) {
-				MappingTree.ClassMapping classMapping = mappingTree.getClass(className);
+				MappingTree.ClassMapping classMapping = mappingTree.getClass(className, productionNamespaceId());
 
 				if (classMapping == null) {
 					LOGGER.info("Failed to find class ({}) to mark access widened by mod ({})", className, modId());
@@ -105,7 +109,7 @@ public final class TransitiveAccessWidenerMappingsProcessor implements Minecraft
 				// Access is also applied to the class, so also add the comment to the class
 				visitClass(access, transitive);
 
-				MappingTree.ClassMapping classMapping = mappingTree.getClass(className);
+				MappingTree.ClassMapping classMapping = mappingTree.getClass(className, productionNamespaceId());
 
 				if (classMapping == null) {
 					LOGGER.info("Failed to find class ({}) to mark access widened by mod ({})", className, modId());
@@ -127,7 +131,7 @@ public final class TransitiveAccessWidenerMappingsProcessor implements Minecraft
 				// Access is also applied to the class, so also add the comment to the class
 				visitClass(access, transitive);
 
-				MappingTree.ClassMapping classMapping = mappingTree.getClass(className);
+				MappingTree.ClassMapping classMapping = mappingTree.getClass(className, productionNamespaceId());
 
 				if (classMapping == null) {
 					LOGGER.info("Failed to find class ({}) to mark access widened by mod ({})", name, modId());

--- a/src/main/java/net/fabricmc/loom/configuration/accesswidener/TransitiveAccessWidenerMappingsProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/accesswidener/TransitiveAccessWidenerMappingsProcessor.java
@@ -28,8 +28,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 
-import net.fabricmc.mappingio.tree.MappingTreeView;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +38,7 @@ import net.fabricmc.loom.api.processor.MappingProcessorContext;
 import net.fabricmc.loom.api.processor.MinecraftJarProcessor;
 import net.fabricmc.loom.util.LazyCloseable;
 import net.fabricmc.mappingio.tree.MappingTree;
+import net.fabricmc.mappingio.tree.MappingTreeView;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
 import net.fabricmc.tinyremapper.TinyRemapper;
 

--- a/src/main/java/net/fabricmc/loom/configuration/processors/ModJavadocProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/ModJavadocProcessor.java
@@ -58,6 +58,7 @@ import net.fabricmc.mappingio.MappingVisitor;
 import net.fabricmc.mappingio.adapter.ForwardingMappingVisitor;
 import net.fabricmc.mappingio.adapter.MappingNsRenamer;
 import net.fabricmc.mappingio.tree.MappingTree;
+import net.fabricmc.mappingio.tree.MappingTreeView;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
 public abstract class ModJavadocProcessor implements MinecraftJarProcessor<ModJavadocProcessor.Spec> {
@@ -156,12 +157,14 @@ public abstract class ModJavadocProcessor implements MinecraftJarProcessor<ModJa
 		}
 
 		public void apply(MemoryMappingTree target) {
-			if (!mappingTree.getSrcNamespace().equals(target.getSrcNamespace())) {
-				throw new IllegalStateException("Cannot apply mappings to differing namespaces. source: %s target: %s".formatted(mappingTree.getSrcNamespace(), target.getSrcNamespace()));
+			int targetNamespaceId = target.getNamespaceId(mappingTree.getSrcNamespace());
+
+			if (targetNamespaceId == MappingTreeView.NULL_NAMESPACE_ID) {
+				throw new IllegalStateException("Mapping tree must have namespace %s".formatted(mappingTree.getSrcNamespace()));
 			}
 
 			for (MappingTree.ClassMapping sourceClass : mappingTree.getClasses()) {
-				final MappingTree.ClassMapping targetClass = target.getClass(sourceClass.getSrcName());
+				final MappingTree.ClassMapping targetClass = target.getClass(sourceClass.getSrcName(), targetNamespaceId);
 
 				if (targetClass == null) {
 					LOGGER.warn("Could not find provided javadoc target class {} from mod {}", sourceClass.getSrcName(), modId);
@@ -171,7 +174,7 @@ public abstract class ModJavadocProcessor implements MinecraftJarProcessor<ModJa
 				applyComment(sourceClass, targetClass);
 
 				for (MappingTree.FieldMapping sourceField : sourceClass.getFields()) {
-					final MappingTree.FieldMapping targetField = targetClass.getField(sourceField.getSrcName(), sourceField.getSrcDesc());
+					final MappingTree.FieldMapping targetField = targetClass.getField(sourceField.getSrcName(), sourceField.getSrcDesc(), targetNamespaceId);
 
 					if (targetField == null) {
 						LOGGER.warn("Could not find provided javadoc target field {}{} from mod {}", sourceField.getSrcName(), sourceField.getSrcDesc(), modId);
@@ -182,7 +185,7 @@ public abstract class ModJavadocProcessor implements MinecraftJarProcessor<ModJa
 				}
 
 				for (MappingTree.MethodMapping sourceMethod : sourceClass.getMethods()) {
-					final MappingTree.MethodMapping targetMethod = targetClass.getMethod(sourceMethod.getSrcName(), sourceMethod.getSrcDesc());
+					final MappingTree.MethodMapping targetMethod = targetClass.getMethod(sourceMethod.getSrcName(), sourceMethod.getSrcDesc(), targetNamespaceId);
 
 					if (targetMethod == null) {
 						LOGGER.warn("Could not find provided javadoc target method {}{} from mod {}", sourceMethod.getSrcName(), sourceMethod.getSrcDesc(), modId);

--- a/src/test/groovy/net/fabricmc/loom/test/integration/AccessWidenerTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/AccessWidenerTest.groovy
@@ -68,6 +68,38 @@ class AccessWidenerTest extends Specification implements GradleProjectTestTrait 
 	}
 
 	@Unroll
+	def "transitive accesswidener official production (gradle #version)"() {
+		setup:
+		def gradle = gradleProject(project: "transitiveAccesswidenerOfficialProd", version: version)
+		ZipUtils.pack(new File(gradle.projectDir, "dummyDependency").toPath(), new File(gradle.projectDir, "dummy.jar").toPath())
+
+		when:
+		def result = gradle.run(task: "build")
+
+		then:
+		result.task(":build").outcome == SUCCESS
+
+		where:
+		version << STANDARD_TEST_VERSIONS
+	}
+
+	@Unroll
+	def "transitive accesswidener official production genSources (gradle #version)"() {
+		setup:
+		def gradle = gradleProject(project: "transitiveAccesswidenerOfficialProd", version: version)
+		ZipUtils.pack(new File(gradle.projectDir, "dummyDependency").toPath(), new File(gradle.projectDir, "dummy.jar").toPath())
+
+		when:
+		def result = gradle.run(task: "genSources")
+
+		then:
+		result.task(":genSources").outcome == SUCCESS
+
+		where:
+		version << STANDARD_TEST_VERSIONS
+	}
+
+	@Unroll
 	def "invalid (#awLine)"() {
 		setup:
 		def gradle = gradleProject(project: "accesswidener", version: version)

--- a/src/test/groovy/net/fabricmc/loom/test/integration/ModJavadocTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/ModJavadocTest.groovy
@@ -56,6 +56,26 @@ class ModJavadocTest extends Specification implements GradleProjectTestTrait {
 		version << STANDARD_TEST_VERSIONS
 	}
 
+	@Unroll
+	def "mod javadoc official production (gradle #version)"() {
+		setup:
+		def gradle = gradleProject(project: "modJavadocOfficialProd", version: version)
+		ZipUtils.pack(new File(gradle.projectDir, "dummyDependency").toPath(), new File(gradle.projectDir, "dummy.jar").toPath())
+
+		when:
+		def result = gradle.run(task: "genSources")
+		def blocks = getClassSource(gradle, "net/minecraft/block/Blocks.java")
+
+		then:
+		result.task(":genSources").outcome == SUCCESS
+		blocks.contains("An example of a mod added class javadoc")
+		blocks.contains("An example of a mod added field javadoc")
+		blocks.contains("An example of a mod added method javadoc")
+
+		where:
+		version << STANDARD_TEST_VERSIONS
+	}
+
 	private static String getClassSource(GradleProject gradle, String classname) {
 		File sourcesJar = gradle.getGeneratedLocalSources("1.17.1-net.fabricmc.yarn.1_17_1.1.17.1+build.59-v2")
 		return new String(ZipUtils.unpack(sourcesJar.toPath(), classname), StandardCharsets.UTF_8)

--- a/src/test/resources/projects/modJavadocOfficialProd/build.gradle
+++ b/src/test/resources/projects/modJavadocOfficialProd/build.gradle
@@ -1,0 +1,25 @@
+// This is used by a range of tests that append to this file before running the gradle tasks.
+// Can be used for tests that require minimal custom setup
+plugins {
+	id 'fabric-loom'
+	id 'maven-publish'
+}
+
+version = "1.0.0"
+group = "com.example"
+
+dependencies {
+	minecraft "com.mojang:minecraft:1.17.1"
+	mappings "net.fabricmc:yarn:1.17.1+build.59:v2"
+	modImplementation "net.fabricmc:fabric-loader:0.11.6"
+
+	modImplementation files("dummy.jar")
+}
+
+loom {
+	productionNamespace = "official"
+}
+
+base {
+	archivesName = "fabric-example-mod"
+}

--- a/src/test/resources/projects/modJavadocOfficialProd/dummyDependency/fabric.mod.json
+++ b/src/test/resources/projects/modJavadocOfficialProd/dummyDependency/fabric.mod.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "id": "dummy",
+  "version": "1",
+  "name": "Dummy Mod",
+  "custom": {
+    "loom:provided_javadoc": "javadoc.tiny"
+  }
+}

--- a/src/test/resources/projects/modJavadocOfficialProd/dummyDependency/javadoc.tiny
+++ b/src/test/resources/projects/modJavadocOfficialProd/dummyDependency/javadoc.tiny
@@ -1,0 +1,7 @@
+tiny	2	0	official
+c	bzq
+	c	An example of a mod added class javadoc
+	f	Lbzp;	A
+		c	An example of a mod added field javadoc
+	m	(I)Ljava/util/function/ToIntFunction;	a
+		c	An example of a mod added method javadoc

--- a/src/test/resources/projects/transitiveAccesswidenerOfficialProd/build.gradle
+++ b/src/test/resources/projects/transitiveAccesswidenerOfficialProd/build.gradle
@@ -1,0 +1,25 @@
+// This is used by a range of tests that append to this file before running the gradle tasks.
+// Can be used for tests that require minimal custom setup
+plugins {
+	id 'fabric-loom'
+	id 'maven-publish'
+}
+
+version = "1.0.0"
+group = "com.example"
+
+dependencies {
+	minecraft "com.mojang:minecraft:1.17.1"
+	mappings "net.fabricmc:yarn:1.17.1+build.59:v2"
+	modImplementation "net.fabricmc:fabric-loader:0.11.6"
+
+	modImplementation files("dummy.jar")
+}
+
+loom {
+	productionNamespace = "official"
+}
+
+base {
+	archivesName = "fabric-example-mod"
+}

--- a/src/test/resources/projects/transitiveAccesswidenerOfficialProd/dummyDependency/dummy.accesswidener
+++ b/src/test/resources/projects/transitiveAccesswidenerOfficialProd/dummyDependency/dummy.accesswidener
@@ -1,0 +1,3 @@
+accessWidener	v2	official
+
+transitive-accessible    method    bxv    a    (Ljava/lang/String;)Lwv;

--- a/src/test/resources/projects/transitiveAccesswidenerOfficialProd/dummyDependency/fabric.mod.json
+++ b/src/test/resources/projects/transitiveAccesswidenerOfficialProd/dummyDependency/fabric.mod.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "id": "dummy",
+  "version": "1",
+  "name": "Dummy Mod",
+  "accessWidener" : "dummy.accesswidener"
+}

--- a/src/test/resources/projects/transitiveAccesswidenerOfficialProd/src/main/java/ExampleMod.java
+++ b/src/test/resources/projects/transitiveAccesswidenerOfficialProd/src/main/java/ExampleMod.java
@@ -1,0 +1,13 @@
+import net.minecraft.world.biome.BiomeKeys;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.util.registry.RegistryKey;
+
+import net.fabricmc.api.ModInitializer;
+
+public class ExampleMod implements ModInitializer {
+	@Override
+	public void onInitialize() {
+		// BiomeKeys.register has been made public by a transitive AW
+		RegistryKey<Biome> biomeRegistryKey = BiomeKeys.register("dummy");
+	}
+}


### PR DESCRIPTION
Allows mismatching mapping tree source namespace and production namespace in projects with transitive access wideners and mod-provided javadocs.