### PR TITLE
Only apply TAWs and mod javadoc from compile&runtime mods.

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/accesswidener/AccessWidenerJarProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/accesswidener/AccessWidenerJarProcessor.java
@@ -84,7 +84,7 @@ public class AccessWidenerJarProcessor implements MinecraftJarProcessor<AccessWi
 		 */
 
 		if (includeTransitive) {
-			for (FabricModJson fabricModJson : context.modDependencies()) {
+			for (FabricModJson fabricModJson : context.modDependenciesCompileRuntime()) {
 				accessWideners.addAll(ModAccessWidenerEntry.readAll(fabricModJson, true));
 			}
 		}

--- a/src/main/java/net/fabricmc/loom/configuration/processors/ModJavadocProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/ModJavadocProcessor.java
@@ -80,7 +80,7 @@ public abstract class ModJavadocProcessor implements MinecraftJarProcessor<ModJa
 	public ModJavadocProcessor.@Nullable Spec buildSpec(SpecContext context) {
 		List<ModJavadoc> javadocs = new ArrayList<>();
 
-		for (FabricModJson fabricModJson : context.allMods()) {
+		for (FabricModJson fabricModJson : context.modDependenciesCompileRuntime()) {
 			ModJavadoc javadoc = ModJavadoc.create(fabricModJson, context.productionNamespace());
 
 			if (javadoc != null) {

--- a/src/test/groovy/net/fabricmc/loom/test/unit/processor/AccessWidenerJarProcessorTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/processor/AccessWidenerJarProcessorTest.groovy
@@ -40,7 +40,7 @@ class AccessWidenerJarProcessorTest extends Specification {
 		def localAccessWidenerProperty = GradleTestUtil.mockRegularFileProperty(file)
 
 		def processor = new AccessWidenerJarProcessor("AccessWidener", true, localAccessWidenerProperty)
-		specContext.modDependencies() >> []
+		specContext.modDependenciesCompileRuntime() >> []
 
 		when:
 		def spec = processor.buildSpec(specContext)
@@ -61,7 +61,7 @@ class AccessWidenerJarProcessorTest extends Specification {
 		mod2.getClassTweakers() >> ["test2.accesswidener": ModEnvironment.UNIVERSAL]
 		mod2.getId() >> "modid2"
 
-		specContext.modDependencies() >> [mod1, mod2].shuffled()
+		specContext.modDependenciesCompileRuntime() >> [mod1, mod2].shuffled()
 
 		def processor = new AccessWidenerJarProcessor("AccessWidener", true, GradleTestUtil.mockRegularFileProperty(null))
 
@@ -75,7 +75,7 @@ class AccessWidenerJarProcessorTest extends Specification {
 	def "No AWs"() {
 		given:
 		def specContext = Mock(SpecContext)
-		specContext.modDependencies() >> []
+		specContext.modDependenciesCompileRuntime() >> []
 
 		def processor = new AccessWidenerJarProcessor("AccessWidener", true, GradleTestUtil.mockRegularFileProperty(null))
 


### PR DESCRIPTION
This is a slight behaviour change, but I believe this is the intended behaviour that now matches interface injection. No idea how this wasnt spotted before.

Fixes #1488