### PR TITLE
Gradle task run configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 !/.gitattributes
 !/.gitignore
 !/.editorconfig
+!/AGENTS.md
 !/build.gradle
 !/gradle.properties
 !/gradlew

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Agent Notes
+
+Fabric Loom is the Gradle toolchain used to develop, remap, and build Fabric mods for Minecraft.
+Approach this repository as a Gradle expert: be highly fluent in Gradle internals, builds, and debugging, and apply that knowledge carefully while still verifying assumptions in code and task output.
+
+- Do not run the full Gradle build or the entire test suite at once; they take many hours in this repository.
+- Prefer targeted Gradle tasks that validate only the area you changed.
+- When verifying final changes, run `./gradlew build -x test`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,3 @@
-# Agent Notes
-
-Fabric Loom is the Gradle toolchain used to develop, remap, and build Fabric mods for Minecraft.
-Approach this repository as a Gradle expert: be highly fluent in Gradle internals, builds, and debugging, and apply that knowledge carefully while still verifying assumptions in code and task output.
-
 - Do not run the full Gradle build or the entire test suite at once; they take many hours in this repository.
 - Prefer targeted Gradle tasks that validate only the area you changed.
 - When verifying final changes, run `./gradlew build -x test`.

--- a/src/main/java/net/fabricmc/loom/api/RunConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/api/RunConfiguration.java
@@ -105,6 +105,17 @@ public interface RunConfiguration extends Named {
 	Property<Boolean> getGenerateRunConfig();
 
 	/**
+	 * When true generated IDE run configurations will prefer to invoke the matching Gradle run task instead of
+	 * launching the game directly, when that IDE supports such a mode.
+	 *
+	 * <p>For example, the {@code client} run configuration will run {@code :runClient}.
+	 *
+	 * <p>Changing this mode may cause an existing generated run configuration to be replaced so the IDE switches to the
+	 * correct run configuration type.
+	 */
+	Property<Boolean> getPreferGradleTask();
+
+	/**
 	 * Group this run config under the given folder.
 	 *
 	 * <p>This is currently only supported on IntelliJ IDEA.
@@ -131,6 +142,7 @@ public interface RunConfiguration extends Named {
 		getSourceSet().convention(parent.getSourceSet());
 		getRunDirectory().convention(parent.getRunDirectory());
 		getGenerateRunConfig().convention(parent.getGenerateRunConfig());
+		getPreferGradleTask().convention(parent.getPreferGradleTask());
 		getIdeConfigFolder().convention(parent.getIdeConfigFolder());
 		getDevLaunchMainClass().convention(parent.getDevLaunchMainClass());
 	}

--- a/src/main/java/net/fabricmc/loom/configuration/ide/DefaultRunConfigurationSettings.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/DefaultRunConfigurationSettings.java
@@ -63,6 +63,7 @@ public class DefaultRunConfigurationSettings {
 		}));
 		run.getRunDirectory().set(project.file("run"));
 		run.getGenerateRunConfig().convention(GradleUtils.isRootProject(project));
+		run.getPreferGradleTask().convention(false);
 	}
 
 	// Apply any additional configuration after the user has modified the settings, but before the run config is generated.
@@ -121,6 +122,7 @@ public class DefaultRunConfigurationSettings {
 		run.getSourceSet().finalizeValue();
 		run.getRunDirectory().finalizeValue();
 		run.getGenerateRunConfig().finalizeValue();
+		run.getPreferGradleTask().finalizeValue();
 		run.getIdeConfigFolder().finalizeValue();
 		run.getDevLaunchMainClass().finalizeValue();
 	}

--- a/src/main/java/net/fabricmc/loom/configuration/ide/idea/AbstractIntellijRunConfigWriter.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/idea/AbstractIntellijRunConfigWriter.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.configuration.ide.idea;
+
+import org.gradle.api.Project;
+
+import net.fabricmc.loom.api.RunConfiguration;
+
+abstract class AbstractIntellijRunConfigWriter implements IntellijRunConfigWriter {
+	protected final RunConfiguration run;
+	protected final Project project;
+
+	protected AbstractIntellijRunConfigWriter(RunConfiguration run, Project project) {
+		this.run = run;
+		this.project = project;
+	}
+
+	@Override
+	public boolean shouldOverwrite(String existingXml) {
+		return !getType().equals(IntellijRunConfigWriter.getType(existingXml));
+	}
+}

--- a/src/main/java/net/fabricmc/loom/configuration/ide/idea/ApplicationIntellijRunConfigWriter.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/idea/ApplicationIntellijRunConfigWriter.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.configuration.ide.idea;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import groovy.xml.XmlUtil;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.SourceSet;
+
+import net.fabricmc.loom.api.RunConfiguration;
+import net.fabricmc.loom.configuration.ide.RunConfigUtils;
+import net.fabricmc.loom.util.Arguments;
+import net.fabricmc.loom.util.gradle.SourceSetHelper;
+import net.fabricmc.loom.util.gradle.SourceSetReference;
+
+public final class ApplicationIntellijRunConfigWriter extends AbstractIntellijRunConfigWriter {
+	private final List<String> excludedLibraryPaths;
+
+	public ApplicationIntellijRunConfigWriter(RunConfiguration run, Project project, List<String> excludedLibraryPaths) {
+		super(run, project);
+		this.excludedLibraryPaths = excludedLibraryPaths;
+	}
+
+	@Override
+	public String render() throws IOException {
+		final String xml;
+
+		try (InputStream input = IdeaSyncTask.class.getClassLoader().getResourceAsStream("idea_run_config_template.xml")) {
+			xml = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+		}
+
+		String runDir = RunConfigUtils.formatRunDir(run, project, File::getAbsolutePath, "$PROJECT_DIR$/%s"::formatted);
+		String folderName = run.getIdeConfigFolder().getOrNull();
+		SourceSet sourceSet = SourceSetHelper.getSourceSetByName(run.getSourceSet().get(), project);
+
+		final String runConfigXml = xml.replace("%NAME%", RunConfigUtils.getDisplayName(run, project))
+				.replace("%MAIN_CLASS%", run.getDevLaunchMainClass().get())
+				.replace("%IDEA_MODULE%", IdeaUtils.getIdeaModuleName(new SourceSetReference(sourceSet, project)))
+				.replace("%RUN_DIRECTORY%", runDir)
+				.replace("%PROGRAM_ARGS%", Arguments.join(run.getProgramArguments().get()).replace("\"", "&quot;"))
+				.replace("%VM_ARGS%", Arguments.join(run.getJvmArguments().get()).replace("\"", "&quot;"))
+				.replace("%IDEA_ENV_VARS%", RunConfigUtils.formatEnvVars(run, "<env name=\"%s\" value=\"%s\"/>"))
+				.replace("%IDEA_FOLDER_NAME%", folderName == null ? "" : "folderName=\"" + XmlUtil.escapeXml(folderName) + "\"")
+				.replaceAll("(?m)^[ \\t]+$", "");
+
+		try {
+			return IdeaSyncTask.setClasspathModificationsInXml(runConfigXml, excludedLibraryPaths);
+		} catch (Exception e) {
+			throw new IOException("Failed to apply IntelliJ classpath modifications", e);
+		}
+	}
+
+	@Override
+	public String getType() {
+		return APPLICATION_TYPE;
+	}
+}

--- a/src/main/java/net/fabricmc/loom/configuration/ide/idea/GradleTaskIntellijRunConfigWriter.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/idea/GradleTaskIntellijRunConfigWriter.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.configuration.ide.idea;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import groovy.xml.XmlUtil;
+import org.gradle.api.Project;
+
+import net.fabricmc.loom.api.RunConfiguration;
+import net.fabricmc.loom.configuration.ide.RunConfigUtils;
+import net.fabricmc.loom.task.LoomTasks;
+
+public final class GradleTaskIntellijRunConfigWriter extends AbstractIntellijRunConfigWriter {
+	public GradleTaskIntellijRunConfigWriter(RunConfiguration run, Project project) {
+		super(run, project);
+	}
+
+	@Override
+	public String render() throws IOException {
+		final String xml;
+
+		try (InputStream input = IdeaSyncTask.class.getClassLoader().getResourceAsStream("idea_gradle_run_config_template.xml")) {
+			xml = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+		}
+
+		String folderName = run.getIdeConfigFolder().getOrNull();
+		String taskPath = project.getPath().equals(":")
+				? ":" + LoomTasks.getRunConfigTaskName(run)
+				: project.getPath() + ":" + LoomTasks.getRunConfigTaskName(run);
+
+		return xml.replace("%NAME%", RunConfigUtils.getDisplayName(run, project))
+				.replace("%TASK_NAME%", taskPath)
+				.replace("%IDEA_FOLDER_NAME%", folderName == null ? "" : "folderName=\"" + XmlUtil.escapeXml(folderName) + "\"");
+	}
+
+	@Override
+	public String getType() {
+		return GRADLE_TASK_TYPE;
+	}
+}

--- a/src/main/java/net/fabricmc/loom/configuration/ide/idea/IdeaSyncTask.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/idea/IdeaSyncTask.java
@@ -26,12 +26,12 @@ package net.fabricmc.loom.configuration.ide.idea;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -45,7 +45,6 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import groovy.xml.XmlUtil;
 import org.gradle.api.Project;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.project.IsolatedProject;
@@ -54,12 +53,9 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.work.DisableCachingByDefault;
 import org.jetbrains.annotations.VisibleForTesting;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -70,15 +66,10 @@ import net.fabricmc.loom.configuration.ide.DefaultRunConfigurationSettings;
 import net.fabricmc.loom.configuration.ide.RunConfigUtils;
 import net.fabricmc.loom.configuration.ide.RuntimeLibraries;
 import net.fabricmc.loom.task.AbstractLoomTask;
-import net.fabricmc.loom.util.Arguments;
 import net.fabricmc.loom.util.Constants;
-import net.fabricmc.loom.util.gradle.SourceSetHelper;
-import net.fabricmc.loom.util.gradle.SourceSetReference;
 
 @DisableCachingByDefault
 public abstract class IdeaSyncTask extends AbstractLoomTask {
-	private static final Logger LOGGER = LoggerFactory.getLogger(IdeaSyncTask.class);
-
 	@Nested
 	protected abstract ListProperty<IntellijRunConfig> getIdeaRunConfigs();
 
@@ -114,14 +105,14 @@ public abstract class IdeaSyncTask extends AbstractLoomTask {
 
 			RunConfiguration runConfiguration = DefaultRunConfigurationSettings.finialise(settings, project);
 			String name = RunConfigUtils.getDisplayName(runConfiguration, project).replaceAll("[^a-zA-Z0-9$_]", "_");
+			IntellijRunConfigWriter writer = createWriter(runConfiguration, project);
 
 			File runConfigFile = new File(runConfigsDir, name + projectPath + ".xml");
-			String runConfigXml = fromTemplate(runConfiguration, project);
-			final List<String> excludedLibraryPaths = RuntimeLibraries.getExcludedLibraryPaths(project, runConfiguration);
+			String runConfigXml = writer.render();
 
 			IntellijRunConfig irc = project.getObjects().newInstance(IntellijRunConfig.class);
 			irc.getRunConfigXml().set(runConfigXml);
-			irc.getExcludedLibraryPaths().set(excludedLibraryPaths);
+			irc.getRunConfigType().set(writer.getType());
 			irc.getLaunchFile().set(runConfigFile);
 			configs.add(irc);
 
@@ -131,27 +122,12 @@ public abstract class IdeaSyncTask extends AbstractLoomTask {
 		return configs;
 	}
 
-	private static String fromTemplate(RunConfiguration run, Project project) throws IOException {
-		String xml;
-
-		try (InputStream input = IdeaSyncTask.class.getClassLoader().getResourceAsStream("idea_run_config_template.xml")) {
-			xml = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+	private static IntellijRunConfigWriter createWriter(RunConfiguration run, Project project) {
+		if (run.getPreferGradleTask().get()) {
+			return new GradleTaskIntellijRunConfigWriter(run, project);
 		}
 
-		String runDir = RunConfigUtils.formatRunDir(run, project, File::getAbsolutePath, "$PROJECT_DIR$/%s"::formatted);
-		String folderName = run.getIdeConfigFolder().getOrNull();
-		SourceSet sourceSet = SourceSetHelper.getSourceSetByName(run.getSourceSet().get(), project);
-
-		xml = xml.replace("%NAME%", RunConfigUtils.getDisplayName(run, project));
-		xml = xml.replace("%MAIN_CLASS%", run.getDevLaunchMainClass().get());
-		xml = xml.replace("%IDEA_MODULE%", IdeaUtils.getIdeaModuleName(new SourceSetReference(sourceSet, project)));
-		xml = xml.replace("%RUN_DIRECTORY%", runDir);
-		xml = xml.replace("%PROGRAM_ARGS%", Arguments.join(run.getProgramArguments().get()).replace("\"", "&quot;"));
-		xml = xml.replace("%VM_ARGS%", Arguments.join(run.getJvmArguments().get()).replace("\"", "&quot;"));
-		xml = xml.replace("%IDEA_ENV_VARS%", RunConfigUtils.formatEnvVars(run, "<env name=\"%s\" value=\"%s\"/>"));
-		xml = xml.replace("%IDEA_FOLDER_NAME%", folderName == null ? "" : "folderName=\"" + XmlUtil.escapeXml(folderName) + "\"");
-
-		return xml;
+		return new ApplicationIntellijRunConfigWriter(run, project, RuntimeLibraries.getExcludedLibraryPaths(project, run));
 	}
 
 	public interface IntellijRunConfig {
@@ -159,41 +135,63 @@ public abstract class IdeaSyncTask extends AbstractLoomTask {
 		Property<String> getRunConfigXml();
 
 		@Input
-		ListProperty<String> getExcludedLibraryPaths();
+		Property<String> getRunConfigType();
 
 		@OutputFile
 		RegularFileProperty getLaunchFile();
 
 		default void writeLaunchFile() throws IOException {
 			Path launchFile = getLaunchFile().get().getAsFile().toPath();
+			final String expectedXml = getRunConfigXml().get();
 
 			if (Files.notExists(launchFile)) {
 				Files.createDirectories(launchFile.getParent());
-				Files.writeString(launchFile, getRunConfigXml().get(), StandardCharsets.UTF_8);
-			}
+				Files.writeString(launchFile, expectedXml, StandardCharsets.UTF_8);
+			} else {
+				final String existingXml = Files.readString(launchFile, StandardCharsets.UTF_8);
 
-			try {
-				setClasspathModifications(launchFile, getExcludedLibraryPaths().get());
-			} catch (Exception e) {
-				LOGGER.error("Failed to modify run configuration xml", e);
+				if (shouldOverwrite(existingXml)) {
+					backupLaunchFile(launchFile);
+					Files.writeString(launchFile, expectedXml, StandardCharsets.UTF_8);
+				} else if (IntellijRunConfigWriter.APPLICATION_TYPE.equals(getRunConfigType().get())) {
+					try {
+						Files.writeString(launchFile, setClasspathModificationsInXml(existingXml, expectedXml), StandardCharsets.UTF_8);
+					} catch (Exception e) {
+						throw new IOException("Failed to update IntelliJ classpath modifications", e);
+					}
+				}
 			}
+		}
+
+		private void backupLaunchFile(Path launchFile) throws IOException {
+			final Path backupDir = launchFile.getParent().resolve("backups");
+			Files.createDirectories(backupDir);
+			final Path backupFile = resolveBackupPath(backupDir, launchFile.getFileName().toString());
+			Files.copy(launchFile, backupFile, StandardCopyOption.REPLACE_EXISTING);
+		}
+
+		private boolean shouldOverwrite(String existingXml) {
+			return !getRunConfigType().get().equals(IntellijRunConfigWriter.getType(existingXml));
 		}
 	}
 
-	private static void setClasspathModifications(Path runConfig, List<String> exclusions) throws IOException {
-		final String inputXml = Files.readString(runConfig, StandardCharsets.UTF_8);
-		final String outputXml;
+	private static Path resolveBackupPath(Path backupDir, String fileName) {
+		Path backupPath = backupDir.resolve(fileName + ".backup");
 
-		try {
-			outputXml = setClasspathModificationsInXml(inputXml, exclusions);
-		} catch (Exception e) {
-			LOGGER.error("Failed to modify idea xml", e);
-
-			return;
+		if (Files.notExists(backupPath)) {
+			return backupPath;
 		}
 
-		if (!inputXml.equals(outputXml)) {
-			Files.writeString(runConfig, outputXml, StandardCharsets.UTF_8);
+		int index = 1;
+
+		while (true) {
+			backupPath = backupDir.resolve(fileName + "." + index + ".backup");
+
+			if (Files.notExists(backupPath)) {
+				return backupPath;
+			}
+
+			index++;
 		}
 	}
 
@@ -234,6 +232,52 @@ public abstract class IdeaSyncTask extends AbstractLoomTask {
 
 		final DOMSource source = new DOMSource(document);
 
+		final StringWriter writer = new StringWriter();
+		transformer.transform(source, new StreamResult(writer));
+
+		return writer.toString().replace("\r", "");
+	}
+
+	@VisibleForTesting
+	public static String setClasspathModificationsInXml(String input, String source) throws Exception {
+		final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+		final DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+		final Document inputDocument = documentBuilder.parse(new InputSource(new StringReader(input)));
+		final Document sourceDocument = documentBuilder.parse(new InputSource(new StringReader(source)));
+
+		final Element inputConfiguration = getConfigurationElement(inputDocument);
+		final Element sourceConfiguration = getConfigurationElement(sourceDocument);
+		final NodeList sourceClasspathModificationsList = sourceConfiguration.getElementsByTagName("classpathModifications");
+
+		removeClasspathModifications(inputConfiguration);
+
+		if (sourceClasspathModificationsList.getLength() > 0) {
+			inputConfiguration.appendChild(inputDocument.importNode(sourceClasspathModificationsList.item(0), true));
+		}
+
+		return documentToString(inputDocument);
+	}
+
+	private static Element getConfigurationElement(Document document) {
+		final NodeList nodeList = document.getDocumentElement().getElementsByTagName("configuration");
+		assert nodeList.getLength() == 1;
+		return (Element) nodeList.item(0);
+	}
+
+	private static void removeClasspathModifications(Element configuration) {
+		final NodeList classpathModificationsList = configuration.getElementsByTagName("classpathModifications");
+
+		for (int i = classpathModificationsList.getLength() - 1; i >= 0; i--) {
+			configuration.removeChild(classpathModificationsList.item(i));
+		}
+	}
+
+	private static String documentToString(Document document) throws Exception {
+		final TransformerFactory transformerFactory = TransformerFactory.newInstance();
+		final Transformer transformer = transformerFactory.newTransformer();
+		transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+
+		final DOMSource source = new DOMSource(document);
 		final StringWriter writer = new StringWriter();
 		transformer.transform(source, new StreamResult(writer));
 

--- a/src/main/java/net/fabricmc/loom/configuration/ide/idea/IdeaSyncTask.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/idea/IdeaSyncTask.java
@@ -33,6 +33,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -64,7 +65,6 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
-import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.RunConfiguration;
 import net.fabricmc.loom.configuration.ide.DefaultRunConfigurationSettings;
 import net.fabricmc.loom.configuration.ide.RunConfigUtils;
@@ -95,28 +95,31 @@ public abstract class IdeaSyncTask extends AbstractLoomTask {
 		}
 	}
 
-	// See: https://github.com/FabricMC/fabric-loom/pull/206#issuecomment-986054254 for the reason why XML's are still used to provide the run configs
 	private List<IntellijRunConfig> getRunConfigs() throws IOException {
-		IsolatedProject rootProject = getProject().getIsolated().getRootProject();
-		LoomGradleExtension extension = LoomGradleExtension.get(getProject());
-		String projectPath = getProject().getPath().equals(rootProject.getPath()) ? "" : getProject().getPath().replace(':', '_');
+		return getRunConfigs(getProject(), getExtension().getRunConfigs());
+	}
+
+	@VisibleForTesting
+	public static List<IntellijRunConfig> getRunConfigs(Project project, Collection<? extends RunConfiguration> runs) throws IOException {
+		IsolatedProject rootProject = project.getIsolated().getRootProject();
+		String projectPath = project.getPath().equals(rootProject.getPath()) ? "" : project.getPath().replace(':', '_');
 		File runConfigsDir = new File(rootProject.getProjectDirectory().file(".idea").getAsFile(), "runConfigurations");
 
 		List<IntellijRunConfig> configs = new ArrayList<>();
 
-		for (RunConfiguration settings : extension.getRunConfigs()) {
+		for (RunConfiguration settings : runs) {
 			if (!settings.getGenerateRunConfig().get()) {
 				continue;
 			}
 
-			RunConfiguration runConfiguration = DefaultRunConfigurationSettings.finialise(settings, getProject());
-			String name = RunConfigUtils.getDisplayName(runConfiguration, getProject()).replaceAll("[^a-zA-Z0-9$_]", "_");
+			RunConfiguration runConfiguration = DefaultRunConfigurationSettings.finialise(settings, project);
+			String name = RunConfigUtils.getDisplayName(runConfiguration, project).replaceAll("[^a-zA-Z0-9$_]", "_");
 
 			File runConfigFile = new File(runConfigsDir, name + projectPath + ".xml");
-			String runConfigXml = fromTemplate(runConfiguration, getProject());
-			final List<String> excludedLibraryPaths = RuntimeLibraries.getExcludedLibraryPaths(getProject(), runConfiguration);
+			String runConfigXml = fromTemplate(runConfiguration, project);
+			final List<String> excludedLibraryPaths = RuntimeLibraries.getExcludedLibraryPaths(project, runConfiguration);
 
-			IntellijRunConfig irc = getProject().getObjects().newInstance(IntellijRunConfig.class);
+			IntellijRunConfig irc = project.getObjects().newInstance(IntellijRunConfig.class);
 			irc.getRunConfigXml().set(runConfigXml);
 			irc.getExcludedLibraryPaths().set(excludedLibraryPaths);
 			irc.getLaunchFile().set(runConfigFile);

--- a/src/main/java/net/fabricmc/loom/configuration/ide/idea/IntellijRunConfigWriter.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/idea/IntellijRunConfigWriter.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2021 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.configuration.ide.idea;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+public interface IntellijRunConfigWriter {
+	String APPLICATION_TYPE = "Application";
+	String GRADLE_TASK_TYPE = "GradleRunConfiguration";
+
+	String render() throws IOException;
+
+	String getType();
+
+	boolean shouldOverwrite(String existingXml);
+
+	static String getType(String existingXml) {
+		try {
+			final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+			final DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+			final Document document = documentBuilder.parse(new InputSource(new StringReader(existingXml)));
+			final NodeList nodeList = document.getDocumentElement().getElementsByTagName("configuration");
+
+			if (nodeList.getLength() != 1) {
+				return "";
+			}
+
+			final Element configuration = (Element) nodeList.item(0);
+			return configuration.getAttribute("type");
+		} catch (Exception e) {
+			return "";
+		}
+	}
+}

--- a/src/main/resources/idea_gradle_run_config_template.xml
+++ b/src/main/resources/idea_gradle_run_config_template.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="%NAME%" type="GradleRunConfiguration" factoryName="Gradle" %IDEA_FOLDER_NAME%>
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="%TASK_NAME%" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/src/test/groovy/net/fabricmc/loom/test/integration/RunConfigTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/RunConfigTest.groovy
@@ -112,6 +112,39 @@ class RunConfigTest extends Specification implements GradleProjectTestTrait {
 		version << STANDARD_TEST_VERSIONS
 	}
 
+	@RestoreSystemProperties
+	@Unroll
+	def "idea auto configuration with gradle task run configs (gradle #version)"() {
+		setup:
+		System.setProperty("idea.sync.active", "true")
+		def gradle = gradleProject(project: "minimalBase", version: version)
+
+		new File(gradle.projectDir, ".idea").mkdirs()
+
+		gradle.buildGradle << """
+                dependencies {
+                    minecraft "com.mojang:minecraft:1.18.1"
+                    mappings "net.fabricmc:yarn:1.18.1+build.18:v2"
+                    modImplementation "${LoomTestVersions.FABRIC_LOADER.mavenNotation()}"
+                }
+
+                loom {
+                    runs.configureEach {
+                        preferGradleTask = true
+                    }
+                }
+            """
+
+		when:
+		def result = gradle.run(tasks: [])
+
+		then:
+		result.task(":ideaSyncTask").outcome == SUCCESS
+
+		where:
+		version << STANDARD_TEST_VERSIONS
+	}
+
 	// Test that the download assets task doesnt depend on a client run existing.
 	@Unroll
 	def "cleared runs (gradle #version)"() {

--- a/src/test/groovy/net/fabricmc/loom/test/unit/IdeaSyncTaskTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/IdeaSyncTaskTest.groovy
@@ -26,13 +26,50 @@ package net.fabricmc.loom.test.unit
 
 import java.nio.charset.StandardCharsets
 
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPlugin
 import org.intellij.lang.annotations.Language
 import spock.lang.Specification
 
+import net.fabricmc.loom.configuration.ide.RunConfigurationInternal
 import net.fabricmc.loom.configuration.ide.idea.IdeaSyncTask
+import net.fabricmc.loom.test.util.GradleTestUtil
 import net.fabricmc.loom.util.Arguments
 
-class IdeaClasspathModificationsTest extends Specification {
+class IdeaSyncTaskTest extends Specification {
+	def "get run configs only includes generated root configs"() {
+		given:
+		def project = mockJavaProject("root")
+		def generatedRun = mockRunConfig(project, "client", "Minecraft Client", true)
+		def skippedRun = mockRunConfig(project, "server", "Minecraft Server", false)
+
+		when:
+		def configs = IdeaSyncTask.getRunConfigs(project, [generatedRun, skippedRun])
+
+		then:
+		configs.size() == 1
+		configs[0].launchFile.get().asFile == new File(project.rootDir, ".idea/runConfigurations/Minecraft_Client.xml")
+		configs[0].excludedLibraryPaths.get().empty
+		configs[0].runConfigXml.get() == expectedRunConfigXml("Minecraft Client", "root.main", "\$PROJECT_DIR\$/run")
+		project.file("run").directory
+		!project.file("server-run").exists()
+	}
+
+	def "get run configs appends subproject path to launch file name"() {
+		given:
+		def rootProject = mockJavaProject("root")
+		def project = mockJavaProject("sub", rootProject)
+		def run = mockRunConfig(project, "client", "Minecraft Client", true)
+
+		when:
+		def configs = IdeaSyncTask.getRunConfigs(project, [run])
+
+		then:
+		configs.size() == 1
+		configs[0].launchFile.get().asFile == new File(rootProject.rootDir, ".idea/runConfigurations/Minecraft_Client___sub__sub.xml")
+		configs[0].runConfigXml.get() == expectedRunConfigXml("Minecraft Client (:sub)", "root.sub.main", "\$PROJECT_DIR\$/sub/run")
+		project.file("run").directory
+	}
 
 	def "configure exclusions"() {
 		when:
@@ -72,6 +109,50 @@ class IdeaClasspathModificationsTest extends Specification {
 		dummyConfig = dummyConfig.replace("%IDEA_FOLDER_NAME%", "")
 
 		return dummyConfig
+	}
+
+	private static Project mockJavaProject(String name, Project parent = null) {
+		def project = parent == null ? GradleTestUtil.mockProject(name) : GradleTestUtil.mockProject(name, parent)
+		project.pluginManager.apply(JavaPlugin)
+		return project
+	}
+
+	private static RunConfigurationInternal mockRunConfig(Project project, String name, String displayName, boolean generateRunConfig) {
+		def run = project.objects.newInstance(RunConfigurationInternal.class, name)
+		run.isFinalised.set(true)
+		run.displayName.set(displayName)
+		run.jvmArguments.set([])
+		run.programArguments.set([])
+		run.environmentVars.set([:])
+		run.runtimeEnvironment.set("client")
+		run.appendProjectPathToDisplayName.set(true)
+		run.sourceSet.set("main")
+		run.runDirectory.set(project.file(name == "server" ? "server-run" : "run"))
+		run.generateRunConfig.set(generateRunConfig)
+		run.ideConfigFolder.set((String) null)
+		run.devLaunchMainClass.set("net.minecraft.client.Main")
+		return run
+	}
+
+	private static String expectedRunConfigXml(String displayName, String moduleName, String runDirectory) {
+		return """\
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="${displayName}" type="Application" factoryName="Application" >
+    <option name="MAIN_CLASS_NAME" value="net.minecraft.client.Main" />
+    <module name="${moduleName}" />
+    <option name="PROGRAM_PARAMETERS" value="" />
+    <option name="VM_PARAMETERS" value="" />
+    <option name="WORKING_DIRECTORY" value="${runDirectory}/" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+    <envs>
+      
+    </envs>
+    <shortenClasspath name="ARGS_FILE" />
+  </configuration>
+</component>
+"""
 	}
 
 	@Language("XML")

--- a/src/test/groovy/net/fabricmc/loom/test/unit/IdeaSyncTaskTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/IdeaSyncTaskTest.groovy
@@ -25,6 +25,7 @@
 package net.fabricmc.loom.test.unit
 
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
@@ -33,6 +34,7 @@ import spock.lang.Specification
 
 import net.fabricmc.loom.configuration.ide.RunConfigurationInternal
 import net.fabricmc.loom.configuration.ide.idea.IdeaSyncTask
+import net.fabricmc.loom.configuration.ide.idea.IntellijRunConfigWriter
 import net.fabricmc.loom.test.util.GradleTestUtil
 import net.fabricmc.loom.util.Arguments
 
@@ -40,8 +42,8 @@ class IdeaSyncTaskTest extends Specification {
 	def "get run configs only includes generated root configs"() {
 		given:
 		def project = mockJavaProject("root")
-		def generatedRun = mockRunConfig(project, "client", "Minecraft Client", true)
-		def skippedRun = mockRunConfig(project, "server", "Minecraft Server", false)
+		def generatedRun = mockRunConfig(project, "client", "Minecraft Client", true, false)
+		def skippedRun = mockRunConfig(project, "server", "Minecraft Server", false, false)
 
 		when:
 		def configs = IdeaSyncTask.getRunConfigs(project, [generatedRun, skippedRun])
@@ -49,7 +51,6 @@ class IdeaSyncTaskTest extends Specification {
 		then:
 		configs.size() == 1
 		configs[0].launchFile.get().asFile == new File(project.rootDir, ".idea/runConfigurations/Minecraft_Client.xml")
-		configs[0].excludedLibraryPaths.get().empty
 		configs[0].runConfigXml.get() == expectedRunConfigXml("Minecraft Client", "root.main", "\$PROJECT_DIR\$/run")
 		project.file("run").directory
 		!project.file("server-run").exists()
@@ -59,7 +60,7 @@ class IdeaSyncTaskTest extends Specification {
 		given:
 		def rootProject = mockJavaProject("root")
 		def project = mockJavaProject("sub", rootProject)
-		def run = mockRunConfig(project, "client", "Minecraft Client", true)
+		def run = mockRunConfig(project, "client", "Minecraft Client", true, false)
 
 		when:
 		def configs = IdeaSyncTask.getRunConfigs(project, [run])
@@ -68,6 +69,21 @@ class IdeaSyncTaskTest extends Specification {
 		configs.size() == 1
 		configs[0].launchFile.get().asFile == new File(rootProject.rootDir, ".idea/runConfigurations/Minecraft_Client___sub__sub.xml")
 		configs[0].runConfigXml.get() == expectedRunConfigXml("Minecraft Client (:sub)", "root.sub.main", "\$PROJECT_DIR\$/sub/run")
+		project.file("run").directory
+	}
+
+	def "get run configs can prefer gradle run configuration"() {
+		given:
+		def project = mockJavaProject("root")
+		def run = mockRunConfig(project, "client", "Minecraft Client", true, true)
+
+		when:
+		def configs = IdeaSyncTask.getRunConfigs(project, [run])
+
+		then:
+		configs.size() == 1
+		configs[0].launchFile.get().asFile == new File(project.rootDir, ".idea/runConfigurations/Minecraft_Client.xml")
+		configs[0].runConfigXml.get() == expectedGradleRunConfigXml("Minecraft Client", ":runClient")
 		project.file("run").directory
 	}
 
@@ -91,6 +107,95 @@ class IdeaSyncTaskTest extends Specification {
 
 		then:
 		output == EXPECTED2
+	}
+
+	def "write launch file overwrites when prefer gradle task setting changes and stores backup"() {
+		given:
+		def project = mockJavaProject("root")
+		def launchFile = project.file(".idea/runConfigurations/Minecraft_Client.xml").toPath()
+		Files.createDirectories(launchFile.parent)
+		Files.writeString(launchFile, expectedRunConfigXml("Minecraft Client", "root.main", "\$PROJECT_DIR\$/run"), StandardCharsets.UTF_8)
+
+		def config = project.objects.newInstance(IdeaSyncTask.IntellijRunConfig)
+		config.runConfigXml.set(expectedGradleRunConfigXml("Minecraft Client", ":runClient"))
+		config.runConfigType.set(IntellijRunConfigWriter.GRADLE_TASK_TYPE)
+		config.launchFile.set(launchFile.toFile())
+
+		when:
+		config.writeLaunchFile()
+
+		then:
+		Files.readString(launchFile, StandardCharsets.UTF_8) == expectedGradleRunConfigXml("Minecraft Client", ":runClient")
+		Files.readString(launchFile.parent.resolve("backups/Minecraft_Client.xml.backup"), StandardCharsets.UTF_8) == expectedRunConfigXml("Minecraft Client", "root.main", "\$PROJECT_DIR\$/run")
+	}
+
+	def "write launch file stores unique backups across multiple mode switches"() {
+		given:
+		def project = mockJavaProject("root")
+		def launchFile = project.file(".idea/runConfigurations/Minecraft_Client.xml").toPath()
+		Files.createDirectories(launchFile.parent)
+		Files.writeString(launchFile, expectedRunConfigXml("Minecraft Client", "root.main", "\$PROJECT_DIR\$/run"), StandardCharsets.UTF_8)
+
+		def gradleConfig = project.objects.newInstance(IdeaSyncTask.IntellijRunConfig)
+		gradleConfig.runConfigXml.set(expectedGradleRunConfigXml("Minecraft Client", ":runClient"))
+		gradleConfig.runConfigType.set(IntellijRunConfigWriter.GRADLE_TASK_TYPE)
+		gradleConfig.launchFile.set(launchFile.toFile())
+
+		def applicationConfig = project.objects.newInstance(IdeaSyncTask.IntellijRunConfig)
+		applicationConfig.runConfigXml.set(expectedRunConfigXml("Minecraft Client", "root.main", "\$PROJECT_DIR\$/run"))
+		applicationConfig.runConfigType.set(IntellijRunConfigWriter.APPLICATION_TYPE)
+		applicationConfig.launchFile.set(launchFile.toFile())
+
+		when:
+		gradleConfig.writeLaunchFile()
+		applicationConfig.writeLaunchFile()
+
+		then:
+		Files.readString(launchFile, StandardCharsets.UTF_8) == expectedRunConfigXml("Minecraft Client", "root.main", "\$PROJECT_DIR\$/run")
+		Files.readString(launchFile.parent.resolve("backups/Minecraft_Client.xml.backup"), StandardCharsets.UTF_8) == expectedRunConfigXml("Minecraft Client", "root.main", "\$PROJECT_DIR\$/run")
+		Files.readString(launchFile.parent.resolve("backups/Minecraft_Client.xml.1.backup"), StandardCharsets.UTF_8) == expectedGradleRunConfigXml("Minecraft Client", ":runClient")
+	}
+
+	def "write launch file does not overwrite matching application config when other inputs change"() {
+		given:
+		def project = mockJavaProject("root")
+		def launchFile = project.file(".idea/runConfigurations/Minecraft_Client.xml").toPath()
+		Files.createDirectories(launchFile.parent)
+		Files.writeString(launchFile, EXPECTED, StandardCharsets.UTF_8)
+
+		def config = project.objects.newInstance(IdeaSyncTask.IntellijRunConfig)
+		config.runConfigXml.set(expectedRunConfigXml("Minecraft Client Updated", "root.main", "\$PROJECT_DIR\$/custom-run"))
+		config.runConfigType.set(IntellijRunConfigWriter.APPLICATION_TYPE)
+		config.launchFile.set(launchFile.toFile())
+
+		when:
+		config.writeLaunchFile()
+
+		then:
+		Files.readString(launchFile, StandardCharsets.UTF_8) == IdeaSyncTask.setClasspathModificationsInXml(EXPECTED, [])
+		Files.notExists(launchFile.parent.resolve("backups/Minecraft_Client.xml.backup"))
+	}
+
+	def "write launch file preserves user application options while updating classpath modifications"() {
+		given:
+		def project = mockJavaProject("root")
+		def launchFile = project.file(".idea/runConfigurations/Minecraft_Client.xml").toPath()
+		Files.createDirectories(launchFile.parent)
+		Files.writeString(launchFile, rawRunConfigXml("Minecraft Client", "main.test", "\$PROJECT_DIR\$/.run", "-Duser.custom=true"), StandardCharsets.UTF_8)
+
+		def config = project.objects.newInstance(IdeaSyncTask.IntellijRunConfig)
+		config.runConfigXml.set(expectedRunConfigXml("Minecraft Client", "main.test", "\$PROJECT_DIR\$/.run", ["/path/to/file.jar"]))
+		config.runConfigType.set(IntellijRunConfigWriter.APPLICATION_TYPE)
+		config.launchFile.set(launchFile.toFile())
+
+		when:
+		config.writeLaunchFile()
+
+		then:
+		def writtenXml = Files.readString(launchFile, StandardCharsets.UTF_8)
+		writtenXml.contains('value="-Duser.custom=true"')
+		writtenXml.contains('<classpathModifications><entry exclude="true" path="/path/to/file.jar"/></classpathModifications>')
+		Files.notExists(launchFile.parent.resolve("backups/Minecraft_Client.xml.backup"))
 	}
 
 	private String fromDummy() {
@@ -117,7 +222,7 @@ class IdeaSyncTaskTest extends Specification {
 		return project
 	}
 
-	private static RunConfigurationInternal mockRunConfig(Project project, String name, String displayName, boolean generateRunConfig) {
+	private static RunConfigurationInternal mockRunConfig(Project project, String name, String displayName, boolean generateRunConfig, boolean preferGradleTask) {
 		def run = project.objects.newInstance(RunConfigurationInternal.class, name)
 		run.isFinalised.set(true)
 		run.displayName.set(displayName)
@@ -129,27 +234,71 @@ class IdeaSyncTaskTest extends Specification {
 		run.sourceSet.set("main")
 		run.runDirectory.set(project.file(name == "server" ? "server-run" : "run"))
 		run.generateRunConfig.set(generateRunConfig)
+		run.preferGradleTask.set(preferGradleTask)
 		run.ideConfigFolder.set((String) null)
 		run.devLaunchMainClass.set("net.minecraft.client.Main")
 		return run
 	}
 
 	private static String expectedRunConfigXml(String displayName, String moduleName, String runDirectory) {
+		return expectedRunConfigXml(displayName, moduleName, runDirectory, [])
+	}
+
+	private static String expectedRunConfigXml(String displayName, String moduleName, String runDirectory, List<String> exclusions) {
+		def rawXml = rawRunConfigXml(displayName, moduleName, runDirectory, "")
+
+		try {
+			return IdeaSyncTask.setClasspathModificationsInXml(rawXml, exclusions)
+		} catch (Exception e) {
+			throw new RuntimeException(e)
+		}
+	}
+
+	private static String rawRunConfigXml(String displayName, String moduleName, String runDirectory, String vmParameters) {
 		return """\
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="${displayName}" type="Application" factoryName="Application" >
     <option name="MAIN_CLASS_NAME" value="net.minecraft.client.Main" />
     <module name="${moduleName}" />
     <option name="PROGRAM_PARAMETERS" value="" />
-    <option name="VM_PARAMETERS" value="" />
+    <option name="VM_PARAMETERS" value="${vmParameters}" />
     <option name="WORKING_DIRECTORY" value="${runDirectory}/" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>
     <envs>
-      
+
     </envs>
     <shortenClasspath name="ARGS_FILE" />
+  </configuration>
+</component>
+"""
+	}
+
+	private static String expectedGradleRunConfigXml(String displayName, String taskName) {
+		return """\
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="${displayName}" type="GradleRunConfiguration" factoryName="Gradle" >
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="\$PROJECT_DIR\$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="${taskName}" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
   </configuration>
 </component>
 """

--- a/src/test/groovy/net/fabricmc/loom/test/util/GradleTestUtil.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/util/GradleTestUtil.groovy
@@ -64,8 +64,19 @@ class GradleTestUtil {
 	}
 
 	static Project mockProject() {
+		return mockProject("test")
+	}
+
+	static Project mockProject(String name) {
 		def extension = mockLoomGradleExtension()
-		def realProject = ProjectBuilder.builder().build()
+		def realProject = ProjectBuilder.builder().withName(name).build()
+		realProject.extensions.add("loom", extension)
+		return realProject
+	}
+
+	static Project mockProject(String name, Project parent) {
+		def extension = mockLoomGradleExtension()
+		def realProject = ProjectBuilder.builder().withName(name).withParent(parent).build()
 		realProject.extensions.add("loom", extension)
 		return realProject
 	}


### PR DESCRIPTION
- Added `RunConfiguration.getPreferGradleTask()` so generated IDE run configs can prefer to use the matching Gradle run task when supported (Only intelij for now).
- Existing generated run configs are only fully replaced when the run config type changes.
- Preserved user-edited application run config options while still refreshing `classpathModifications`.
- Added backup creation for replaced run configs, with numbered backups so older backups are never overwritten.
- Added unit coverage for generation, overwrite behavior, classpath modification updates, and backup rotation.