### PR TITLE
Print Maven artifact URL on publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -344,8 +344,7 @@ if (ENV.MAVEN_URL && ENV.EXPERIMENTAL) {
 						.append(plugin.id.replace(".", "/"))
 						.append("/")
 						.append(project.version)
-						.append("/")
-						.append("\n")
+						.append("/\n")
 			}
 			println("Published to:\n" + urls)
 		}

--- a/build.gradle
+++ b/build.gradle
@@ -333,6 +333,25 @@ publishing {
 	}
 }
 
+if (ENV.MAVEN_URL && ENV.EXPERIMENTAL) {
+	tasks.named("publish") {
+		doLast {
+			StringBuilder urls = new StringBuilder()
+			gradlePlugin.plugins.forEach { plugin ->
+				urls.append(ENV.MAVEN_URL)
+				if (!ENV.MAVEN_URL.endsWith("/")) urls.append("/")
+				urls
+						.append(plugin.id.replace(".", "/"))
+						.append("/")
+						.append(project.version)
+						.append("/")
+						.append("\n")
+			}
+			println("Published to:\n" + urls)
+		}
+	}
+}
+
 // A task to output a json file with a list of all the test to run
 tasks.register('writeActionsTestMatrix') {
 	doLast {


### PR DESCRIPTION
A small build script change that should make getting the correct maven artifact for a corresponding GitHub action build easier. Assuming a successful publish, the presence of `ENV.MAVEN_URL`, and `ENV.EXPERIMENTAL` being true; prints the URL to each artifact.

There is almost certainly a better way of doing this, but with my limited insight into GitHub actions, and how to take advantage of it within Gradle, this feels good enough.