### PR TITLE
Use OS path resolution for xvfb-run executable and make useXvfb task property public

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
@@ -84,7 +84,7 @@ public abstract class AbstractRunTask extends JavaExec {
 	// We use a string here, as it's technically an output, but we don't want to cache runs of this task by default.
 	protected abstract Property<String> getArgFilePath();
 	@Input
-	protected abstract Property<Boolean> getUseXvfb();
+	public abstract Property<Boolean> getUseXvfb();
 
 	@Nested
 	@Optional

--- a/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
@@ -212,7 +212,7 @@ public abstract class AbstractRunTask extends JavaExec {
 	}
 
 	private void execWithXvfb() {
-		String xvfbRunPath = "/usr/bin/xvfb-run";
+		String xvfbRunPath = "xvfb-run";
 
 		String javaExec = getJavaLauncher().get().getExecutablePath().getAsFile().getAbsolutePath();
 

--- a/src/main/java/net/fabricmc/loom/task/prod/ClientProductionRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/prod/ClientProductionRunTask.java
@@ -127,7 +127,7 @@ public abstract non-sealed class ClientProductionRunTask extends AbstractProduct
 				throw new UnsupportedOperationException("XVFB is only supported on Linux");
 			}
 
-			exec.commandLine("/usr/bin/xvfb-run");
+			exec.commandLine("xvfb-run");
 			exec.args("-a", getJavaLauncher().get().getExecutablePath());
 
 			return;


### PR DESCRIPTION
Changes:
- Use OS path resolution for xvfb-run executable by only specifying the executable name
- Make useXvfb task property public to allow users to use xvfb outside of the fixed convention (CI + Linux)

Closes #1501 