### PR TITLE
Remap local variables in mod remapping

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ asm = "9.9"
 gson = "2.10.1"
 
 stitch = "0.6.2"
-tiny-remapper = "0.12.3"
+tiny-remapper = "0.13.0"
 clazz-tweaker = "0.1.1"
 mapping-io = "0.8.0"
 lorenz-tiny = "4.0.2"

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModProcessor.java
@@ -149,7 +149,7 @@ public class ModProcessor {
 
 		TinyRemapper.Builder builder = TinyRemapper.newRemapper(TinyRemapperLoggerAdapter.INSTANCE)
 				.withKnownIndyBsm(knownIndyBsms)
-				.withMappings(TinyRemapperHelper.create(mappingConfiguration.getMappingsService(project, serviceFactory).getMappingTree(), productionNamespace.toString(), toM, false))
+				.withMappings(TinyRemapperHelper.create(mappingConfiguration.getMappingsService(project, serviceFactory).getMappingTree(), productionNamespace.toString(), toM, true))
 				.renameInvalidLocals(false)
 				.extraAnalyzeVisitor(AccessWidenerAnalyzeVisitorProvider.createFromMods(productionNamespace.toString(), remapList));
 

--- a/src/main/java/net/fabricmc/loom/task/service/MappingsService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/MappingsService.java
@@ -97,7 +97,7 @@ public final class MappingsService extends Service<MappingsService.Options> impl
 	 */
 	public static Provider<Options> createOptionsWithProjectMappings(Project project, Provider<String> from, Provider<String> to) {
 		final MappingConfiguration mappingConfiguration = LoomGradleExtension.get(project).getMappingConfiguration();
-		return createOptions(project, mappingConfiguration.tinyMappings, from, to, false);
+		return createOptions(project, mappingConfiguration.tinyMappings, from, to, true);
 	}
 
 	public static Provider<MappingsService.Options> createForRemapTask(AbstractRemapJarTask remapJarTask) {
@@ -125,7 +125,7 @@ public final class MappingsService extends Service<MappingsService.Options> impl
 							project,
 							mappingsFile.toPath(),
 							remapJarTask.getSourceNamespace(), remapJarTask.getTargetNamespace(),
-							false)
+							true)
 					.get();
 		});
 	}


### PR DESCRIPTION
Used in remapping method arg names in `@ModifyVariable`, mostly from fabric-api. 