### PR TITLE
fix Unpick constants for layered mappings with Unpick metadata V1

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsFactory.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsFactory.java
@@ -165,6 +165,6 @@ public record LayeredMappingsFactory(LayeredMappingSpec spec) {
 		}
 
 		ZipUtils.add(mappingsFile, UnpickMetadata.UNPICK_DEFINITIONS_PATH, unpickData.definitions());
-		ZipUtils.add(mappingsFile, UnpickMetadata.UNPICK_METADATA_PATH, unpickData.rawMetadata());
+		ZipUtils.add(mappingsFile, UnpickMetadata.UNPICK_METADATA_PATH, LoomGradlePlugin.GSON.toJson(unpickData.metadata()));
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsFactory.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsFactory.java
@@ -164,7 +164,9 @@ public record LayeredMappingsFactory(LayeredMappingSpec spec) {
 			return;
 		}
 
+		byte[] data = UnpickMetadata.toJson(unpickData.metadata()).getBytes(StandardCharsets.UTF_8);
+
 		ZipUtils.add(mappingsFile, UnpickMetadata.UNPICK_DEFINITIONS_PATH, unpickData.definitions());
-		ZipUtils.add(mappingsFile, UnpickMetadata.UNPICK_METADATA_PATH, LoomGradlePlugin.GSON.toJson(unpickData.metadata()));
+		ZipUtils.add(mappingsFile, UnpickMetadata.UNPICK_METADATA_PATH, data);
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsProcessor.java
@@ -41,6 +41,7 @@ import net.fabricmc.loom.configuration.providers.mappings.extras.annotations.Ann
 import net.fabricmc.loom.configuration.providers.mappings.extras.annotations.AnnotationsLayer;
 import net.fabricmc.loom.configuration.providers.mappings.extras.signatures.SignatureFixesLayer;
 import net.fabricmc.loom.configuration.providers.mappings.extras.unpick.UnpickLayer;
+import net.fabricmc.loom.configuration.providers.mappings.unpick.UnpickMetadata;
 import net.fabricmc.mappingio.adapter.MappingSourceNsSwitch;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
