### PR TITLE
Add plugin marker for repositories plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -241,6 +241,10 @@ gradlePlugin {
 			id = 'net.fabricmc.fabric-loom-companion'
 			implementationClass = 'net.fabricmc.loom.LoomCompanionGradlePlugin'
 		}
+		fabricLoomRepositories {
+			id = 'net.fabricmc.fabric-loom-repositories'
+			implementationClass = 'net.fabricmc.loom.LoomRepositoryPlugin'
+		}
 	}
 }
 

--- a/src/test/resources/projects/dependencyResolutionManagement/settings.gradle
+++ b/src/test/resources/projects/dependencyResolutionManagement/settings.gradle
@@ -1,11 +1,11 @@
 pluginManagement {
 	plugins {
-		id 'fabric-loom'
+		id 'net.fabricmc.fabric-loom-repositories'
 	}
 }
 
 plugins {
-	id 'fabric-loom'
+	id 'net.fabricmc.fabric-loom-repositories'
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
The legacy `fabric-loom` plugin applies this when detecting it's applied to settings. It's cleaner to allow the user to explicitly apply it, rather than copy this functionality into the new plugins.