### PR TITLE
Respect `--project-cache-dir` and use mildly more idiomatic cache directories

### DIFF
--- a/src/main/java/net/fabricmc/loom/extension/LoomFilesBaseImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomFilesBaseImpl.java
@@ -58,9 +58,11 @@ public abstract class LoomFilesBaseImpl implements LoomFiles {
 	@Override
 	public File getProjectPersistentCache() {
 		var normalizedPath = getProjectPath().replace(":", File.separator).substring(1); // Replace ":" with file separator and remove leading ":"
+
 		if (normalizedPath.isEmpty()) {
 			return getRootProjectPersistentCache();
 		}
+
 		return createFile(getProjectCacheDir(), "loom-cache" + File.separator + "projects" + File.separator + normalizedPath);
 	}
 

--- a/src/main/java/net/fabricmc/loom/extension/LoomFilesBaseImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomFilesBaseImpl.java
@@ -33,8 +33,9 @@ import net.fabricmc.loom.LoomGradleExtension;
 public abstract class LoomFilesBaseImpl implements LoomFiles {
 	protected abstract File getGradleUserHomeDir();
 	protected abstract File getRootDir();
-	protected abstract File getProjectDir();
 	protected abstract File getBuildDir();
+	protected abstract File getProjectCacheDir();
+	protected abstract String getProjectPath();
 
 	public LoomFilesBaseImpl() { }
 
@@ -51,12 +52,16 @@ public abstract class LoomFilesBaseImpl implements LoomFiles {
 
 	@Override
 	public File getRootProjectPersistentCache() {
-		return createFile(getRootDir(), ".gradle" + File.separator + "loom-cache");
+		return createFile(getProjectCacheDir(), "loom-cache");
 	}
 
 	@Override
 	public File getProjectPersistentCache() {
-		return createFile(getProjectDir(), ".gradle" + File.separator + "loom-cache");
+		var normalizedPath = getProjectPath().replace(":", File.separator).substring(1); // Replace ":" with file separator and remove leading ":"
+		if (normalizedPath.isEmpty()) {
+			return getRootProjectPersistentCache();
+		}
+		return createFile(getProjectCacheDir(), normalizedPath + File.separator + "loom-cache");
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/extension/LoomFilesBaseImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomFilesBaseImpl.java
@@ -61,7 +61,7 @@ public abstract class LoomFilesBaseImpl implements LoomFiles {
 		if (normalizedPath.isEmpty()) {
 			return getRootProjectPersistentCache();
 		}
-		return createFile(getProjectCacheDir(), normalizedPath + File.separator + "loom-cache");
+		return createFile(getProjectCacheDir(), "loom-cache" + File.separator + "projects" + File.separator + normalizedPath);
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/extension/LoomFilesProjectImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomFilesProjectImpl.java
@@ -47,12 +47,18 @@ public final class LoomFilesProjectImpl extends LoomFilesBaseImpl {
 	}
 
 	@Override
-	protected File getProjectDir() {
-		return project.getProjectDir();
+	protected File getBuildDir() {
+		return project.getLayout().getBuildDirectory().getAsFile().get();
 	}
 
 	@Override
-	protected File getBuildDir() {
-		return project.getLayout().getBuildDirectory().getAsFile().get();
+	protected File getProjectCacheDir() {
+		var overridden = project.getGradle().getStartParameter().getProjectCacheDir();
+		return overridden == null ? new File(getRootDir(), ".gradle") : overridden;
+	}
+
+	@Override
+	protected String getProjectPath() {
+		return project.getPath();
 	}
 }

--- a/src/main/java/net/fabricmc/loom/extension/LoomFilesSettingsImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomFilesSettingsImpl.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 
 import org.gradle.api.initialization.Settings;
 
-public class LoomFilesSettingsImpl extends LoomFilesBaseImpl {
+public final class LoomFilesSettingsImpl extends LoomFilesBaseImpl {
 	private final Settings settings;
 
 	public LoomFilesSettingsImpl(Settings settings) {
@@ -47,8 +47,14 @@ public class LoomFilesSettingsImpl extends LoomFilesBaseImpl {
 	}
 
 	@Override
-	protected File getProjectDir() {
-		throw new IllegalStateException("You can not access project directory from setting stage");
+	protected File getProjectCacheDir() {
+		var overridden = settings.getGradle().getStartParameter().getProjectCacheDir();
+		return overridden == null ? new File(getRootDir(), ".gradle") : overridden;
+	}
+
+	@Override
+	protected String getProjectPath() {
+		throw new IllegalStateException("You can not access project path from setting stage");
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #1203. Currently loom's use of the project-level `.gradle` folder has two issues:
- it doesn't respect changes to this folder made by passing the `--project-cache-dir` argument
- it uses a `.gradle` folder in subprojects as well, which is just not a thing Gradle has -- in fact, when `--project-cache-dir` is used, you can't relate the location of the project cache dir to the project dir at all, necessarily

This PR fixes both issues by respecting `--project-cache-dir`, and by putting all build-level loom caches within that cache dir in a nested hierarchy for subprojects. So instead of:
```
rootProject
- .gradle
  - loom-cache
    - <stuff>
- subproject
  - .gradle
    - loom-cache
      - <stuff>
```
You now have 
```
.whatever-the-persistent-cache-is
- loom-cache
  - <stuff>
  - projects
    - subproject
      - <stuff>
```
This will result in a _very minor_ cache miss the first time you run with this (to my knowledge, most stuff is in the root project loom cache dir with only a couple odds and ends in the subproject ones anyways).