@@ -150,6 +151,19 @@ public class LayeredMappingsProcessor {
 			if (layer instanceof UnpickLayer unpickLayer) {
 				UnpickLayer.UnpickData data = unpickLayer.getUnpickData();
 				if (data == null) continue;
+
+				if (!data.metadata().hasConstantsLocation()) {
+					// if the constants location is not provided explicitly, Loom
+					// cannot trick its way into finding them, since the mappings
+					// dependency points to the layered mappings instead of the
+					// individual layer that provided the unpick data
+					String fallbackConstants = unpickLayer.getFallbackConstants();
+					UnpickMetadata metadata = fallbackConstants == null
+								? data.metadata().withoutConstants()
+								: data.metadata().withConstants(fallbackConstants);
+
+					data = new UnpickLayer.UnpickData(metadata, data.definitions());
+				}
 
 				unpickDataList.add(data);
 			}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/unpick/UnpickLayer.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/unpick/UnpickLayer.java
@@ -38,6 +38,9 @@ public interface UnpickLayer {
 	@Nullable
 	UnpickData getUnpickData() throws IOException;
 
+	@Nullable
+	String getFallbackConstants();
+
 	record UnpickData(UnpickMetadata metadata, byte[] definitions) {
 		public static UnpickData read(Path metadataPath, Path definitionPath) throws IOException {
 			final byte[] definitions = Files.readAllBytes(definitionPath);

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/unpick/UnpickLayer.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/extras/unpick/UnpickLayer.java
@@ -38,11 +38,10 @@ public interface UnpickLayer {
 	@Nullable
 	UnpickData getUnpickData() throws IOException;
 
-	record UnpickData(UnpickMetadata metadata, byte[] rawMetadata, byte[] definitions) {
+	record UnpickData(UnpickMetadata metadata, byte[] definitions) {
 		public static UnpickData read(Path metadataPath, Path definitionPath) throws IOException {
 			final byte[] definitions = Files.readAllBytes(definitionPath);
-			final byte[] metadata = Files.readAllBytes(metadataPath);
-			return new UnpickData(UnpickMetadata.parse(metadataPath), metadata, definitions);
+			return new UnpickData(UnpickMetadata.parse(metadataPath), definitions);
 		}
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsLayer.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsLayer.java
@@ -55,7 +55,8 @@ public record FileMappingsLayer(
 		boolean enigma, // Enigma cannot be automatically detected since it's stored in a directory.
 		boolean unpick,
 		boolean annotations,
-		String mergeNamespace
+		String mergeNamespace,
+		String fallbackUnpickConstants
 ) implements MappingLayer, UnpickLayer, AnnotationsLayer {
 	@Override
 	public void visit(MappingVisitor mappingVisitor) throws IOException {
@@ -116,7 +117,15 @@ public record FileMappingsLayer(
 				return null;
 			}
 
-			return UnpickData.read(unpickMetadata, unpickDefinitions);
+			UnpickData unpickData = UnpickData.read(unpickMetadata, unpickDefinitions);
+			UnpickMetadata metadata = unpickData.metadata();
+
+			if (metadata instanceof UnpickMetadata.V1 && fallbackUnpickConstants != null) {
+				metadata = metadata.withConstants(fallbackUnpickConstants);
+				unpickData = new UnpickData(metadata, unpickData.definitions());
+			}
+
+			return unpickData;
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsLayer.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsLayer.java
@@ -117,16 +117,17 @@ public record FileMappingsLayer(
 				return null;
 			}
 
-			UnpickData unpickData = UnpickData.read(unpickMetadata, unpickDefinitions);
-			UnpickMetadata metadata = unpickData.metadata();
-
-			if (metadata instanceof UnpickMetadata.V1 && fallbackUnpickConstants != null) {
-				metadata = metadata.withConstants(fallbackUnpickConstants);
-				unpickData = new UnpickData(metadata, unpickData.definitions());
-			}
-
-			return unpickData;
+			return UnpickData.read(unpickMetadata, unpickDefinitions);
 		}
+	}
+
+	@Override
+	public @Nullable String getFallbackConstants() {
+		if (!unpick) {
+			return null;
+		}
+
+		return fallbackUnpickConstants;
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsSpec.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsSpec.java
@@ -35,12 +35,14 @@ public record FileMappingsSpec(
 		FileSpec fileSpec, String mappingPath,
 		Optional<String> fallbackSourceNamespace, String fallbackTargetNamespace,
 		boolean enigma, boolean unpick, boolean annotations,
-		Optional<String> mergeNamespace
+		Optional<String> mergeNamespace,
+		Optional<String> fallbackUnpickConstants
 ) implements MappingsSpec<FileMappingsLayer> {
 	@Override
 	public FileMappingsLayer createLayer(MappingContext context) {
 		String finalFallbackSourceNamespace = fallbackSourceNamespace.orElse(context.productionNamespace());
 		String finalMergeNamespace = mergeNamespace.orElse(context.isUsingIntermediateMappings() ? MappingsNamespace.INTERMEDIARY.toString() : MappingsNamespace.OFFICIAL.toString());
-		return new FileMappingsLayer(fileSpec.get(context), mappingPath, finalFallbackSourceNamespace, fallbackTargetNamespace, enigma, unpick, annotations, finalMergeNamespace);
+		String finalFallbackUnpickConstants = unpick ? fallbackUnpickConstants.orElse(null) : null;
+		return new FileMappingsLayer(fileSpec.get(context), mappingPath, finalFallbackSourceNamespace, fallbackTargetNamespace, enigma, unpick, annotations, finalMergeNamespace, finalFallbackUnpickConstants);
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsSpecBuilderImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsSpecBuilderImpl.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.api.mappings.layered.spec.FileMappingsSpecBuilder;
 import net.fabricmc.loom.api.mappings.layered.spec.FileSpec;
+import net.fabricmc.loom.configuration.providers.mappings.utils.MavenFileSpec;
 
 public class FileMappingsSpecBuilderImpl implements FileMappingsSpecBuilder {
 	/**
@@ -45,6 +46,7 @@ public class FileMappingsSpecBuilderImpl implements FileMappingsSpecBuilder {
 	private boolean unpick = false;
 	private boolean annotations = false;
 	private Optional<String> mergeNamespace = Optional.empty();
+	private Optional<String> fallbackUnpickConstants = Optional.empty();
 
 	private FileMappingsSpecBuilderImpl(FileSpec fileSpec) {
 		this.fileSpec = fileSpec;
@@ -82,6 +84,18 @@ public class FileMappingsSpecBuilderImpl implements FileMappingsSpecBuilder {
 	@Override
 	public FileMappingsSpecBuilderImpl containsUnpick() {
 		unpick = true;
+
+		if (fileSpec instanceof MavenFileSpec mavenFileSpec) {
+			String dependencyNotation = mavenFileSpec.dependencyNotation();
+			String[] notationParts = dependencyNotation.split("[:]");
+
+			if (notationParts.length == 4) {
+				dependencyNotation = dependencyNotation.substring(0, dependencyNotation.lastIndexOf(':'));
+			}
+
+			fallbackUnpickConstants = Optional.of(dependencyNotation + ":constants");
+		}
+
 		return this;
 	}
 
@@ -104,6 +118,6 @@ public class FileMappingsSpecBuilderImpl implements FileMappingsSpecBuilder {
 	}
 
 	public FileMappingsSpec build() {
-		return new FileMappingsSpec(fileSpec, mappingPath, fallbackSourceNamespace, fallbackTargetNamespace, enigma, unpick, annotations, mergeNamespace);
+		return new FileMappingsSpec(fileSpec, mappingPath, fallbackSourceNamespace, fallbackTargetNamespace, enigma, unpick, annotations, mergeNamespace, fallbackUnpickConstants);
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsSpecBuilderImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/file/FileMappingsSpecBuilderImpl.java
@@ -87,7 +87,7 @@ public class FileMappingsSpecBuilderImpl implements FileMappingsSpecBuilder {
 
 		if (fileSpec instanceof MavenFileSpec mavenFileSpec) {
 			String dependencyNotation = mavenFileSpec.dependencyNotation();
-			String[] notationParts = dependencyNotation.split("[:]");
+			String[] notationParts = dependencyNotation.split(":");
 
 			if (notationParts.length == 4) {
 				dependencyNotation = dependencyNotation.substring(0, dependencyNotation.lastIndexOf(':'));

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/unpick/UnpickMetadata.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/unpick/UnpickMetadata.java
@@ -39,9 +39,21 @@ public sealed interface UnpickMetadata permits UnpickMetadata.V1, UnpickMetadata
 	String UNPICK_METADATA_PATH = "extras/unpick.json";
 	String UNPICK_DEFINITIONS_PATH = "extras/definitions.unpick";
 
+	/**
+	 * @return whether constants are required by the Unpick definitions
+	 */
 	boolean hasConstants();
 
+	/**
+	 * @return whether the maven location of the constants is specified by this metadata
+	 */
+	boolean hasConstantsLocation();
+
 	UnpickMetadata withConstants(String constants);
+
+	default UnpickMetadata withoutConstants() {
+		return withConstants(null);
+	}
 
 	/**
 	 * @param unpickGroup Deprecated, always uses the version of unpick loom depends on.
@@ -54,8 +66,14 @@ public sealed interface UnpickMetadata permits UnpickMetadata.V1, UnpickMetadata
 		}
 
 		@Override
+		public boolean hasConstantsLocation() {
+			return false;
+		}
+
+		@Override
 		public UnpickMetadata withConstants(String constants) {
-			// all v1 data is deprecated and ignored by Loom, just update to v2
+			// all v1 data is deprecated and ignored by Loom
+			// and only v2 format allows setting the constants location
 			return new UnpickMetadata.V2(MappingsNamespace.NAMED.toString(), constants);
 		}
 	}
@@ -70,6 +88,11 @@ public sealed interface UnpickMetadata permits UnpickMetadata.V1, UnpickMetadata
 		@Override
 		public boolean hasConstants() {
 			return constants != null;
+		}
+
+		@Override
+		public boolean hasConstantsLocation() {
+			return true;
 		}
 
 		@Override

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/unpick/UnpickMetadata.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/unpick/UnpickMetadata.java
@@ -33,12 +33,15 @@ import com.google.gson.JsonObject;
 import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradlePlugin;
+import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 
 public sealed interface UnpickMetadata permits UnpickMetadata.V1, UnpickMetadata.V2 {
 	String UNPICK_METADATA_PATH = "extras/unpick.json";
 	String UNPICK_DEFINITIONS_PATH = "extras/definitions.unpick";
 
 	boolean hasConstants();
+
+	UnpickMetadata withConstants(String constants);
 
 	/**
 	 * @param unpickGroup Deprecated, always uses the version of unpick loom depends on.
@@ -48,6 +51,12 @@ public sealed interface UnpickMetadata permits UnpickMetadata.V1, UnpickMetadata
 		@Override
 		public boolean hasConstants() {
 			return true;
+		}
+
+		@Override
+		public UnpickMetadata withConstants(String constants) {
+			// all v1 data is deprecated and ignored by Loom, just update to v2
+			return new UnpickMetadata.V2(MappingsNamespace.NAMED.toString(), constants);
 		}
 	}
 
@@ -61,6 +70,11 @@ public sealed interface UnpickMetadata permits UnpickMetadata.V1, UnpickMetadata
 		@Override
 		public boolean hasConstants() {
 			return constants != null;
+		}
+
+		@Override
+		public UnpickMetadata withConstants(String constants) {
+			return new UnpickMetadata.V2(namespace, constants);
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/unpick/UnpickMetadata.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/unpick/UnpickMetadata.java
@@ -78,6 +78,18 @@ public sealed interface UnpickMetadata permits UnpickMetadata.V1, UnpickMetadata
 		}
 	}
 
+	static String toJson(UnpickMetadata metadata) {
+		JsonObject json = LoomGradlePlugin.GSON.toJsonTree(metadata).getAsJsonObject();
+
+		int version = switch (metadata) {
+		case UnpickMetadata.V1 v1 -> 1;
+		case UnpickMetadata.V2 v2 -> 2;
+		};
+		json.addProperty("version", version);
+
+		return json.toString();
+	}
+
 	static UnpickMetadata parse(Path path) throws IOException {
 		JsonObject jsonObject = LoomGradlePlugin.GSON.fromJson(Files.readString(path, StandardCharsets.UTF_8), JsonObject.class);
 

--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingSpecBuilderTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingSpecBuilderTest.groovy
@@ -115,7 +115,7 @@ class LayeredMappingSpecBuilderTest extends Specification {
 		}
 		def layers = spec.layers()
 		then:
-		spec.version == "layered+hash.38489917"
+		spec.version == "layered+hash.1193216257"
 		layers.size() == 2
 		layers[0].class == IntermediaryMappingsSpec
 		layers[1].class == FileMappingsSpec

--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingsSpecification.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingsSpecification.groovy
@@ -90,7 +90,7 @@ abstract class LayeredMappingsSpecification extends Specification implements Lay
 
 	MemoryMappingTree getSingleMapping(MappingsSpec<? extends MappingLayer> spec) {
 		MemoryMappingTree mappingTree = new MemoryMappingTree()
-		spec.createLayer(new TestMappingContext([spec])).visit(mappingTree)
+		spec.createLayer(createMappingContext(spec)).visit(mappingTree)
 		return mappingTree
 	}
 
@@ -108,7 +108,12 @@ abstract class LayeredMappingsSpecification extends Specification implements Lay
 
 	UnpickLayer.UnpickData getUnpickData(MappingsSpec<? extends MappingLayer>... specs) {
 		LayeredMappingsProcessor processor = createLayeredMappingsProcessor(specs)
-		return processor.getUnpickData(processor.resolveLayers(new TestMappingContext(specs.toList())))
+		MappingContext context = createMappingContext(specs)
+		return processor.getUnpickData(processor.resolveLayers(context))
+	}
+
+	MappingContext createMappingContext(MappingsSpec<? extends MappingLayer>... specs) {
+		return new TestMappingContext(specs.toList())
 	}
 
 	private static LayeredMappingsProcessor createLayeredMappingsProcessor(MappingsSpec<? extends MappingLayer>... specs) {

--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingsTestConstants.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingsTestConstants.groovy
@@ -27,8 +27,15 @@ package net.fabricmc.loom.test.unit.layeredmappings
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftVersionMeta
 
 interface LayeredMappingsTestConstants {
+	public static final String INTERMEDIARY_1_21_11_URL = "https://maven.fabricmc.net/net/fabricmc/intermediary/1.21.11/intermediary-1.21.11-v2.jar"
 	public static final String INTERMEDIARY_1_17_URL = "https://maven.fabricmc.net/net/fabricmc/intermediary/1.17/intermediary-1.17-v2.jar"
 	public static final String INTERMEDIARY_1_16_5_URL = "https://maven.fabricmc.net/net/fabricmc/intermediary/1.16.5/intermediary-1.16.5-v2.jar"
+
+	public static final Map<String, MinecraftVersionMeta.Download> DOWNLOADS_1_21_11 = [
+		client_mappings: new MinecraftVersionMeta.Download(null, "031a68bebf55d824f66d6573d8c752f0e1bf232a", 11779287, "https://piston-data.mojang.com/v1/objects/031a68bebf55d824f66d6573d8c752f0e1bf232a/client.txt"),
+		server_mappings: new MinecraftVersionMeta.Download(null, "64bb6d763bed0a9f1d632ec347938594144943ed", 56327581, "https://launcher.mojang.com/v1/objects/64bb6d763bed0a9f1d632ec347938594144943ed/server.txt")
+	]
+	public static final MinecraftVersionMeta VERSION_META_1_21_11 = new MinecraftVersionMeta(null, null, null, 0, DOWNLOADS_1_21_11, null, null, null, null, 0, "2025-12-09T12:23:30+00:00", null, null, null)
 
 	public static final Map<String, MinecraftVersionMeta.Download> DOWNLOADS_1_17 = [
 		client_mappings: new MinecraftVersionMeta.Download(null, "227d16f520848747a59bef6f490ae19dc290a804", 6431705, "https://launcher.mojang.com/v1/objects/227d16f520848747a59bef6f490ae19dc290a804/client.txt"),
@@ -44,5 +51,8 @@ interface LayeredMappingsTestConstants {
 
 	public static final String PARCHMENT_NOTATION = "org.parchmentmc.data:parchment-1.16.5:20210608-SNAPSHOT@zip"
 	public static final String PARCHMENT_URL = "https://maven.parchmentmc.net/org/parchmentmc/data/parchment-1.16.5/20210608-SNAPSHOT/parchment-1.16.5-20210608-SNAPSHOT.zip"
+	public static final String YARN_1_21_11_URL = "https://maven.fabricmc.net/net/fabricmc/yarn/1.21.11%2Bbuild.4/yarn-1.21.11%2Bbuild.4-v2.jar"
 	public static final String YARN_1_17_URL = "https://maven.fabricmc.net/net/fabricmc/yarn/1.17%2Bbuild.13/yarn-1.17%2Bbuild.13-v2.jar"
+	public static final String YARN_1_21_11_NOTATION = "net.fabricmc:yarn:1.21.11+build.4"
+	public static final String YARN_1_17_NOTATION = "net.fabricmc:yarn:1.17+build.13"
 }

--- a/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingsUnpickTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/layeredmappings/LayeredMappingsUnpickTest.groovy
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2022 FabricMC
+ * Copyright (c) 2026 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,20 +26,47 @@ package net.fabricmc.loom.test.unit.layeredmappings
 
 import net.fabricmc.loom.api.mappings.layered.spec.FileSpec
 import net.fabricmc.loom.configuration.providers.mappings.file.FileMappingsSpecBuilderImpl
+import net.fabricmc.loom.configuration.providers.mappings.intermediary.IntermediaryMappingsSpec
 import net.fabricmc.loom.configuration.providers.mappings.unpick.UnpickMetadata
 
-class UnpickLayerTest extends LayeredMappingsSpecification {
-	def "read unpick data from yarn"() {
+class LayeredMappingsUnpickTest extends LayeredMappingsSpecification {
+	def "compile unpick data from yarn layer with unpick metadata v1"() {
+		setup:
+		intermediaryUrl = INTERMEDIARY_1_17_URL
+		mockMinecraftProvider.getVersionInfo() >> VERSION_META_1_17
 		when:
-		def yarnSpec = FileMappingsSpecBuilderImpl.builder(FileSpec.create(YARN_1_17_URL)).containsUnpick().build()
-		def yarnLayer = yarnSpec.createLayer(createMappingContext(yarnSpec))
-		def unpickData = yarnLayer.getUnpickData()
+		withMavenFile(YARN_1_17_NOTATION, downloadFile(YARN_1_17_URL, "yarn-1.17.jar"))
+		def builder = FileMappingsSpecBuilderImpl.builder(FileSpec.create(YARN_1_17_NOTATION)).containsUnpick()
+		def unpickData = getUnpickData(
+				new IntermediaryMappingsSpec(),
+				builder.build()
+				)
 		def metadata = unpickData.metadata()
 		then:
-		metadata instanceof UnpickMetadata.V1
-		metadata.unpickGroup() == "net.fabricmc.unpick"
-		metadata.unpickVersion() == "2.2.0"
+		metadata instanceof UnpickMetadata.V2
+		metadata.namespace() == "named"
+		metadata.constants() == "${YARN_1_17_NOTATION}:constants"
 
 		unpickData.definitions().length == 56119
+	}
+
+	def "compile unpick data from yarn layer with unpick metadata v2 without constants"() {
+		setup:
+		intermediaryUrl = INTERMEDIARY_1_21_11_URL
+		mockMinecraftProvider.getVersionInfo() >> VERSION_META_1_21_11
+		when:
+		withMavenFile(YARN_1_21_11_NOTATION, downloadFile(YARN_1_21_11_URL, "yarn-1.21.11.jar"))
+		def builder = FileMappingsSpecBuilderImpl.builder(FileSpec.create(YARN_1_21_11_NOTATION)).containsUnpick()
+		def unpickData = getUnpickData(
+				new IntermediaryMappingsSpec(),
+				builder.build()
+				)
+		def metadata = unpickData.metadata()
+		then:
+		metadata instanceof UnpickMetadata.V2
+		metadata.namespace() == "intermediary"
+		metadata.constants() == null
+
+		unpickData.definitions().length == 66489
 	}
 }


### PR DESCRIPTION
For regular mappings dependencies with Unpick metadata V1, Loom uses the maven dependency notation to construct the dependency for the Unpick constants. But this breaks when using layered mappings, since the mappings dependency points to the layered mappings file, not the original mappings dependency.

This PR addresses this by constructing a fallback constants dependency notation based off the maven dependency, and passing this to the `FileMappingsLayer`, where the Unpick metadata is patched before it is passed to the layered mappings processor.