### PR TITLE
fix: defer game JVM arg resolution to execution time

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
@@ -147,7 +147,7 @@ public abstract class AbstractRunTask extends JavaExec {
 			}
 		});
 		getMainClass().set(config.flatMap(RunConfiguration::getDevLaunchMainClass));
-		getJvmArguments().addAll(getProject().provider(this::getGameJvmArgs));
+		getJvmArgumentProviders().add(this::getGameJvmArgs);
 
 		getInternalRunDir().set(config.flatMap(RunConfiguration::getRunDirectory));
 		getInternalEnvironmentVars().set(config.flatMap(RunConfiguration::getEnvironmentVars));
@@ -246,6 +246,11 @@ public abstract class AbstractRunTask extends JavaExec {
 		commandLine.add("--auto-servernum");
 		commandLine.add(javaExec);
 		commandLine.addAll(getJvmArguments().get());
+
+		for (CommandLineArgumentProvider provider : getJvmArgumentProviders()) {
+			provider.asArguments().forEach(commandLine::add);
+		}
+
 		commandLine.add(getMainClass().get());
 		commandLine.addAll(getArgs());
 


### PR DESCRIPTION
`AbstractRunTask` previously wired `getGameJvmArgs()` into `jvmArguments` via a provider:

    getJvmArguments().addAll(getProject().provider(this::getGameJvmArgs));

In Gradle 9, `getJvmArgs()` bridges to `getJvmArguments().get()`, which forces the
provider to evaluate. IDE tooling that calls `getJvmArgs()` during configuration
(e.g. IntelliJ's coroutine-debug init script) therefore triggers `getGameJvmArgs()` at
configuration time. That method resolves `runtimeClasspath`, which in a Gradle composite
build crosses the included-build lock boundary and fails with:

    Resolution of the configuration ':included-mod:runtimeClasspath' was attempted
    without an exclusive lock. This is unsafe and not allowed.

**Changes:**
- Move `getGameJvmArgs()` into `jvmArgumentProviders`, which Gradle only evaluates at
  execution time — not when `getJvmArgs()` is queried.
- Update `execWithXvfb()` to iterate `getJvmArgumentProviders()` alongside
  `getJvmArguments()`, since it manually assembles the JVM command line and would
  otherwise drop the argfile entry when xvfb is active.

Fixes #1558 