### PR TITLE
Add `loom.uncompressNestedJars`

### DIFF
--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -293,6 +293,19 @@ public interface LoomGradleExtensionAPI {
 
 	Property<Boolean> getSplitModDependencies();
 
+	/**
+	 * Whether to transform zip entries within nested jars to be using STORED compression.
+	 *
+	 * <p>This will usually reduce the resulting jar size by avoiding double-compression.
+	 *
+	 * <p>However, this will very likely increase the decompressed size during runtime as a side effect.
+	 *
+	 * <p>Default: false
+	 *
+	 * @return the property controlling this toggle
+	 */
+	Property<Boolean> getUncompressNestedJars();
+
 	<T extends RemapperParameters> void addRemapperExtension(Class<? extends RemapperExtension<T>> remapperExtensionClass, Class<T> parametersClass, Action<T> parameterAction);
 
 	/**

--- a/src/main/java/net/fabricmc/loom/build/nesting/NestableJarGenerationTask.java
+++ b/src/main/java/net/fabricmc/loom/build/nesting/NestableJarGenerationTask.java
@@ -48,12 +48,14 @@ import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.bundling.ZipEntryCompression;
 import org.gradle.work.DisableCachingByDefault;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -81,6 +83,9 @@ public abstract class NestableJarGenerationTask extends AbstractLoomTask {
 
 	@Input
 	protected abstract MapProperty<String, Metadata> getJarIds();
+
+	@Input
+	public abstract Property<Boolean> getUncompressNestedJars();
 
 	@TaskAction
 	void makeNestableJars() {
@@ -219,6 +224,10 @@ public abstract class NestableJarGenerationTask extends AbstractLoomTask {
 	private void makeNestableJar(final File input, final File output, final String modJsonFile) {
 		try {
 			Files.copy(input.toPath(), output.toPath());
+
+			if (getUncompressNestedJars().get()) {
+				ZipReprocessorUtil.reprocessZip(output.toPath(), false, true, ZipEntryCompression.STORED);
+			}
 		} catch (IOException e) {
 			throw new UncheckedIOException("Failed to copy mod file %s".formatted(input), e);
 		}

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -102,6 +102,7 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	private final Property<Boolean> remapJsrAnnotationsToJetBrains;
 	private final Property<Boolean> runtimeOnlyLog4j;
 	private final Property<Boolean> splitModDependencies;
+	private final Property<Boolean> uncompressNestedJars;
 	private final Property<MinecraftJarConfiguration<?, ?, ?>> minecraftJarConfiguration;
 	private final Property<Boolean> splitEnvironmentalSourceSet;
 	private final InterfaceInjectionExtensionAPI interfaceInjectionExtension;
@@ -199,6 +200,9 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 
 		this.splitModDependencies = project.getObjects().property(Boolean.class).convention(true);
 		this.splitModDependencies.finalizeValueOnRead();
+
+		this.uncompressNestedJars = project.getObjects().property(Boolean.class).convention(false);
+		this.uncompressNestedJars.finalizeValueOnRead();
 
 		this.interfaceInjectionExtension = project.getObjects().newInstance(InterfaceInjectionExtensionAPI.class);
 		this.interfaceInjectionExtension.getIsEnabled().convention(true);
@@ -443,6 +447,11 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 	@Override
 	public Property<Boolean> getSplitModDependencies() {
 		return splitModDependencies;
+	}
+
+	@Override
+	public Property<Boolean> getUncompressNestedJars() {
+		return uncompressNestedJars;
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/task/RemapTaskConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapTaskConfiguration.java
@@ -71,6 +71,7 @@ public abstract class RemapTaskConfiguration implements Runnable {
 		TaskProvider<NestableJarGenerationTask> processIncludeJarsTask = getTasks().register(Constants.Task.PROCESS_INCLUDE_JARS, NestableJarGenerationTask.class, task -> {
 			task.from(includeConfiguration);
 			task.getOutputDirectory().set(getProject().getLayout().getBuildDirectory().dir(task.getName()));
+			task.getUncompressNestedJars().set(extension.getUncompressNestedJars());
 		});
 
 		if (extension.dontRemapOutputs()) {

--- a/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
+++ b/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
@@ -69,7 +69,10 @@ public class SourceRemapper {
 				logger.progress("remapping sources - " + source.getName());
 				Files.deleteIfExists(destination.toPath());
 				remapSourcesInner(source, destination);
-				ZipReprocessorUtil.reprocessZip(destination.toPath(), reproducibleFileOrder, preserveFileTimestamps);
+
+				if (reproducibleFileOrder || !preserveFileTimestamps) {
+					ZipReprocessorUtil.reprocessZip(destination.toPath(), reproducibleFileOrder, preserveFileTimestamps);
+				}
 
 				// Set the remapped sources creation date to match the sources if we're likely succeeded in making it
 				destination.setLastModified(source.lastModified());

--- a/src/main/java/net/fabricmc/loom/util/ZipReprocessorUtil.java
+++ b/src/main/java/net/fabricmc/loom/util/ZipReprocessorUtil.java
@@ -92,10 +92,6 @@ public class ZipReprocessorUtil {
 	}
 
 	public static void reprocessZip(Path file, boolean reproducibleFileOrder, boolean preserveFileTimestamps, ZipEntryCompression zipEntryCompression) throws IOException {
-		if (!reproducibleFileOrder && preserveFileTimestamps) {
-			return;
-		}
-
 		final Path tempFile = file.resolveSibling(file.getFileName() + ".tmp");
 
 		try (var zipFile = new ZipFile(file.toFile());


### PR DESCRIPTION
Adds an optional transformation step of converting zip entries within nested jars to be using STORED compression. 

This will usually reduce the compressed nested jar sizes, especially for nested jars with a lot of compiled java code, and therefore reduce the size of the final distributed mod jar. 

Table for compressed size comparisons:
|Library|Without transformation|After transformation|
|-|-|-|
|RxJava 3.1.12|2.2 MiB|1.3 MiB|
|Caffeine 3.2.1|728 KiB|300 KiB|
|exp4j 0.4.8|37.5 KiB|22.5 KiB|
|lwjgl 3.4.1|1.0 MiB|777 KiB|
|MixinSquared 0.3.7-beta.1|105.3 KiB|63.4 KiB|

As a side effect, this will almost certainly increase disk space usage when fabric-loader extracts them during runtime. 

This is made as an opt-in feature as `loom.uncompressNestedJars`. 