### PR TITLE
feat: Add option to control registration of default run configurations

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/mods/AccessWidenerAnalyzeVisitorProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/AccessWidenerAnalyzeVisitorProvider.java
@@ -31,6 +31,8 @@ import org.objectweb.asm.ClassVisitor;
 
 import net.fabricmc.classtweaker.api.ClassTweaker;
 import net.fabricmc.classtweaker.api.ClassTweakerReader;
+import net.fabricmc.classtweaker.api.visitor.ClassTweakerVisitor;
+import net.fabricmc.classtweaker.visitors.ForwardingVisitor;
 import net.fabricmc.loom.configuration.mods.dependency.ModDependency;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.tinyremapper.TinyRemapper;
@@ -47,7 +49,7 @@ public record AccessWidenerAnalyzeVisitorProvider(ClassTweaker accessWidener) im
 				continue;
 			}
 
-			final var reader = ClassTweakerReader.create(accessWidener);
+			final var reader = ClassTweakerReader.create(new ClassTweakerRemapFilter(accessWidener));
 			reader.read(accessWidenerData.content());
 		}
 
@@ -57,5 +59,16 @@ public record AccessWidenerAnalyzeVisitorProvider(ClassTweaker accessWidener) im
 	@Override
 	public ClassVisitor insertAnalyzeVisitor(int mrjVersion, String className, ClassVisitor next) {
 		return accessWidener.createClassVisitor(Constants.ASM_VERSION, next, null);
+	}
+
+	private static class ClassTweakerRemapFilter extends ForwardingVisitor {
+		private ClassTweakerRemapFilter(ClassTweakerVisitor... visitors) {
+			super(visitors);
+		}
+
+		@Override
+		public void visitEnumExtension(String owner, String addedConstant, boolean transitive) {
+			// Ignore enum extensions, as they are not required exist in the remapping context
+		}
 	}
 }

--- a/src/main/java/net/fabricmc/loom/task/LoomTasks.java
+++ b/src/main/java/net/fabricmc/loom/task/LoomTasks.java
@@ -213,29 +213,32 @@ public abstract class LoomTasks implements Runnable {
 			});
 		});
 
