### PR TITLE
Use OS path resolution for xvfb-run executable and make useXvfb task property public

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
@@ -63,10 +63,10 @@ import net.fabricmc.loom.configuration.ide.RunConfig;
 import net.fabricmc.loom.task.prod.TracyCapture;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.Platform;
+import net.fabricmc.loom.util.XVFBExistsValueSource;
 
 public abstract class AbstractRunTask extends JavaExec {
 	private static final Logger LOGGER = LoggerFactory.getLogger(AbstractRunTask.class);
-	private static final String XVFB_PATH = "xvfb-run";
 
 	@Inject
 	protected abstract ExecOperations getExecOperations();
@@ -149,7 +149,7 @@ public abstract class AbstractRunTask extends JavaExec {
 				getProject().getProviders().environmentVariable("CI")
 						.map(value -> Platform.CURRENT.getOperatingSystem().isLinux())
 						.zip(config, (enabled, runConfig) -> enabled && runConfig.environment.equals("client"))
-						.map(enabled -> enabled && Files.exists(Path.of(XVFB_PATH)))
+						.flatMap(enabled -> enabled ? XVFBExistsValueSource.exists(getProject()) : getProject().getProviders().provider(() -> false))
 						.orElse(false)
 		);
 
@@ -219,7 +219,7 @@ public abstract class AbstractRunTask extends JavaExec {
 
 		// Build the complete command line: xvfb-run --auto-servernum java [jvm-args] mainclass [program-args]
 		List<String> commandLine = new ArrayList<>();
-		commandLine.add(XVFB_PATH);
+		commandLine.add(XVFBExistsValueSource.XVFB);
 		commandLine.add("--auto-servernum");
 		commandLine.add(javaExec);
 		commandLine.addAll(getJvmArguments().get());

--- a/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
@@ -66,7 +66,7 @@ import net.fabricmc.loom.util.Platform;
 
 public abstract class AbstractRunTask extends JavaExec {
 	private static final Logger LOGGER = LoggerFactory.getLogger(AbstractRunTask.class);
-	private static final String XVFB_PATH = "/usr/bin/xvfb-run";
+	private static final String XVFB_PATH = "xvfb-run";
 
 	@Inject
 	protected abstract ExecOperations getExecOperations();

--- a/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
@@ -85,7 +85,7 @@ public abstract class AbstractRunTask extends JavaExec {
 	// We use a string here, as it's technically an output, but we don't want to cache runs of this task by default.
 	protected abstract Property<String> getArgFilePath();
 	@Input
-	protected abstract Property<Boolean> getUseXvfb();
+	public abstract Property<Boolean> getUseXvfb();
 
 	@Nested
 	@Optional

--- a/src/main/java/net/fabricmc/loom/task/prod/ClientProductionRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/prod/ClientProductionRunTask.java
@@ -42,6 +42,7 @@ import org.jetbrains.annotations.ApiStatus;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.Platform;
+import net.fabricmc.loom.util.XVFBExistsValueSource;
 
 /**
  * A task that runs the Minecraft client in a similar way to a production launcher. You must manually register a task of this type to use it.
@@ -127,7 +128,7 @@ public abstract non-sealed class ClientProductionRunTask extends AbstractProduct
 				throw new UnsupportedOperationException("XVFB is only supported on Linux");
 			}
 
-			exec.commandLine("xvfb-run");
+			exec.commandLine(XVFBExistsValueSource.XVFB);
 			exec.args("-a", getJavaLauncher().get().getExecutablePath());
 
 			return;

--- a/src/main/java/net/fabricmc/loom/task/prod/ClientProductionRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/prod/ClientProductionRunTask.java
@@ -127,7 +127,7 @@ public abstract non-sealed class ClientProductionRunTask extends AbstractProduct
 				throw new UnsupportedOperationException("XVFB is only supported on Linux");
 			}
 
-			exec.commandLine("/usr/bin/xvfb-run");
+			exec.commandLine("xvfb-run");
 			exec.args("-a", getJavaLauncher().get().getExecutablePath());
 
 			return;

--- a/src/main/java/net/fabricmc/loom/util/XVFBExistsValueSource.java
+++ b/src/main/java/net/fabricmc/loom/util/XVFBExistsValueSource.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util;
+
+import javax.inject.Inject;
+
+import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ValueSource;
+import org.gradle.api.provider.ValueSourceParameters;
+import org.gradle.process.ExecOperations;
+import org.gradle.process.ExecResult;
+
+public abstract class XVFBExistsValueSource implements ValueSource<Boolean, ValueSourceParameters.None> {
+	public static final String XVFB = "xvfb-run";
+
+	@Inject
+	protected abstract ExecOperations getExecOperations();
+
+	@Override
+	public Boolean obtain() {
+		ExecResult result = getExecOperations().exec(spec -> {
+			spec.commandLine(XVFB);
+			spec.args("--help");
+		});
+
+		return result.getExitValue() == 0;
+	}
+
+	public static Provider<Boolean> exists(Project project) {
+		return project.getProviders().of(XVFBExistsValueSource.class, i -> { });
+	}
+}


### PR DESCRIPTION
Changes:
- Use OS path resolution for xvfb-run executable by only specifying the executable name
- Make useXvfb task property public to allow users to use xvfb outside of the fixed convention (CI + Linux)

Closes #1501
Replaces #1502