### PR TITLE
Fix comment appender

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
@@ -215,7 +215,8 @@ public abstract class InterfaceInjectionProcessor implements MinecraftJarProcess
 		};
 	}
 
-	private static String appendComment(String comment, List<InjectedInterface> injectedInterfaces) {
+	@Nullable
+	private static String appendComment(@Nullable String comment, List<InjectedInterface> injectedInterfaces) {
 		if (injectedInterfaces.isEmpty()) {
 			return comment;
 		}
@@ -234,7 +235,7 @@ public abstract class InterfaceInjectionProcessor implements MinecraftJarProcess
 			}
 		}
 
-		return comment;
+		return commentBuilder.toString();
 	}
 
 	private record InjectedInterface(String modId, String className, String ifaceName, @Nullable String generics) {

--- a/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
@@ -41,6 +41,7 @@ import javax.inject.Inject;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.Nullable;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -216,6 +217,7 @@ public abstract class InterfaceInjectionProcessor implements MinecraftJarProcess
 	}
 
 	@Nullable
+	@Contract("!null, _ -> !null")
 	private static String appendComment(@Nullable String comment, List<InjectedInterface> injectedInterfaces) {
 		if (injectedInterfaces.isEmpty()) {
 			return comment;


### PR DESCRIPTION
While going trough IntelliJ warnings after I noticed some parts of the code were missing `@Nullable` annotations I noticed that this method always returned the passed in parameter instead of the built one.

This also marks the comment parameter as nullable and adds a contract so IntelliJ doesn't keep complaining about nullability when it's not a concern