-		extension.getRunConfigs().create("client", RunConfigSettings::client);
-		extension.getRunConfigs().create("server", RunConfigSettings::server);
+		// Skip creating the default client/server run configs entirely when opted out via the gradle
+		// property. This must be checked at apply time so the corresponding tasks are never registered;
+		// once whenObjectAdded fires for a config, its task exists for the lifetime of the build.
+		if (!GradleUtils.getBooleanProperty(getProject(), Constants.Properties.DISABLE_DEFAULT_RUN_CONFIGS)) {
+			extension.getRunConfigs().create("client", RunConfigSettings::client);
+			extension.getRunConfigs().create("server", RunConfigSettings::server);
 
-		// Remove the client or server run config when not required. Done by name to not remove any possible custom run configs
-		GradleUtils.afterSuccessfulEvaluation(getProject(), () -> {
-			String taskName;
+			// Remove the client or server run config when not required. Done by name to not remove any possible custom run configs
+			GradleUtils.afterSuccessfulEvaluation(getProject(), () -> {
+				String taskName;
 
-			boolean serverOnly = extension.getMinecraftJarConfiguration().get() == MinecraftJarConfiguration.SERVER_ONLY;
-			boolean clientOnly = extension.getMinecraftJarConfiguration().get() == MinecraftJarConfiguration.CLIENT_ONLY;
+				boolean serverOnly = extension.getMinecraftJarConfiguration().get() == MinecraftJarConfiguration.SERVER_ONLY;
+				boolean clientOnly = extension.getMinecraftJarConfiguration().get() == MinecraftJarConfiguration.CLIENT_ONLY;
 
-			if (serverOnly) {
-				// Server only, remove the client run config
-				taskName = "client";
-			} else if (clientOnly) {
-				// Client only, remove the server run config
-				taskName = "server";
-			} else {
-				return;
-			}
+				if (serverOnly) {
+					taskName = "client";
+				} else if (clientOnly) {
+					taskName = "server";
+				} else {
+					return;
+				}
 
-			extension.getRunConfigs().removeIf(settings -> settings.getName().equals(taskName)
-					|| settings.getName().equals(taskName + "RenderDoc"));
-		});
+				extension.getRunConfigs().removeIf(settings -> settings.getName().equals(taskName)
+						|| settings.getName().equals(taskName + "RenderDoc"));
+			});
+		}
 	}
 
 	private void configureRenderDocTasks() {

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -168,6 +168,14 @@ public class Constants {
 		 * Set to true in all {@link net.fabricmc.loom.task.RenderDocRunTask} can be used to determine at runtime if running with loom's renderdoc setup.
 		 */
 		public static final String RENDER_DOC = "fabric.loom.renderdoc.enabled";
+		/**
+		 * When set to {@code true}, Loom will not create the default {@code client} and {@code server}
+		 * run configurations (and their associated {@code runClient}/{@code runServer} tasks).
+		 *
+		 * <p>This must be a gradle property rather than a DSL property because run config creation
+		 * happens at plugin apply time, before the {@code loom { }} block is evaluated.
+		 */
+		public static final String DISABLE_DEFAULT_RUN_CONFIGS = "fabric.loom.disableDefaultRunConfigs";
 	}
 
 	public static final class Manifest {

--- a/src/test/groovy/net/fabricmc/loom/test/integration/RunConfigTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/RunConfigTest.groovy
@@ -34,6 +34,7 @@ import spock.util.environment.RestoreSystemProperties
 
 import net.fabricmc.loom.test.LoomTestConstants
 import net.fabricmc.loom.test.util.GradleProjectTestTrait
+import net.fabricmc.loom.util.Constants
 import net.fabricmc.loom.util.download.Download
 
 import static net.fabricmc.loom.test.LoomTestConstants.STANDARD_TEST_VERSIONS
@@ -134,6 +135,58 @@ class RunConfigTest extends Specification implements GradleProjectTestTrait {
 
 		then:
 		result.task(":downloadAssets").outcome == SUCCESS
+
+		where:
+		version << STANDARD_TEST_VERSIONS
+	}
+
+	@Unroll
+	def "default run configs registered (gradle #version)"() {
+		setup:
+		def gradle = gradleProject(project: "minimalBase", version: version)
+
+		gradle.buildGradle << '''
+                dependencies {
+                    minecraft "com.mojang:minecraft:1.18.1"
+                    mappings "net.fabricmc:yarn:1.18.1+build.18:v2"
+                    modImplementation "net.fabricmc:fabric-loader:0.12.12"
+                }
+            '''
+
+		when:
+		def result = gradle.run(tasks: ["tasks", "--all"])
+
+		then:
+		result.task(":tasks").outcome == SUCCESS
+		(result.output =~ /(?m)^runClient\s/).find()
+		(result.output =~ /(?m)^runServer\s/).find()
+
+		where:
+		version << STANDARD_TEST_VERSIONS
+	}
+
+	@Unroll
+	def "default run configs disabled via gradle property (gradle #version)"() {
+		setup:
+		def gradle = gradleProject(project: "minimalBase", version: version)
+
+		gradle.gradleProperties << "\n${Constants.Properties.DISABLE_DEFAULT_RUN_CONFIGS}=true\n"
+
+		gradle.buildGradle << '''
+                dependencies {
+                    minecraft "com.mojang:minecraft:1.18.1"
+                    mappings "net.fabricmc:yarn:1.18.1+build.18:v2"
+                    modImplementation "net.fabricmc:fabric-loader:0.12.12"
+                }
+            '''
+
+		when:
+		def result = gradle.run(tasks: ["tasks", "--all"])
+
+		then:
+		result.task(":tasks").outcome == SUCCESS
+		!(result.output =~ /(?m)^runClient\s/).find()
+		!(result.output =~ /(?m)^runServer\s/).find()
 
 		where:
 		version << STANDARD_TEST_VERSIONS


### PR DESCRIPTION
This pull request adds support for disabling the automatic creation of default `client` and `server` run configurations (and their associated tasks) in Loom via a new Gradle property. It also introduces integration tests to verify this behavior and updates the documentation for the new property.

**New feature: Disable default run configs via Gradle property**
- Added the `fabric.loom.disableDefaultRunConfigs` property to `Constants.Properties`, allowing users to opt out of generating default `client` and `server` run configurations and their tasks. This is checked at plugin apply time to prevent the tasks from ever being registered. [[1]](diffhunk://#diff-8fc8f7ff8e3c01b1e4f4f5b068cc7988aa943b42a1ef52043ab2a4716ebd0156R171-R178) [[2]](diffhunk://#diff-d0fb60efa43f5e3c711a10dd42f532a263ef88523dfc6bbf07263a02dd99b068R216-R219)

**Task registration logic changes**
- Updated `LoomTasks.java` to conditionally skip creating the default run configs and associated tasks if the new property is set.
- Minor refactor to clarify logic for removing client/server run configs based on jar configuration. [[1]](diffhunk://#diff-d0fb60efa43f5e3c711a10dd42f532a263ef88523dfc6bbf07263a02dd99b068L227-L230) [[2]](diffhunk://#diff-d0fb60efa43f5e3c711a10dd42f532a263ef88523dfc6bbf07263a02dd99b068R242)

**Testing**
- Added integration tests in `RunConfigTest.groovy` to verify that the default run configs are registered by default and are properly disabled when the property is set.
- Imported the new property constant into the test file for use.