### PR TITLE
Support GStrings in runs VM args

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
@@ -149,7 +149,7 @@ public class RunConfig {
 
 		// Custom parameters
 		runConfig.programArgs.addAll(settings.getProgramArgs());
-		runConfig.vmArgs.addAll(settings.getVmArgs());
+		runConfig.vmArgs.addAll(settings.getVmArgs().stream().map(Object::toString).toList());
 		runConfig.vmArgs.add("-Dfabric.dli.main=" + mainClass);
 		runConfig.environmentVariables = new HashMap<>();
 		runConfig.environmentVariables.putAll(settings.getEnvironmentVariables());


### PR DESCRIPTION
Avoids a gradle crash when loading a loom project in IDEA with a GString in a run config's VM args

e.g. to base a VM arg off a project property