### PR TITLE
Run tests on arm64 platforms.

### DIFF
--- a/.github/workflows/publish-exp.yml
+++ b/.github/workflows/publish-exp.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: 'temurin'
+          distribution: 'microsoft'
       - uses: actions/checkout@v4
       - uses: gradle/actions/wrapper-validation@v4
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: 'temurin'
+          distribution: 'microsoft'
       - uses: actions/checkout@v4
       - uses: gradle/actions/wrapper-validation@v4
 

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -109,8 +109,9 @@ jobs:
       fail-fast: false
       matrix:
         test: ${{ fromJson(needs.prepare_test_matrix.outputs.matrix) }}
+        os: [ windows-2025, windows-11-arm ]
 
-    runs-on: windows-2025
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
@@ -142,8 +143,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 21, 25 ]
-        os: [ windows-2025, ubuntu-24.04, macos-26 ]
+        java: [ 25 ]
+        os: [ windows-2025, ubuntu-24.04, macos-26, windows-11-arm, ubuntu-22.04-arm, macos-26-intel ]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -101,8 +101,6 @@ jobs:
           path: "*.hprof"
 
   run_tests_windows:
-    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.extended_tests == 'true' }}
-
     needs: prepare_test_matrix
 
     strategy:

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: 'temurin'
+          distribution: 'microsoft'
       - uses: actions/checkout@v4
       - uses: gradle/actions/wrapper-validation@v4
       - run: ./gradlew build check -x test --stacktrace --warning-mode fail
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: 'temurin'
+          distribution: 'microsoft'
       - uses: gradle/actions/wrapper-validation@v4
       - run: ./gradlew build check -x test --stacktrace --warning-mode fail
 
@@ -56,7 +56,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: 'temurin'
+          distribution: 'microsoft'
       - uses: actions/checkout@v4
       - run: ./gradlew writeActionsTestMatrix --stacktrace --warning-mode fail
       -
@@ -82,7 +82,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: 'temurin'
+          distribution: 'microsoft'
       - run: ./gradlew printActionsTestName --name="${{ matrix.test }}" test --tests ${{ matrix.test }} --stacktrace --warning-mode fail
         env:
           TEST_WARNING_MODE: fail
@@ -119,7 +119,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: 'temurin'
+          distribution: 'microsoft'
       - run: ./gradlew printActionsTestName --name="${{ matrix.test }}" test --tests ${{ matrix.test }} --stacktrace --warning-mode fail
         env:
           TEST_WARNING_MODE: fail
@@ -152,7 +152,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'temurin'
+          distribution: 'microsoft'
 
       - run: ./gradlew test --tests *ReproducibleBuildTest --stacktrace --warning-mode fail
 


### PR DESCRIPTION
Extended tests run on both x64 and arm64 windows, reproducable build tests now only run on Java 25 but across all supported platforms.