### PR TITLE
Initial provider migration of Configurations

### DIFF
--- a/src/main/java/net/fabricmc/loom/build/mixin/AnnotationProcessorInvoker.java
+++ b/src/main/java/net/fabricmc/loom/build/mixin/AnnotationProcessorInvoker.java
@@ -141,8 +141,8 @@ public abstract class AnnotationProcessorInvoker<T extends Task> {
 				project.getLogger().info("Adding mixin to classpath of AP config: " + processorConfig.getName());
 				// Pass named MC classpath to mixin AP classpath
 				processorConfig.extendsFrom(
-						configs.getByName(Constants.Configurations.LOADER_DEPENDENCIES),
-						configs.getByName(Constants.Configurations.MAPPINGS_FINAL)
+						configs.named(Constants.Configurations.LOADER_DEPENDENCIES),
+						configs.named(Constants.Configurations.MAPPINGS_FINAL)
 				);
 
 				// Add Mixin and mixin extensions (fabric-mixin-compile-extensions pulls mixin itself too)

--- a/src/main/java/net/fabricmc/loom/configuration/LoomConfigurations.java
+++ b/src/main/java/net/fabricmc/loom/configuration/LoomConfigurations.java
@@ -60,8 +60,8 @@ public abstract class LoomConfigurations implements Runnable {
 		var minecraftServerCompile = registerNonTransitive(Constants.Configurations.MINECRAFT_SERVER_COMPILE_LIBRARIES, Role.RESOLVABLE);
 		var minecraftCompile = registerNonTransitive(Constants.Configurations.MINECRAFT_COMPILE_LIBRARIES, Role.RESOLVABLE);
 		minecraftCompile.configure(configuration -> {
-			configuration.extendsFrom(minecraftClientCompile.get());
-			configuration.extendsFrom(minecraftServerCompile.get());
+			configuration.extendsFrom(minecraftClientCompile);
+			configuration.extendsFrom(minecraftServerCompile);
 		});
 
 		// Set up the minecraft runtime configurations, this extends from the compile configurations.
@@ -69,12 +69,12 @@ public abstract class LoomConfigurations implements Runnable {
 		var minecraftServerRuntime = registerNonTransitive(Constants.Configurations.MINECRAFT_SERVER_RUNTIME_LIBRARIES, Role.RESOLVABLE);
 
 		// Runtime extends from compile
-		minecraftClientRuntime.configure(configuration -> configuration.extendsFrom(minecraftClientCompile.get()));
-		minecraftServerRuntime.configure(configuration -> configuration.extendsFrom(minecraftServerCompile.get()));
+		minecraftClientRuntime.configure(configuration -> configuration.extendsFrom(minecraftClientCompile));
+		minecraftServerRuntime.configure(configuration -> configuration.extendsFrom(minecraftServerCompile));
 
 		registerNonTransitive(Constants.Configurations.MINECRAFT_RUNTIME_LIBRARIES, Role.RESOLVABLE).configure(minecraftRuntime -> {
-			minecraftRuntime.extendsFrom(minecraftClientRuntime.get());
-			minecraftRuntime.extendsFrom(minecraftServerRuntime.get());
+			minecraftRuntime.extendsFrom(minecraftClientRuntime);
+			minecraftRuntime.extendsFrom(minecraftServerRuntime);
 		});
 
 		registerNonTransitive(Constants.Configurations.MINECRAFT_NATIVES, Role.RESOLVABLE);
@@ -88,7 +88,7 @@ public abstract class LoomConfigurations implements Runnable {
 			registerNonTransitive(Constants.Configurations.MAPPING_CONSTANTS, Role.RESOLVABLE);
 
 			register(Constants.Configurations.NAMED_ELEMENTS, Role.CONSUMABLE).configure(configuration -> {
-				configuration.extendsFrom(getConfigurations().getByName(JavaPlugin.API_CONFIGURATION_NAME));
+				configuration.extendsFrom(getConfigurations().named(JavaPlugin.API_CONFIGURATION_NAME));
 			});
 
 			extendsFrom(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME, Constants.Configurations.MAPPING_CONSTANTS);
@@ -132,7 +132,7 @@ public abstract class LoomConfigurations implements Runnable {
 	}
 
 	public void extendsFrom(String a, String b) {
-		getConfigurations().getByName(a, configuration -> configuration.extendsFrom(getConfigurations().getByName(b)));
+		getConfigurations().named(a, configuration -> configuration.extendsFrom(getConfigurations().named(b)));
 	}
 
 	public enum Role {

--- a/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
+++ b/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
@@ -30,12 +30,12 @@ import java.util.function.Function;
 
 import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectList;
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.jetbrains.annotations.VisibleForTesting;
 
@@ -106,9 +106,9 @@ public final class RemapConfigurations {
 	 * @param settings the remap configuration settings
 	 * @param runtime  if {@code true}, returns the runtime configuration;
 	 *                 if {@code false}, returns the compile-time one
-	 * @return the collector configuration
+	 * @return the collector configuration provider
 	 */
-	public static Provider<Configuration> getOrRegisterCollectorConfiguration(Project project, RemapConfigurationSettings settings, boolean runtime) {
+	public static NamedDomainObjectProvider<? extends Configuration> getOrRegisterCollectorConfiguration(Project project, RemapConfigurationSettings settings, boolean runtime) {
 		return getOrRegisterCollectorConfiguration(project, settings.getSourceSet().get(), runtime);
 	}
 
@@ -120,12 +120,12 @@ public final class RemapConfigurations {
 	 * @param sourceSet the source set to apply the collector config to, should generally match {@link RemapConfigurationSettings#getSourceSet()}
 	 * @param runtime   if {@code true}, returns the runtime configuration;
 	 *                  if {@code false}, returns the compile-time one
-	 * @return the collector configuration
+	 * @return the collector configuration provider
 	 */
 	// Note: this method is generally called on demand, so these configurations
 	// won't exist at buildscript evaluation time. There's no need for them anyway
 	// since they're internals.
-	public static Provider<Configuration> getOrRegisterCollectorConfiguration(Project project, SourceSet sourceSet, boolean runtime) {
+	public static NamedDomainObjectProvider<? extends Configuration> getOrRegisterCollectorConfiguration(Project project, SourceSet sourceSet, boolean runtime) {
 		final String configurationName = "mod"
 				+ (runtime ? "Runtime" : "Compile")
 				+ "Classpath"
@@ -134,7 +134,7 @@ public final class RemapConfigurations {
 		final ConfigurationContainer configurations = project.getConfigurations();
 
 		if (configurations.findByName(configurationName) == null) {
-			Provider<Configuration> configuration = configurations.register(configurationName, config -> {
+			NamedDomainObjectProvider<? extends Configuration> configuration = configurations.register(configurationName, config -> {
 				// Don't get transitive deps of already remapped mods
 				config.setTransitive(false);
 
@@ -170,7 +170,7 @@ public final class RemapConfigurations {
 	}
 
 	public static void applyToProject(Project project, RemapConfigurationSettings settings) {
-		final Provider<Configuration> configuration = project.getConfigurations().register(settings.getName(), config -> config.setTransitive(true));
+		final NamedDomainObjectProvider<Configuration> configuration = project.getConfigurations().register(settings.getName(), config -> config.setTransitive(true));
 
 		if (settings.getOnCompileClasspath().get()) {
 			extendsFrom(Constants.Configurations.MOD_COMPILE_CLASSPATH, configuration, project);
@@ -195,7 +195,7 @@ public final class RemapConfigurations {
 		};
 	}
 
-	private static void extendsFrom(String name, Provider<Configuration> configuration, Project project) {
+	private static void extendsFrom(String name, NamedDomainObjectProvider<? extends Configuration> configuration, Project project) {
 		project.getConfigurations().named(name).configure(namedConfiguration -> {
 			namedConfiguration.extendsFrom(configuration);
 		});

--- a/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
+++ b/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
@@ -35,6 +35,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.jetbrains.annotations.VisibleForTesting;
 
@@ -85,7 +86,7 @@ public final class RemapConfigurations {
 
 		// Apply the client target names to the main configurations
 		for (ConfigurationOption option : getValidOptions(mainSourceSet)) {
-			configurations.getByName(option.name(mainSourceSet), settings -> {
+			configurations.named(option.name(mainSourceSet), settings -> {
 				String name = option.targetName(clientSourceSet);
 
 				if (name == null) {
@@ -107,8 +108,8 @@ public final class RemapConfigurations {
 	 *                 if {@code false}, returns the compile-time one
 	 * @return the collector configuration
 	 */
-	public static Configuration getOrCreateCollectorConfiguration(Project project, RemapConfigurationSettings settings, boolean runtime) {
-		return getOrCreateCollectorConfiguration(project, settings.getSourceSet().get(), runtime);
+	public static Provider<Configuration> getOrRegisterCollectorConfiguration(Project project, RemapConfigurationSettings settings, boolean runtime) {
+		return getOrRegisterCollectorConfiguration(project, settings.getSourceSet().get(), runtime);
 	}
 
 	/**
@@ -124,26 +125,25 @@ public final class RemapConfigurations {
 	// Note: this method is generally called on demand, so these configurations
 	// won't exist at buildscript evaluation time. There's no need for them anyway
 	// since they're internals.
-	public static Configuration getOrCreateCollectorConfiguration(Project project, SourceSet sourceSet, boolean runtime) {
+	public static Provider<Configuration> getOrRegisterCollectorConfiguration(Project project, SourceSet sourceSet, boolean runtime) {
 		final String configurationName = "mod"
 				+ (runtime ? "Runtime" : "Compile")
 				+ "Classpath"
 				+ Strings.capitalize(sourceSet.getName())
 				+ "Mapped";
 		final ConfigurationContainer configurations = project.getConfigurations();
-		Configuration configuration = configurations.findByName(configurationName);
 
-		if (configuration == null) {
-			configuration = configurations.create(configurationName);
+		if (configurations.findByName(configurationName) == null) {
+			Provider<Configuration> configuration = configurations.register(configurationName, config -> {
+				// Don't get transitive deps of already remapped mods
+				config.setTransitive(false);
 
-			// Don't get transitive deps of already remapped mods
-			configuration.setTransitive(false);
-
-			// Set the usage attribute to fetch the correct artifacts.
-			// Note: Even though most deps are resolved via copies of mod* configurations,
-			// non-remapped mods that get added straight to these collectors will need the attribute.
-			final Usage usage = project.getObjects().named(Usage.class, runtime ? Usage.JAVA_RUNTIME : Usage.JAVA_API);
-			configuration.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
+				// Set the usage attribute to fetch the correct artifacts.
+				// Note: Even though most deps are resolved via copies of mod* configurations,
+				// non-remapped mods that get added straight to these collectors will need the attribute.
+				final Usage usage = project.getObjects().named(Usage.class, runtime ? Usage.JAVA_RUNTIME : Usage.JAVA_API);
+				config.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
+			});
 
 			// The main classpath also applies to the test source set like with normal dependencies.
 			final boolean isMainSourceSet = sourceSet.getName().equals("main");
@@ -162,16 +162,15 @@ public final class RemapConfigurations {
 					extendsFrom(JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME, configuration, project);
 				}
 			}
-		}
 
-		return configuration;
+			return configuration;
+		} else {
+			return configurations.named(configurationName);
+		}
 	}
 
 	public static void applyToProject(Project project, RemapConfigurationSettings settings) {
-		// No point bothering to make it lazily, gradle realises configurations right away.
-		// <https://github.com/gradle/gradle/blob/v7.4.2/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePlugin.java#L104>
-		final Configuration configuration = project.getConfigurations().create(settings.getName());
-		configuration.setTransitive(true);
+		final Provider<Configuration> configuration = project.getConfigurations().register(settings.getName(), config -> config.setTransitive(true));
 
 		if (settings.getOnCompileClasspath().get()) {
 			extendsFrom(Constants.Configurations.MOD_COMPILE_CLASSPATH, configuration, project);
@@ -196,7 +195,7 @@ public final class RemapConfigurations {
 		};
 	}
 
-	private static void extendsFrom(String name, Configuration configuration, Project project) {
+	private static void extendsFrom(String name, Provider<Configuration> configuration, Project project) {
 		project.getConfigurations().named(name).configure(namedConfiguration -> {
 			namedConfiguration.extendsFrom(configuration);
 		});

--- a/src/main/java/net/fabricmc/loom/configuration/fabricapi/FabricApiAbstractSourceSet.java
+++ b/src/main/java/net/fabricmc/loom/configuration/fabricapi/FabricApiAbstractSourceSet.java
@@ -86,9 +86,7 @@ abstract class FabricApiAbstractSourceSet {
 	private static void extendsFrom(Project project, String name, String extendsFrom) {
 		final ConfigurationContainer configurations = project.getConfigurations();
 
-		configurations.named(name, configuration -> {
-			configuration.extendsFrom(configurations.getByName(extendsFrom));
-		});
+		configurations.named(name, configuration -> configuration.extendsFrom(configurations.named(extendsFrom)));
 	}
 
 	private void dependsOn(SourceSet sourceSet, SourceSet other) {

--- a/src/main/java/net/fabricmc/loom/configuration/fabricapi/FabricApiDataGeneration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/fabricapi/FabricApiDataGeneration.java
@@ -124,7 +124,7 @@ public abstract class FabricApiDataGeneration extends FabricApiAbstractSourceSet
 		final ConfigurationContainer configurations = project.getConfigurations();
 
 		configurations.named(name, configuration -> {
-			configuration.extendsFrom(configurations.getByName(extendsFrom));
+			configuration.extendsFrom(configurations.named(extendsFrom));
 		});
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactRef.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactRef.java
@@ -29,13 +29,13 @@ import static net.fabricmc.loom.configuration.mods.ModConfigurationRemapper.repl
 
 import java.nio.file.Path;
 
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
-import org.gradle.api.provider.Provider;
 import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.util.Checksum;
@@ -53,7 +53,7 @@ public interface ArtifactRef {
 
 	@Nullable String classifier();
 
-	void applyToConfiguration(Project project, Provider<Configuration> configuration);
+	void applyToConfiguration(Project project, NamedDomainObjectProvider<? extends Configuration> configuration);
 
 	record ResolvedArtifactRef(ResolvedArtifact artifact, @Nullable Path sources) implements ArtifactRef {
 		@Override
@@ -78,7 +78,7 @@ public interface ArtifactRef {
 		}
 
 		@Override
-		public void applyToConfiguration(Project project, Provider<Configuration> configuration) {
+		public void applyToConfiguration(Project project, NamedDomainObjectProvider<? extends Configuration> configuration) {
 			final DependencyHandler dependencies = project.getDependencies();
 
 			Dependency dep = dependencies.create(artifact.getModuleVersion() + (artifact.getClassifier() == null ? "" : ':' + artifact.getClassifier())); // the owning module of the artifact
@@ -87,7 +87,7 @@ public interface ArtifactRef {
 				moduleDependency.setTransitive(false);
 			}
 
-			dependencies.add(configuration.get().getName(), dep);
+			dependencies.add(configuration.getName(), dep);
 		}
 	}
 
@@ -103,10 +103,10 @@ public interface ArtifactRef {
 		}
 
 		@Override
-		public void applyToConfiguration(Project project, Provider<Configuration> configuration) {
+		public void applyToConfiguration(Project project, NamedDomainObjectProvider<? extends Configuration> configuration) {
 			final DependencyHandler dependencies = project.getDependencies();
 
-			dependencies.add(configuration.get().getName(), project.files(path.toFile()));
+			dependencies.add(configuration.getName(), project.files(path.toFile()));
 		}
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactRef.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactRef.java
@@ -35,6 +35,7 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.provider.Provider;
 import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.util.Checksum;
@@ -52,7 +53,7 @@ public interface ArtifactRef {
 
 	@Nullable String classifier();
 
-	void applyToConfiguration(Project project, Configuration configuration);
+	void applyToConfiguration(Project project, Provider<Configuration> configuration);
 
 	record ResolvedArtifactRef(ResolvedArtifact artifact, @Nullable Path sources) implements ArtifactRef {
 		@Override
@@ -77,7 +78,7 @@ public interface ArtifactRef {
 		}
 
 		@Override
-		public void applyToConfiguration(Project project, Configuration configuration) {
+		public void applyToConfiguration(Project project, Provider<Configuration> configuration) {
 			final DependencyHandler dependencies = project.getDependencies();
 
 			Dependency dep = dependencies.create(artifact.getModuleVersion() + (artifact.getClassifier() == null ? "" : ':' + artifact.getClassifier())); // the owning module of the artifact
@@ -86,7 +87,7 @@ public interface ArtifactRef {
 				moduleDependency.setTransitive(false);
 			}
 
-			dependencies.add(configuration.getName(), dep);
+			dependencies.add(configuration.get().getName(), dep);
 		}
 	}
 
@@ -102,10 +103,10 @@ public interface ArtifactRef {
 		}
 
 		@Override
-		public void applyToConfiguration(Project project, Configuration configuration) {
+		public void applyToConfiguration(Project project, Provider<Configuration> configuration) {
 			final DependencyHandler dependencies = project.getDependencies();
 
-			dependencies.add(configuration.getName(), project.files(path.toFile()));
+			dependencies.add(configuration.get().getName(), project.files(path.toFile()));
 		}
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
@@ -55,6 +55,7 @@ import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.jvm.JvmLibrary;
 import org.gradle.language.base.artifact.SourcesArtifact;
@@ -90,9 +91,9 @@ public class ModConfigurationRemapper {
 		final DependencyHandler dependencies = project.getDependencies();
 		// The configurations where the source and remapped artifacts go.
 		// key: source, value: target
-		final Map<Configuration, Configuration> configsToRemap = new LinkedHashMap<>();
+		final Map<Provider<Configuration>, Provider<Configuration>> configsToRemap = new LinkedHashMap<>();
 		// Client remapped dep collectors for split source sets. Same keys and values.
-		final Map<Configuration, Configuration> clientConfigsToRemap = new HashMap<>();
+		final Map<Provider<Configuration>, Provider<Configuration>> clientConfigsToRemap = new HashMap<>();
 
 		/*
 		 * Hack fix/improvement for https://github.com/FabricMC/fabric-loom/issues/1012
@@ -113,19 +114,22 @@ public class ModConfigurationRemapper {
 			envToEnabled.forEach((runtime, enabled) -> {
 				if (!enabled) return;
 
-				final Configuration target = RemapConfigurations.getOrCreateCollectorConfiguration(project, entry, runtime);
+				final Provider<Configuration> target = RemapConfigurations.getOrRegisterCollectorConfiguration(project, entry, runtime);
 				// We copy the source with the desired usage type to get only the runtime or api jars, not both.
-				final Configuration sourceCopy = entry.getSourceConfiguration().get().copyRecursive();
-				final Usage usage = project.getObjects().named(Usage.class, runtime ? Usage.JAVA_RUNTIME : Usage.JAVA_API);
-				sourceCopy.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
-				sourceCopy.setCanBeConsumed(false);
+				Provider<Configuration> sourceCopy = entry.getSourceConfiguration().map(source -> {
+					Configuration copy = source.copyRecursive();
+					Usage usage = project.getObjects().named(Usage.class, runtime ? Usage.JAVA_RUNTIME : Usage.JAVA_API);
+					copy.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
+					copy.setCanBeConsumed(false);
+					return copy;
+				});
 				configsToRemap.put(sourceCopy, target);
 
 				// If our remap configuration entry targets the client source set as well,
 				// let's set up a collector for it too.
 				if (entry.getClientSourceConfigurationName().isPresent()) {
 					final SourceSet clientSourceSet = SourceSetHelper.getSourceSetByName(MinecraftSourceSets.Split.CLIENT_ONLY_SOURCE_SET_NAME, project);
-					final Configuration clientTarget = RemapConfigurations.getOrCreateCollectorConfiguration(project, clientSourceSet, runtime);
+					final Provider<Configuration> clientTarget = RemapConfigurations.getOrRegisterCollectorConfiguration(project, clientSourceSet, runtime);
 					clientConfigsToRemap.put(sourceCopy, clientTarget);
 				}
 			});
@@ -135,10 +139,9 @@ public class ModConfigurationRemapper {
 				// Note: legacy (pre-1.1) behavior is kept for this remapping since
 				// we don't have a modApiElements/modRuntimeElements kind of configuration.
 				// TODO: Expose API/runtime usage attributes for namedElements to make it work like normal project dependencies.
-				final Configuration remappedConfig = project.getConfigurations().maybeCreate(entry.getRemappedConfigurationName());
-				remappedConfig.setTransitive(false);
-				project.getConfigurations().getByName(Constants.Configurations.NAMED_ELEMENTS).extendsFrom(remappedConfig);
-				configsToRemap.put(entry.getSourceConfiguration().get(), remappedConfig);
+				final Provider<Configuration> remappedConfig = project.getConfigurations().register(entry.getRemappedConfigurationName(), config -> config.setTransitive(false));
+				project.getConfigurations().named(Constants.Configurations.NAMED_ELEMENTS).configure(config -> config.extendsFrom(remappedConfig));
+				configsToRemap.put(entry.getSourceConfiguration(), remappedConfig);
 			}
 		}
 
@@ -155,14 +158,14 @@ public class ModConfigurationRemapper {
 		// Go through all the configs to find artifacts to remap and
 		// the installer data. The installer data has to be added before
 		// any mods are remapped since remapping needs the dependencies provided by that data.
-		final Map<Configuration, List<ModDependency>> dependenciesBySourceConfig = new HashMap<>();
+		final Map<Provider<Configuration>, List<ModDependency>> dependenciesBySourceConfig = new HashMap<>();
 		AsyncCache<ArtifactMetadata> metaCache = new AsyncCache<>();
 		configsToRemap.forEach((sourceConfig, remappedConfig) -> {
 			/*
 			sourceConfig - The source configuration where the intermediary named artifacts come from. i.e "modApi"
 			remappedConfig - The target configuration where the remapped artifacts go
 			 */
-			final Configuration clientRemappedConfig = clientConfigsToRemap.get(sourceConfig);
+			final Provider<Configuration> clientRemappedConfig = clientConfigsToRemap.get(sourceConfig);
 			List<ArtifactRef> artifactRefs = resolveArtifacts(project, sourceConfig);
 			Map<ArtifactRef, ArtifactMetadata> metadataMap = getMetadata(artifactRefs, metaCache, extension.getDefaultMixinRemapTypeEnum().get());
 			final List<ModDependency> modDependencies = new ArrayList<>();
@@ -204,7 +207,7 @@ public class ModConfigurationRemapper {
 				return;
 			}
 
-			final Configuration clientRemappedConfig = clientConfigsToRemap.get(sourceConfig);
+			final Provider<Configuration> clientRemappedConfig = clientConfigsToRemap.get(sourceConfig);
 			final boolean refreshDeps = LoomGradleExtension.get(project).refreshDeps();
 			// TODO: With the same artifacts being considered multiple times for their different
 			//   usage attributes, this should probably not process them multiple times even with refreshDeps.
@@ -250,7 +253,7 @@ public class ModConfigurationRemapper {
 		return AsyncCache.joinMap(futures);
 	}
 
-	private static void createConstraints(ArtifactRef artifact, Configuration targetConfig, Configuration sourceConfig, DependencyHandler dependencies) {
+	private static void createConstraints(ArtifactRef artifact, Provider<Configuration> targetConfig, Provider<Configuration> sourceConfig, DependencyHandler dependencies) {
 		if (true) {
 			// Disabled due to the gradle module metadata causing issues. Try the MavenProject test to reproduce issue.
 			return;
@@ -260,10 +263,10 @@ public class ModConfigurationRemapper {
 			final String dependencyCoordinate = "%s:%s".formatted(mavenArtifact.group(), mavenArtifact.name());
 
 			// Prevent adding the same un-remapped dependency to the target configuration.
-			targetConfig.getDependencyConstraints().add(dependencies.getConstraints().create(dependencyCoordinate, constraint -> {
+			targetConfig.get().getDependencyConstraints().add(dependencies.getConstraints().create(dependencyCoordinate, constraint -> {
 				constraint.because("configuration (%s) already contains the remapped module from configuration (%s)".formatted(
-						targetConfig.getName(),
-						sourceConfig.getName()
+						targetConfig.get().getName(),
+						sourceConfig.get().getName()
 				));
 
 				constraint.version(MutableVersionConstraint::rejectAll);
@@ -271,10 +274,10 @@ public class ModConfigurationRemapper {
 		}
 	}
 
-	private static List<ArtifactRef> resolveArtifacts(Project project, Configuration configuration) {
+	private static List<ArtifactRef> resolveArtifacts(Project project, Provider<Configuration> configuration) {
 		final List<ArtifactRef> artifacts = new ArrayList<>();
 
-		final Set<ResolvedArtifact> resolvedArtifacts = configuration.getResolvedConfiguration().getResolvedArtifacts();
+		final Set<ResolvedArtifact> resolvedArtifacts = configuration.get().getResolvedConfiguration().getResolvedArtifacts();
 		Map<ResolvedArtifact, Path> sourcesMap = downloadAllSources(project, resolvedArtifacts);
 
 		for (ResolvedArtifact artifact : resolvedArtifacts) {
@@ -284,7 +287,7 @@ public class ModConfigurationRemapper {
 
 		// FileCollectionDependency (files/fileTree) doesn't resolve properly,
 		// so we have to "resolve" it on our own. The naming is "abc.jar" => "unspecified:abc:unspecified".
-		for (FileCollectionDependency dependency : configuration.getAllDependencies().withType(FileCollectionDependency.class)) {
+		for (FileCollectionDependency dependency : configuration.get().getAllDependencies().withType(FileCollectionDependency.class)) {
 			final String group = replaceIfNullOrEmpty(dependency.getGroup(), () -> MISSING_GROUP);
 			final FileCollection files = dependency.getFiles();
 

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
@@ -45,7 +45,6 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.FileCollectionDependency;
 import org.gradle.api.artifacts.MutableVersionConstraint;
-import org.gradle.api.artifacts.ResolvableConfiguration;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -117,11 +116,17 @@ public class ModConfigurationRemapper {
 
 				final NamedDomainObjectProvider<? extends Configuration> target = RemapConfigurations.getOrRegisterCollectorConfiguration(project, entry, runtime);
 				// We copy the source with the desired usage type to get only the runtime or api jars, not both.
-				NamedDomainObjectProvider<ResolvableConfiguration> sourceCopy = project.getConfigurations().resolvable(entry.getSourceConfiguration().getName() + "Copy", config -> {
-					config.extendsFrom(entry.getSourceConfiguration());
-					Usage usage = project.getObjects().named(Usage.class, runtime ? Usage.JAVA_RUNTIME : Usage.JAVA_API);
-					config.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
-				});
+				final String name = entry.getSourceConfiguration().getName() + "Copy";
+				NamedDomainObjectProvider<? extends Configuration> sourceCopy;
+				if (project.getConfigurations().findByName(name) != null) {
+					sourceCopy = project.getConfigurations().named(name);
+				} else {
+					sourceCopy = project.getConfigurations().resolvable(name, config -> {
+						config.extendsFrom(entry.getSourceConfiguration());
+						Usage usage = project.getObjects().named(Usage.class, runtime ? Usage.JAVA_RUNTIME : Usage.JAVA_API);
+						config.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
+					});
+				}
 				configsToRemap.put(sourceCopy, target);
 
 				// If our remap configuration entry targets the client source set as well,

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
@@ -117,16 +117,11 @@ public class ModConfigurationRemapper {
 				final NamedDomainObjectProvider<? extends Configuration> target = RemapConfigurations.getOrRegisterCollectorConfiguration(project, entry, runtime);
 				// We copy the source with the desired usage type to get only the runtime or api jars, not both.
 				final String name = entry.getSourceConfiguration().getName() + "Copy";
-				NamedDomainObjectProvider<? extends Configuration> sourceCopy;
-				if (project.getConfigurations().findByName(name) != null) {
-					sourceCopy = project.getConfigurations().named(name);
-				} else {
-					sourceCopy = project.getConfigurations().resolvable(name, config -> {
-						config.extendsFrom(entry.getSourceConfiguration());
-						Usage usage = project.getObjects().named(Usage.class, runtime ? Usage.JAVA_RUNTIME : Usage.JAVA_API);
-						config.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
-					});
-				}
+				final NamedDomainObjectProvider<? extends Configuration> sourceCopy = project.getConfigurations().resolvable(name, config -> {
+					config.extendsFrom(entry.getSourceConfiguration());
+					Usage usage = project.getObjects().named(Usage.class, runtime ? Usage.JAVA_RUNTIME : Usage.JAVA_API);
+					config.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
+				});
 				configsToRemap.put(sourceCopy, target);
 
 				// If our remap configuration entry targets the client source set as well,

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
@@ -40,6 +40,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.FileCollectionDependency;
@@ -91,9 +92,9 @@ public class ModConfigurationRemapper {
 		final DependencyHandler dependencies = project.getDependencies();
 		// The configurations where the source and remapped artifacts go.
 		// key: source, value: target
-		final Map<Provider<Configuration>, Provider<Configuration>> configsToRemap = new LinkedHashMap<>();
+		final Map<Provider<? extends Configuration>, NamedDomainObjectProvider<? extends Configuration>> configsToRemap = new LinkedHashMap<>();
 		// Client remapped dep collectors for split source sets. Same keys and values.
-		final Map<Provider<Configuration>, Provider<Configuration>> clientConfigsToRemap = new HashMap<>();
+		final Map<Provider<? extends Configuration>, NamedDomainObjectProvider<? extends Configuration>> clientConfigsToRemap = new HashMap<>();
 
 		/*
 		 * Hack fix/improvement for https://github.com/FabricMC/fabric-loom/issues/1012
@@ -114,9 +115,9 @@ public class ModConfigurationRemapper {
 			envToEnabled.forEach((runtime, enabled) -> {
 				if (!enabled) return;
 
-				final Provider<Configuration> target = RemapConfigurations.getOrRegisterCollectorConfiguration(project, entry, runtime);
+				final NamedDomainObjectProvider<? extends Configuration> target = RemapConfigurations.getOrRegisterCollectorConfiguration(project, entry, runtime);
 				// We copy the source with the desired usage type to get only the runtime or api jars, not both.
-				Provider<Configuration> sourceCopy = entry.getSourceConfiguration().map(source -> {
+				Provider<? extends Configuration> sourceCopy = entry.getSourceConfiguration().map(source -> {
 					Configuration copy = source.copyRecursive();
 					Usage usage = project.getObjects().named(Usage.class, runtime ? Usage.JAVA_RUNTIME : Usage.JAVA_API);
 					copy.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
@@ -129,7 +130,7 @@ public class ModConfigurationRemapper {
 				// let's set up a collector for it too.
 				if (entry.getClientSourceConfigurationName().isPresent()) {
 					final SourceSet clientSourceSet = SourceSetHelper.getSourceSetByName(MinecraftSourceSets.Split.CLIENT_ONLY_SOURCE_SET_NAME, project);
-					final Provider<Configuration> clientTarget = RemapConfigurations.getOrRegisterCollectorConfiguration(project, clientSourceSet, runtime);
+					final NamedDomainObjectProvider<? extends Configuration> clientTarget = RemapConfigurations.getOrRegisterCollectorConfiguration(project, clientSourceSet, runtime);
 					clientConfigsToRemap.put(sourceCopy, clientTarget);
 				}
 			});
@@ -139,7 +140,7 @@ public class ModConfigurationRemapper {
 				// Note: legacy (pre-1.1) behavior is kept for this remapping since
 				// we don't have a modApiElements/modRuntimeElements kind of configuration.
 				// TODO: Expose API/runtime usage attributes for namedElements to make it work like normal project dependencies.
-				final Provider<Configuration> remappedConfig = project.getConfigurations().register(entry.getRemappedConfigurationName(), config -> config.setTransitive(false));
+				final NamedDomainObjectProvider<? extends Configuration> remappedConfig = project.getConfigurations().register(entry.getRemappedConfigurationName(), config -> config.setTransitive(false));
 				project.getConfigurations().named(Constants.Configurations.NAMED_ELEMENTS).configure(config -> config.extendsFrom(remappedConfig));
 				configsToRemap.put(entry.getSourceConfiguration(), remappedConfig);
 			}
@@ -158,14 +159,14 @@ public class ModConfigurationRemapper {
 		// Go through all the configs to find artifacts to remap and
 		// the installer data. The installer data has to be added before
 		// any mods are remapped since remapping needs the dependencies provided by that data.
-		final Map<Provider<Configuration>, List<ModDependency>> dependenciesBySourceConfig = new HashMap<>();
+		final Map<Provider<? extends Configuration>, List<ModDependency>> dependenciesBySourceConfig = new HashMap<>();
 		AsyncCache<ArtifactMetadata> metaCache = new AsyncCache<>();
 		configsToRemap.forEach((sourceConfig, remappedConfig) -> {
 			/*
 			sourceConfig - The source configuration where the intermediary named artifacts come from. i.e "modApi"
 			remappedConfig - The target configuration where the remapped artifacts go
 			 */
-			final Provider<Configuration> clientRemappedConfig = clientConfigsToRemap.get(sourceConfig);
+			final Provider<? extends Configuration> clientRemappedConfig = clientConfigsToRemap.get(sourceConfig);
 			List<ArtifactRef> artifactRefs = resolveArtifacts(project, sourceConfig);
 			Map<ArtifactRef, ArtifactMetadata> metadataMap = getMetadata(artifactRefs, metaCache, extension.getDefaultMixinRemapTypeEnum().get());
 			final List<ModDependency> modDependencies = new ArrayList<>();
@@ -207,7 +208,7 @@ public class ModConfigurationRemapper {
 				return;
 			}
 
-			final Provider<Configuration> clientRemappedConfig = clientConfigsToRemap.get(sourceConfig);
+			final NamedDomainObjectProvider<? extends Configuration> clientRemappedConfig = clientConfigsToRemap.get(sourceConfig);
 			final boolean refreshDeps = LoomGradleExtension.get(project).refreshDeps();
 			// TODO: With the same artifacts being considered multiple times for their different
 			//   usage attributes, this should probably not process them multiple times even with refreshDeps.
@@ -253,7 +254,7 @@ public class ModConfigurationRemapper {
 		return AsyncCache.joinMap(futures);
 	}
 
-	private static void createConstraints(ArtifactRef artifact, Provider<Configuration> targetConfig, Provider<Configuration> sourceConfig, DependencyHandler dependencies) {
+	private static void createConstraints(ArtifactRef artifact, NamedDomainObjectProvider<? extends Configuration> targetConfig, Provider<? extends Configuration> sourceConfig, DependencyHandler dependencies) {
 		if (true) {
 			// Disabled due to the gradle module metadata causing issues. Try the MavenProject test to reproduce issue.
 			return;
@@ -265,7 +266,7 @@ public class ModConfigurationRemapper {
 			// Prevent adding the same un-remapped dependency to the target configuration.
 			targetConfig.get().getDependencyConstraints().add(dependencies.getConstraints().create(dependencyCoordinate, constraint -> {
 				constraint.because("configuration (%s) already contains the remapped module from configuration (%s)".formatted(
-						targetConfig.get().getName(),
+						targetConfig.getName(),
 						sourceConfig.get().getName()
 				));
 
@@ -274,7 +275,7 @@ public class ModConfigurationRemapper {
 		}
 	}
 
-	private static List<ArtifactRef> resolveArtifacts(Project project, Provider<Configuration> configuration) {
+	private static List<ArtifactRef> resolveArtifacts(Project project, Provider<? extends Configuration> configuration) {
 		final List<ArtifactRef> artifacts = new ArrayList<>();
 
 		final Set<ResolvedArtifact> resolvedArtifacts = configuration.get().getResolvedConfiguration().getResolvedArtifacts();

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
@@ -56,6 +56,7 @@ import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.jvm.JvmLibrary;
 import org.gradle.language.base.artifact.SourcesArtifact;
@@ -91,9 +92,9 @@ public class ModConfigurationRemapper {
 		final DependencyHandler dependencies = project.getDependencies();
 		// The configurations where the source and remapped artifacts go.
 		// key: source, value: target
-		final Map<NamedDomainObjectProvider<? extends Configuration>, NamedDomainObjectProvider<? extends Configuration>> configsToRemap = new LinkedHashMap<>();
+		final Map<Provider<? extends Configuration>, NamedDomainObjectProvider<? extends Configuration>> configsToRemap = new LinkedHashMap<>();
 		// Client remapped dep collectors for split source sets. Same keys and values.
-		final Map<NamedDomainObjectProvider<? extends Configuration>, NamedDomainObjectProvider<? extends Configuration>> clientConfigsToRemap = new HashMap<>();
+		final Map<Provider<? extends Configuration>, NamedDomainObjectProvider<? extends Configuration>> clientConfigsToRemap = new HashMap<>();
 
 		/*
 		 * Hack fix/improvement for https://github.com/FabricMC/fabric-loom/issues/1012
@@ -116,11 +117,11 @@ public class ModConfigurationRemapper {
 
 				final NamedDomainObjectProvider<? extends Configuration> target = RemapConfigurations.getOrRegisterCollectorConfiguration(project, entry, runtime);
 				// We copy the source with the desired usage type to get only the runtime or api jars, not both.
-				final String name = entry.getSourceConfiguration().getName() + "Copy";
-				final NamedDomainObjectProvider<? extends Configuration> sourceCopy = project.getConfigurations().resolvable(name, config -> {
-					config.extendsFrom(entry.getSourceConfiguration());
+				Provider<? extends Configuration> sourceCopy = entry.getSourceConfiguration().map(source -> {
+					Configuration copy = source.copyRecursive();
 					Usage usage = project.getObjects().named(Usage.class, runtime ? Usage.JAVA_RUNTIME : Usage.JAVA_API);
-					config.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
+					copy.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
+					return copy;
 				});
 				configsToRemap.put(sourceCopy, target);
 
@@ -157,7 +158,7 @@ public class ModConfigurationRemapper {
 		// Go through all the configs to find artifacts to remap and
 		// the installer data. The installer data has to be added before
 		// any mods are remapped since remapping needs the dependencies provided by that data.
-		final Map<NamedDomainObjectProvider<? extends Configuration>, List<ModDependency>> dependenciesBySourceConfig = new HashMap<>();
+		final Map<Provider<? extends Configuration>, List<ModDependency>> dependenciesBySourceConfig = new HashMap<>();
 		AsyncCache<ArtifactMetadata> metaCache = new AsyncCache<>();
 		configsToRemap.forEach((sourceConfig, remappedConfig) -> {
 			/*
@@ -252,7 +253,7 @@ public class ModConfigurationRemapper {
 		return AsyncCache.joinMap(futures);
 	}
 
-	private static void createConstraints(ArtifactRef artifact, NamedDomainObjectProvider<? extends Configuration> targetConfig, NamedDomainObjectProvider<? extends Configuration> sourceConfig, DependencyHandler dependencies) {
+	private static void createConstraints(ArtifactRef artifact, NamedDomainObjectProvider<? extends Configuration> targetConfig, Provider<? extends Configuration> sourceConfig, DependencyHandler dependencies) {
 		if (true) {
 			// Disabled due to the gradle module metadata causing issues. Try the MavenProject test to reproduce issue.
 			return;
@@ -265,7 +266,7 @@ public class ModConfigurationRemapper {
 			targetConfig.get().getDependencyConstraints().add(dependencies.getConstraints().create(dependencyCoordinate, constraint -> {
 				constraint.because("configuration (%s) already contains the remapped module from configuration (%s)".formatted(
 						targetConfig.getName(),
-						sourceConfig.getName()
+						sourceConfig.get().getName()
 				));
 
 				constraint.version(MutableVersionConstraint::rejectAll);
@@ -273,7 +274,7 @@ public class ModConfigurationRemapper {
 		}
 	}
 
-	private static List<ArtifactRef> resolveArtifacts(Project project, NamedDomainObjectProvider<? extends Configuration> configuration) {
+	private static List<ArtifactRef> resolveArtifacts(Project project, Provider<? extends Configuration> configuration) {
 		final List<ArtifactRef> artifacts = new ArrayList<>();
 
 		final Set<ResolvedArtifact> resolvedArtifacts = configuration.get().getResolvedConfiguration().getResolvedArtifacts();

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModConfigurationRemapper.java
@@ -45,6 +45,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.FileCollectionDependency;
 import org.gradle.api.artifacts.MutableVersionConstraint;
+import org.gradle.api.artifacts.ResolvableConfiguration;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -56,7 +57,6 @@ import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.jvm.JvmLibrary;
 import org.gradle.language.base.artifact.SourcesArtifact;
@@ -92,9 +92,9 @@ public class ModConfigurationRemapper {
 		final DependencyHandler dependencies = project.getDependencies();
 		// The configurations where the source and remapped artifacts go.
 		// key: source, value: target
-		final Map<Provider<? extends Configuration>, NamedDomainObjectProvider<? extends Configuration>> configsToRemap = new LinkedHashMap<>();
+		final Map<NamedDomainObjectProvider<? extends Configuration>, NamedDomainObjectProvider<? extends Configuration>> configsToRemap = new LinkedHashMap<>();
 		// Client remapped dep collectors for split source sets. Same keys and values.
-		final Map<Provider<? extends Configuration>, NamedDomainObjectProvider<? extends Configuration>> clientConfigsToRemap = new HashMap<>();
+		final Map<NamedDomainObjectProvider<? extends Configuration>, NamedDomainObjectProvider<? extends Configuration>> clientConfigsToRemap = new HashMap<>();
 
 		/*
 		 * Hack fix/improvement for https://github.com/FabricMC/fabric-loom/issues/1012
@@ -117,12 +117,10 @@ public class ModConfigurationRemapper {
 
 				final NamedDomainObjectProvider<? extends Configuration> target = RemapConfigurations.getOrRegisterCollectorConfiguration(project, entry, runtime);
 				// We copy the source with the desired usage type to get only the runtime or api jars, not both.
-				Provider<? extends Configuration> sourceCopy = entry.getSourceConfiguration().map(source -> {
-					Configuration copy = source.copyRecursive();
+				NamedDomainObjectProvider<ResolvableConfiguration> sourceCopy = project.getConfigurations().resolvable(entry.getSourceConfiguration().getName() + "Copy", config -> {
+					config.extendsFrom(entry.getSourceConfiguration());
 					Usage usage = project.getObjects().named(Usage.class, runtime ? Usage.JAVA_RUNTIME : Usage.JAVA_API);
-					copy.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
-					copy.setCanBeConsumed(false);
-					return copy;
+					config.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
 				});
 				configsToRemap.put(sourceCopy, target);
 
@@ -159,14 +157,14 @@ public class ModConfigurationRemapper {
 		// Go through all the configs to find artifacts to remap and
 		// the installer data. The installer data has to be added before
 		// any mods are remapped since remapping needs the dependencies provided by that data.
-		final Map<Provider<? extends Configuration>, List<ModDependency>> dependenciesBySourceConfig = new HashMap<>();
+		final Map<NamedDomainObjectProvider<? extends Configuration>, List<ModDependency>> dependenciesBySourceConfig = new HashMap<>();
 		AsyncCache<ArtifactMetadata> metaCache = new AsyncCache<>();
 		configsToRemap.forEach((sourceConfig, remappedConfig) -> {
 			/*
 			sourceConfig - The source configuration where the intermediary named artifacts come from. i.e "modApi"
 			remappedConfig - The target configuration where the remapped artifacts go
 			 */
-			final Provider<? extends Configuration> clientRemappedConfig = clientConfigsToRemap.get(sourceConfig);
+			final NamedDomainObjectProvider<? extends Configuration> clientRemappedConfig = clientConfigsToRemap.get(sourceConfig);
 			List<ArtifactRef> artifactRefs = resolveArtifacts(project, sourceConfig);
 			Map<ArtifactRef, ArtifactMetadata> metadataMap = getMetadata(artifactRefs, metaCache, extension.getDefaultMixinRemapTypeEnum().get());
 			final List<ModDependency> modDependencies = new ArrayList<>();
@@ -254,7 +252,7 @@ public class ModConfigurationRemapper {
 		return AsyncCache.joinMap(futures);
 	}
 
-	private static void createConstraints(ArtifactRef artifact, NamedDomainObjectProvider<? extends Configuration> targetConfig, Provider<? extends Configuration> sourceConfig, DependencyHandler dependencies) {
+	private static void createConstraints(ArtifactRef artifact, NamedDomainObjectProvider<? extends Configuration> targetConfig, NamedDomainObjectProvider<? extends Configuration> sourceConfig, DependencyHandler dependencies) {
 		if (true) {
 			// Disabled due to the gradle module metadata causing issues. Try the MavenProject test to reproduce issue.
 			return;
@@ -267,7 +265,7 @@ public class ModConfigurationRemapper {
 			targetConfig.get().getDependencyConstraints().add(dependencies.getConstraints().create(dependencyCoordinate, constraint -> {
 				constraint.because("configuration (%s) already contains the remapped module from configuration (%s)".formatted(
 						targetConfig.getName(),
-						sourceConfig.get().getName()
+						sourceConfig.getName()
 				));
 
 				constraint.version(MutableVersionConstraint::rejectAll);
@@ -275,7 +273,7 @@ public class ModConfigurationRemapper {
 		}
 	}
 
-	private static List<ArtifactRef> resolveArtifacts(Project project, Provider<? extends Configuration> configuration) {
+	private static List<ArtifactRef> resolveArtifacts(Project project, NamedDomainObjectProvider<? extends Configuration> configuration) {
 		final List<ArtifactRef> artifacts = new ArrayList<>();
 
 		final Set<ResolvedArtifact> resolvedArtifacts = configuration.get().getResolvedConfiguration().getResolvedArtifacts();

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModProcessor.java
@@ -79,10 +79,10 @@ public class ModProcessor {
 	private static final Pattern COPY_CONFIGURATION_PATTERN = Pattern.compile("^(.+)Copy[0-9]*$");
 
 	private final Project project;
-	private final Provider<Configuration> sourceConfiguration;
+	private final Provider<? extends Configuration> sourceConfiguration;
 	private final ServiceFactory serviceFactory;
 
-	public ModProcessor(Project project, Provider<Configuration> sourceConfiguration, ServiceFactory serviceFactory) {
+	public ModProcessor(Project project, Provider<? extends Configuration> sourceConfiguration, ServiceFactory serviceFactory) {
 		this.project = project;
 		this.sourceConfiguration = sourceConfiguration;
 		this.serviceFactory = serviceFactory;
@@ -100,7 +100,7 @@ public class ModProcessor {
 	// Creates a human-readable descriptive string for the configuration.
 	// This consists primarily of the name with any copy suffixes stripped
 	// (they're not informative), and the usage attribute if present.
-	private String describeConfiguration(Provider<Configuration> configuration) {
+	private String describeConfiguration(Provider<? extends Configuration> configuration) {
 		String description = configuration.get().getName();
 		final Matcher copyMatcher = COPY_CONFIGURATION_PATTERN.matcher(description);
 

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModProcessor.java
@@ -43,10 +43,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.gson.JsonObject;
-import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.attributes.Usage;
+import org.gradle.api.provider.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,10 +79,10 @@ public class ModProcessor {
 	private static final Pattern COPY_CONFIGURATION_PATTERN = Pattern.compile("^(.+)Copy[0-9]*$");
 
 	private final Project project;
-	private final NamedDomainObjectProvider<? extends Configuration> sourceConfiguration;
+	private final Provider<? extends Configuration> sourceConfiguration;
 	private final ServiceFactory serviceFactory;
 
-	public ModProcessor(Project project, NamedDomainObjectProvider<? extends Configuration> sourceConfiguration, ServiceFactory serviceFactory) {
+	public ModProcessor(Project project, Provider<? extends Configuration> sourceConfiguration, ServiceFactory serviceFactory) {
 		this.project = project;
 		this.sourceConfiguration = sourceConfiguration;
 		this.serviceFactory = serviceFactory;
@@ -100,8 +100,8 @@ public class ModProcessor {
 	// Creates a human-readable descriptive string for the configuration.
 	// This consists primarily of the name with any copy suffixes stripped
 	// (they're not informative), and the usage attribute if present.
-	private String describeConfiguration(NamedDomainObjectProvider<? extends Configuration> configuration) {
-		String description = configuration.getName();
+	private String describeConfiguration(Provider<? extends Configuration> configuration) {
+		String description = configuration.get().getName();
 		final Matcher copyMatcher = COPY_CONFIGURATION_PATTERN.matcher(description);
 
 		// If we find a copy suffix, remove it.

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModProcessor.java
@@ -43,10 +43,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.gson.JsonObject;
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.attributes.Usage;
-import org.gradle.api.provider.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,10 +79,10 @@ public class ModProcessor {
 	private static final Pattern COPY_CONFIGURATION_PATTERN = Pattern.compile("^(.+)Copy[0-9]*$");
 
 	private final Project project;
-	private final Provider<? extends Configuration> sourceConfiguration;
+	private final NamedDomainObjectProvider<? extends Configuration> sourceConfiguration;
 	private final ServiceFactory serviceFactory;
 
-	public ModProcessor(Project project, Provider<? extends Configuration> sourceConfiguration, ServiceFactory serviceFactory) {
+	public ModProcessor(Project project, NamedDomainObjectProvider<? extends Configuration> sourceConfiguration, ServiceFactory serviceFactory) {
 		this.project = project;
 		this.sourceConfiguration = sourceConfiguration;
 		this.serviceFactory = serviceFactory;
@@ -100,8 +100,8 @@ public class ModProcessor {
 	// Creates a human-readable descriptive string for the configuration.
 	// This consists primarily of the name with any copy suffixes stripped
 	// (they're not informative), and the usage attribute if present.
-	private String describeConfiguration(Provider<? extends Configuration> configuration) {
-		String description = configuration.get().getName();
+	private String describeConfiguration(NamedDomainObjectProvider<? extends Configuration> configuration) {
+		String description = configuration.getName();
 		final Matcher copyMatcher = COPY_CONFIGURATION_PATTERN.matcher(description);
 
 		// If we find a copy suffix, remove it.

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModProcessor.java
@@ -46,6 +46,7 @@ import com.google.gson.JsonObject;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.attributes.Usage;
+import org.gradle.api.provider.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,10 +79,10 @@ public class ModProcessor {
 	private static final Pattern COPY_CONFIGURATION_PATTERN = Pattern.compile("^(.+)Copy[0-9]*$");
 
 	private final Project project;
-	private final Configuration sourceConfiguration;
+	private final Provider<Configuration> sourceConfiguration;
 	private final ServiceFactory serviceFactory;
 
-	public ModProcessor(Project project, Configuration sourceConfiguration, ServiceFactory serviceFactory) {
+	public ModProcessor(Project project, Provider<Configuration> sourceConfiguration, ServiceFactory serviceFactory) {
 		this.project = project;
 		this.sourceConfiguration = sourceConfiguration;
 		this.serviceFactory = serviceFactory;
@@ -99,8 +100,8 @@ public class ModProcessor {
 	// Creates a human-readable descriptive string for the configuration.
 	// This consists primarily of the name with any copy suffixes stripped
 	// (they're not informative), and the usage attribute if present.
-	private String describeConfiguration(Configuration configuration) {
-		String description = configuration.getName();
+	private String describeConfiguration(Provider<Configuration> configuration) {
+		String description = configuration.get().getName();
 		final Matcher copyMatcher = COPY_CONFIGURATION_PATTERN.matcher(description);
 
 		// If we find a copy suffix, remove it.
@@ -114,7 +115,7 @@ public class ModProcessor {
 		}
 
 		// Add the usage if present, e.g. "modImplementation (java-api)"
-		final Usage usage = configuration.getAttributes().getAttribute(Usage.USAGE_ATTRIBUTE);
+		final Usage usage = configuration.get().getAttributes().getAttribute(Usage.USAGE_ATTRIBUTE);
 
 		if (usage != null) {
 			description += " (" + usage.getName() + ")";

--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/ModDependencyFactory.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/ModDependencyFactory.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.provider.Provider;
 import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradleExtension;
@@ -41,7 +42,7 @@ import net.fabricmc.loom.util.AttributeHelper;
 public class ModDependencyFactory {
 	private static final String TARGET_ATTRIBUTE_KEY = "loom-target";
 
-	public static ModDependency create(ArtifactRef artifact, ArtifactMetadata metadata, Configuration targetConfig, @Nullable Configuration targetClientConfig, ModDependencyOptions options, Project project) {
+	public static ModDependency create(ArtifactRef artifact, ArtifactMetadata metadata, Provider<Configuration> targetConfig, @Nullable Provider<Configuration> targetClientConfig, ModDependencyOptions options, Project project) {
 		if (targetClientConfig != null && LoomGradleExtension.get(project).getSplitModDependencies().get()) {
 			final Optional<JarSplitter.Target> cachedTarget = readTarget(artifact);
 			JarSplitter.Target target;

--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/ModDependencyFactory.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/ModDependencyFactory.java
@@ -42,7 +42,7 @@ import net.fabricmc.loom.util.AttributeHelper;
 public class ModDependencyFactory {
 	private static final String TARGET_ATTRIBUTE_KEY = "loom-target";
 
-	public static ModDependency create(ArtifactRef artifact, ArtifactMetadata metadata, Provider<Configuration> targetConfig, @Nullable Provider<Configuration> targetClientConfig, ModDependencyOptions options, Project project) {
+	public static ModDependency create(ArtifactRef artifact, ArtifactMetadata metadata, Provider<? extends Configuration> targetConfig, @Nullable Provider<? extends Configuration> targetClientConfig, ModDependencyOptions options, Project project) {
 		if (targetClientConfig != null && LoomGradleExtension.get(project).getSplitModDependencies().get()) {
 			final Optional<JarSplitter.Target> cachedTarget = readTarget(artifact);
 			JarSplitter.Target target;

--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/ModDependencyFactory.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/ModDependencyFactory.java
@@ -28,9 +28,9 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Optional;
 
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.provider.Provider;
 import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradleExtension;
@@ -42,7 +42,7 @@ import net.fabricmc.loom.util.AttributeHelper;
 public class ModDependencyFactory {
 	private static final String TARGET_ATTRIBUTE_KEY = "loom-target";
 
-	public static ModDependency create(ArtifactRef artifact, ArtifactMetadata metadata, Provider<? extends Configuration> targetConfig, @Nullable Provider<? extends Configuration> targetClientConfig, ModDependencyOptions options, Project project) {
+	public static ModDependency create(ArtifactRef artifact, ArtifactMetadata metadata, NamedDomainObjectProvider<? extends Configuration> targetConfig, @Nullable NamedDomainObjectProvider<? extends Configuration> targetClientConfig, ModDependencyOptions options, Project project) {
 		if (targetClientConfig != null && LoomGradleExtension.get(project).getSplitModDependencies().get()) {
 			final Optional<JarSplitter.Target> cachedTarget = readTarget(artifact);
 			JarSplitter.Target target;

--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SimpleModDependency.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SimpleModDependency.java
@@ -28,9 +28,9 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Objects;
 
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.provider.Provider;
 import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.configuration.mods.ArtifactMetadata;
@@ -38,10 +38,10 @@ import net.fabricmc.loom.configuration.mods.ArtifactRef;
 
 // Single jar in and out
 public final class SimpleModDependency extends ModDependency {
-	private final Provider<? extends Configuration> targetConfig;
+	private final NamedDomainObjectProvider<? extends Configuration> targetConfig;
 	private final LocalMavenHelper maven;
 
-	public SimpleModDependency(ArtifactRef artifact, ArtifactMetadata metadata, ModDependencyOptions options, Provider<? extends Configuration> targetConfig, Project project) {
+	public SimpleModDependency(ArtifactRef artifact, ArtifactMetadata metadata, ModDependencyOptions options, NamedDomainObjectProvider<? extends Configuration> targetConfig, Project project) {
 		super(artifact, metadata, options);
 		this.targetConfig = Objects.requireNonNull(targetConfig);
 		this.maven = createMavenHelper(project, null);
@@ -59,6 +59,6 @@ public final class SimpleModDependency extends ModDependency {
 
 	@Override
 	public void applyToProject(Project project) {
-		project.getDependencies().add(targetConfig.get().getName(), maven.getNotation());
+		project.getDependencies().add(targetConfig.getName(), maven.getNotation());
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SimpleModDependency.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SimpleModDependency.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.provider.Provider;
 import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.configuration.mods.ArtifactMetadata;
@@ -40,9 +41,9 @@ public final class SimpleModDependency extends ModDependency {
 	private final Configuration targetConfig;
 	private final LocalMavenHelper maven;
 
-	public SimpleModDependency(ArtifactRef artifact, ArtifactMetadata metadata, ModDependencyOptions options, Configuration targetConfig, Project project) {
+	public SimpleModDependency(ArtifactRef artifact, ArtifactMetadata metadata, ModDependencyOptions options, Provider<Configuration> targetConfig, Project project) {
 		super(artifact, metadata, options);
-		this.targetConfig = Objects.requireNonNull(targetConfig);
+		this.targetConfig = Objects.requireNonNull(targetConfig.get());
 		this.maven = createMavenHelper(project, null);
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SimpleModDependency.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SimpleModDependency.java
@@ -38,12 +38,12 @@ import net.fabricmc.loom.configuration.mods.ArtifactRef;
 
 // Single jar in and out
 public final class SimpleModDependency extends ModDependency {
-	private final Configuration targetConfig;
+	private final Provider<? extends Configuration> targetConfig;
 	private final LocalMavenHelper maven;
 
-	public SimpleModDependency(ArtifactRef artifact, ArtifactMetadata metadata, ModDependencyOptions options, Provider<Configuration> targetConfig, Project project) {
+	public SimpleModDependency(ArtifactRef artifact, ArtifactMetadata metadata, ModDependencyOptions options, Provider<? extends Configuration> targetConfig, Project project) {
 		super(artifact, metadata, options);
-		this.targetConfig = Objects.requireNonNull(targetConfig.get());
+		this.targetConfig = Objects.requireNonNull(targetConfig);
 		this.maven = createMavenHelper(project, null);
 	}
 
@@ -59,6 +59,6 @@ public final class SimpleModDependency extends ModDependency {
 
 	@Override
 	public void applyToProject(Project project) {
-		project.getDependencies().add(targetConfig.getName(), maven.getNotation());
+		project.getDependencies().add(targetConfig.get().getName(), maven.getNotation());
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SplitModDependency.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SplitModDependency.java
@@ -41,18 +41,18 @@ import net.fabricmc.loom.configuration.mods.JarSplitter;
 
 // Single jar in, 2 out.
 public final class SplitModDependency extends ModDependency {
-	private final Configuration targetCommonConfig;
-	private final Configuration targetClientConfig;
+	private final Provider<? extends Configuration> targetCommonConfig;
+	private final Provider<? extends Configuration> targetClientConfig;
 	private final JarSplitter.Target target;
 	@Nullable
 	private final LocalMavenHelper commonMaven;
 	@Nullable
 	private final LocalMavenHelper clientMaven;
 
-	public SplitModDependency(ArtifactRef artifact, ArtifactMetadata metadata, ModDependencyOptions options, Provider<Configuration> targetCommonConfig, Provider<Configuration> targetClientConfig, JarSplitter.Target target, Project project) {
+	public SplitModDependency(ArtifactRef artifact, ArtifactMetadata metadata, ModDependencyOptions options, Provider<? extends Configuration> targetCommonConfig, Provider<? extends Configuration> targetClientConfig, JarSplitter.Target target, Project project) {
 		super(artifact, metadata, options);
-		this.targetCommonConfig = Objects.requireNonNull(targetCommonConfig.get());
-		this.targetClientConfig = Objects.requireNonNull(targetClientConfig.get());
+		this.targetCommonConfig = Objects.requireNonNull(targetCommonConfig);
+		this.targetClientConfig = Objects.requireNonNull(targetClientConfig);
 		this.target = Objects.requireNonNull(target);
 		this.commonMaven = target.common() ? createMavenHelper(project, "common") : null;
 		this.clientMaven = target.client() ? createMavenHelper(project, "client") : null;
@@ -106,11 +106,11 @@ public final class SplitModDependency extends ModDependency {
 	@Override
 	public void applyToProject(Project project) {
 		if (target.common()) {
-			project.getDependencies().add(targetCommonConfig.getName(), getCommonMaven().getNotation());
+			project.getDependencies().add(targetCommonConfig.get().getName(), getCommonMaven().getNotation());
 		}
 
 		if (target.client()) {
-			project.getDependencies().add(targetClientConfig.getName(), getClientMaven().getNotation());
+			project.getDependencies().add(targetClientConfig.get().getName(), getClientMaven().getNotation());
 		}
 
 		if (target == JarSplitter.Target.SPLIT) {

--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SplitModDependency.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SplitModDependency.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.provider.Provider;
 import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradleExtension;
@@ -48,10 +49,10 @@ public final class SplitModDependency extends ModDependency {
 	@Nullable
 	private final LocalMavenHelper clientMaven;
 
-	public SplitModDependency(ArtifactRef artifact, ArtifactMetadata metadata, ModDependencyOptions options, Configuration targetCommonConfig, Configuration targetClientConfig, JarSplitter.Target target, Project project) {
+	public SplitModDependency(ArtifactRef artifact, ArtifactMetadata metadata, ModDependencyOptions options, Provider<Configuration> targetCommonConfig, Provider<Configuration> targetClientConfig, JarSplitter.Target target, Project project) {
 		super(artifact, metadata, options);
-		this.targetCommonConfig = Objects.requireNonNull(targetCommonConfig);
-		this.targetClientConfig = Objects.requireNonNull(targetClientConfig);
+		this.targetCommonConfig = Objects.requireNonNull(targetCommonConfig.get());
+		this.targetClientConfig = Objects.requireNonNull(targetClientConfig.get());
 		this.target = Objects.requireNonNull(target);
 		this.commonMaven = target.common() ? createMavenHelper(project, "common") : null;
 		this.clientMaven = target.client() ? createMavenHelper(project, "client") : null;

--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SplitModDependency.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/SplitModDependency.java
@@ -28,9 +28,9 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Objects;
 
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.provider.Provider;
 import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradleExtension;
@@ -41,15 +41,15 @@ import net.fabricmc.loom.configuration.mods.JarSplitter;
 
 // Single jar in, 2 out.
 public final class SplitModDependency extends ModDependency {
-	private final Provider<? extends Configuration> targetCommonConfig;
-	private final Provider<? extends Configuration> targetClientConfig;
+	private final NamedDomainObjectProvider<? extends Configuration> targetCommonConfig;
+	private final NamedDomainObjectProvider<? extends Configuration> targetClientConfig;
 	private final JarSplitter.Target target;
 	@Nullable
 	private final LocalMavenHelper commonMaven;
 	@Nullable
 	private final LocalMavenHelper clientMaven;
 
-	public SplitModDependency(ArtifactRef artifact, ArtifactMetadata metadata, ModDependencyOptions options, Provider<? extends Configuration> targetCommonConfig, Provider<? extends Configuration> targetClientConfig, JarSplitter.Target target, Project project) {
+	public SplitModDependency(ArtifactRef artifact, ArtifactMetadata metadata, ModDependencyOptions options, NamedDomainObjectProvider<? extends Configuration> targetCommonConfig, NamedDomainObjectProvider<? extends Configuration> targetClientConfig, JarSplitter.Target target, Project project) {
 		super(artifact, metadata, options);
 		this.targetCommonConfig = Objects.requireNonNull(targetCommonConfig);
 		this.targetClientConfig = Objects.requireNonNull(targetClientConfig);
@@ -106,11 +106,11 @@ public final class SplitModDependency extends ModDependency {
 	@Override
 	public void applyToProject(Project project) {
 		if (target.common()) {
-			project.getDependencies().add(targetCommonConfig.get().getName(), getCommonMaven().getNotation());
+			project.getDependencies().add(targetCommonConfig.getName(), getCommonMaven().getNotation());
 		}
 
 		if (target.client()) {
-			project.getDependencies().add(targetClientConfig.get().getName(), getClientMaven().getNotation());
+			project.getDependencies().add(targetClientConfig.getName(), getClientMaven().getNotation());
 		}
 
 		if (target == JarSplitter.Target.SPLIT) {

--- a/src/main/java/net/fabricmc/loom/configuration/processors/speccontext/DeobfSpecContext.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/speccontext/DeobfSpecContext.java
@@ -134,11 +134,9 @@ public record DeobfSpecContext(List<FabricModJson> modDependencies,
 		var futures = new ArrayList<CompletableFuture<List<FabricModJson>>>();
 
 		for (File artifact : projectView.getFullClasspath().getFiles()) {
-			futures.add(fmjCache.get(artifact.toPath().toAbsolutePath().toString(), () -> {
-				return getMod(artifact.toPath())
-						.map(List::of)
-						.orElseGet(List::of);
-			}));
+			futures.add(fmjCache.get(artifact.toPath().toAbsolutePath().toString(), () -> getMod(artifact.toPath())
+					.map(List::of)
+					.orElseGet(List::of)));
 		}
 
 		if (!projectView.disableProjectDependantMods()) {

--- a/src/main/java/net/fabricmc/loom/configuration/processors/speccontext/RemappedProjectView.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/speccontext/RemappedProjectView.java
@@ -31,8 +31,9 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.gradle.api.NamedDomainObjectList;
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ResolvableConfiguration;
 import org.gradle.api.attributes.Usage;
 
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
@@ -59,10 +60,11 @@ public interface RemappedProjectView extends ProjectView {
 			final Usage usage = project.getObjects().named(Usage.class, artifactUsage.getGradleUsage());
 
 			return settings -> {
-				final Configuration configuration = settings.getSourceConfiguration().get().copyRecursive();
-				configuration.setCanBeConsumed(false);
-				configuration.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
-				return configuration.resolve().stream().map(File::toPath);
+				final NamedDomainObjectProvider<ResolvableConfiguration> configuration = project.getConfigurations().resolvable(settings.getSourceConfiguration().getName() + "Copy", config -> {
+					config.extendsFrom(settings.getSourceConfiguration());
+					config.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
+				});
+				return configuration.get().resolve().stream().map(File::toPath);
 			};
 		}
 

--- a/src/main/java/net/fabricmc/loom/configuration/processors/speccontext/RemappedProjectView.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/speccontext/RemappedProjectView.java
@@ -33,7 +33,7 @@ import java.util.stream.Stream;
 import org.gradle.api.NamedDomainObjectList;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.ResolvableConfiguration;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.attributes.Usage;
 
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
@@ -60,10 +60,16 @@ public interface RemappedProjectView extends ProjectView {
 			final Usage usage = project.getObjects().named(Usage.class, artifactUsage.getGradleUsage());
 
 			return settings -> {
-				final NamedDomainObjectProvider<ResolvableConfiguration> configuration = project.getConfigurations().resolvable(settings.getSourceConfiguration().getName() + "Copy", config -> {
-					config.extendsFrom(settings.getSourceConfiguration());
-					config.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
-				});
+				final String name = settings.getSourceConfiguration().getName() + "Copy";
+				NamedDomainObjectProvider<? extends Configuration> configuration;
+				if (project.getConfigurations().findByName(name) != null) {
+					configuration = project.getConfigurations().named(name);
+				} else {
+					configuration = project.getConfigurations().resolvable(name, config -> {
+						config.extendsFrom(settings.getSourceConfiguration());
+						config.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
+					});
+				}
 				return configuration.get().resolve().stream().map(File::toPath);
 			};
 		}

--- a/src/main/java/net/fabricmc/loom/configuration/processors/speccontext/RemappedProjectView.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/speccontext/RemappedProjectView.java
@@ -31,7 +31,6 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.gradle.api.NamedDomainObjectList;
-import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.attributes.Usage;
@@ -60,17 +59,11 @@ public interface RemappedProjectView extends ProjectView {
 			final Usage usage = project.getObjects().named(Usage.class, artifactUsage.getGradleUsage());
 
 			return settings -> {
-				final String name = settings.getSourceConfiguration().getName() + "Copy";
-				NamedDomainObjectProvider<? extends Configuration> configuration;
-				if (project.getConfigurations().findByName(name) != null) {
-					configuration = project.getConfigurations().named(name);
-				} else {
-					configuration = project.getConfigurations().resolvable(name, config -> {
-						config.extendsFrom(settings.getSourceConfiguration());
-						config.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
-					});
-				}
-				return configuration.get().resolve().stream().map(File::toPath);
+				final Configuration detached = project.getConfigurations().detachedConfiguration();
+				detached.extendsFrom(settings.getSourceConfiguration());
+				detached.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
+				detached.setCanBeConsumed(false);
+				return detached.resolve().stream().map(File::toPath);
 			};
 		}
 

--- a/src/main/java/net/fabricmc/loom/configuration/processors/speccontext/RemappedProjectView.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/speccontext/RemappedProjectView.java
@@ -59,11 +59,10 @@ public interface RemappedProjectView extends ProjectView {
 			final Usage usage = project.getObjects().named(Usage.class, artifactUsage.getGradleUsage());
 
 			return settings -> {
-				final Configuration detached = project.getConfigurations().detachedConfiguration();
-				detached.extendsFrom(settings.getSourceConfiguration());
-				detached.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
-				detached.setCanBeConsumed(false);
-				return detached.resolve().stream().map(File::toPath);
+				final Configuration configuration = settings.getSourceConfiguration().get().copyRecursive();
+				configuration.setCanBeConsumed(false);
+				configuration.attributes(attributes -> attributes.attribute(Usage.USAGE_ATTRIBUTE, usage));
+				return configuration.resolve().stream().map(File::toPath);
 			};
 		}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftLibraryProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftLibraryProvider.java
@@ -113,7 +113,7 @@ public class MinecraftLibraryProvider {
 
 		// After Minecraft 1.19-pre1 the natives should be on the runtime classpath.
 		if (!minecraftProvider.getVersionInfo().hasNativesToExtract()) {
-			project.getConfigurations().named(Constants.Configurations.MINECRAFT_RUNTIME_LIBRARIES, configuration -> configuration.extendsFrom(project.getConfigurations().getByName(Constants.Configurations.MINECRAFT_NATIVES)));
+			project.getConfigurations().named(Constants.Configurations.MINECRAFT_RUNTIME_LIBRARIES, configuration -> configuration.extendsFrom(project.getConfigurations().named(Constants.Configurations.MINECRAFT_NATIVES)));
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftSourceSets.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftSourceSets.java
@@ -60,21 +60,21 @@ public abstract sealed class MinecraftSourceSets permits MinecraftSourceSets.Sin
 
 	public abstract void afterEvaluate(Project project);
 
-	protected void createConfigurations(Project project) {
+	protected void registerConfigurations(Project project) {
 		final ConfigurationContainer configurations = project.getConfigurations();
 
 		for (ConfigurationName configurationName : getConfigurations()) {
 			configurations.register(configurationName.runtime(), configuration -> {
 				configuration.setTransitive(false);
-				configuration.extendsFrom(configurations.getByName(configurationName.mcLibsRuntimeName()));
-				configuration.extendsFrom(configurations.getByName(Constants.Configurations.LOADER_DEPENDENCIES));
-				configuration.extendsFrom(configurations.getByName(Constants.Configurations.LOOM_DEVELOPMENT_DEPENDENCIES));
+				configuration.extendsFrom(configurations.named(configurationName.mcLibsRuntimeName()));
+				configuration.extendsFrom(configurations.named(Constants.Configurations.LOADER_DEPENDENCIES));
+				configuration.extendsFrom(configurations.named(Constants.Configurations.LOOM_DEVELOPMENT_DEPENDENCIES));
 			});
 
 			configurations.register(configurationName.compile(), configuration -> {
 				configuration.setTransitive(false);
-				configuration.extendsFrom(configurations.getByName(configurationName.mcLibsCompileName()));
-				configuration.extendsFrom(configurations.getByName(Constants.Configurations.LOADER_DEPENDENCIES));
+				configuration.extendsFrom(configurations.named(configurationName.mcLibsCompileName()));
+				configuration.extendsFrom(configurations.named(Constants.Configurations.LOADER_DEPENDENCIES));
 			});
 		}
 	}
@@ -82,9 +82,7 @@ public abstract sealed class MinecraftSourceSets permits MinecraftSourceSets.Sin
 	protected void extendsFrom(Project project, String name, String extendsFrom) {
 		final ConfigurationContainer configurations = project.getConfigurations();
 
-		configurations.named(name, configuration -> {
-			configuration.extendsFrom(configurations.getByName(extendsFrom));
-		});
+		configurations.named(name, configuration -> configuration.extendsFrom(configurations.named(extendsFrom)));
 	}
 
 	/**
@@ -120,7 +118,7 @@ public abstract sealed class MinecraftSourceSets permits MinecraftSourceSets.Sin
 		@Override
 		public void afterEvaluate(Project project) {
 			// This is done in afterEvaluate as we need to be sure that split source sets was not enabled.
-			createConfigurations(project);
+			registerConfigurations(project);
 
 			extendsFrom(project, JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME, MINECRAFT_NAMED.compile());
 			extendsFrom(project, JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME, MINECRAFT_NAMED.runtime());
@@ -173,7 +171,7 @@ public abstract sealed class MinecraftSourceSets permits MinecraftSourceSets.Sin
 
 		// Called during evaluation, when the loom extension method is called.
 		private void evaluate(Project project) {
-			createConfigurations(project);
+			registerConfigurations(project);
 			final ConfigurationContainer configurations = project.getConfigurations();
 
 			// Register our new client only source set, main becomes common only, with their respective jars.
@@ -224,7 +222,7 @@ public abstract sealed class MinecraftSourceSets permits MinecraftSourceSets.Sin
 			// Remap with the client compile classpath.
 			project.getTasks().withType(AbstractRemapJarTask.class).configureEach(remapJarTask -> {
 				remapJarTask.getClasspath().from(
-						project.getConfigurations().getByName(clientOnlySourceSet.getCompileClasspathConfigurationName())
+						project.getConfigurations().named(clientOnlySourceSet.getCompileClasspathConfigurationName())
 				);
 			});
 

--- a/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
@@ -221,7 +221,7 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 		getClasspath().from(decompilerOptions.getClasspath()).finalizeValueOnRead();
 		dependsOn(decompilerOptions.getClasspath().getBuiltBy());
 
-		getMinecraftCompileLibraries().from(getProject().getConfigurations().getByName(Constants.Configurations.MINECRAFT_COMPILE_LIBRARIES));
+		getMinecraftCompileLibraries().from(getProject().getConfigurations().named(Constants.Configurations.MINECRAFT_COMPILE_LIBRARIES));
 		getDecompileCacheFile().set(getExtension().getFiles().getDecompileCache(CACHE_VERSION));
 
 		getUseCache().convention(true);

--- a/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
@@ -104,7 +104,7 @@ public abstract class RemapJarTask extends AbstractRemapJarTask {
 		super();
 		LoomGradleExtension extension = LoomGradleExtension.get(getProject());
 		final ConfigurationContainer configurations = getProject().getConfigurations();
-		getClasspath().from(configurations.getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
+		getClasspath().from(configurations.named(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
 		getAddNestedDependencies().convention(true).finalizeValueOnRead();
 		getOptimizeFabricModJson().convention(false).finalizeValueOnRead();
 

--- a/src/main/java/net/fabricmc/loom/task/RemapSourcesJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapSourcesJarTask.java
@@ -50,7 +50,7 @@ public abstract class RemapSourcesJarTask extends AbstractRemapJarTask {
 	@Inject
 	public RemapSourcesJarTask() {
 		super();
-		getClasspath().from(getProject().getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
+		getClasspath().from(getProject().getConfigurations().named(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
 		getJarType().set("sources");
 
 		getSourcesRemapperServiceOptions().set(SourceRemapperService.createOptions(this));

--- a/src/main/java/net/fabricmc/loom/task/service/MigrateMappingsService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/MigrateMappingsService.java
@@ -73,7 +73,7 @@ public final class MigrateMappingsService extends Service<MigrateMappingsService
 		final Provider<String> to = project.provider(() -> "named");
 
 		ConfigurableFileCollection classpath = project.getObjects().fileCollection();
-		classpath.from(project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
+		classpath.from(project.getConfigurations().named(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
 		// Question: why are both of these needed?
 		classpath.from(extension.getMinecraftJars(MappingsNamespace.INTERMEDIARY));
 		classpath.from(extension.getMinecraftJars(MappingsNamespace.NAMED));

--- a/src/main/java/net/fabricmc/loom/task/service/TinyRemapperService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/TinyRemapperService.java
@@ -141,19 +141,19 @@ public class TinyRemapperService extends Service<TinyRemapperService.Options> im
 			ConfigurableFileCollection files = project.files(extension.getMinecraftJars(MappingsNamespace.INTERMEDIARY));
 
 			if (classpathLibraries == ClasspathLibraries.INCLUDE) {
-				files = files.from(configurations.getByName(Constants.Configurations.MINECRAFT_COMPILE_LIBRARIES));
+				files = files.from(configurations.named(Constants.Configurations.MINECRAFT_COMPILE_LIBRARIES));
 			}
 
 			return files;
 		}
 
 		if (classpathLibraries == ClasspathLibraries.INCLUDE) {
-			return configurations.getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME);
+			return project.files(configurations.named(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
 		}
 
-		return configurations.getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
-				.minus(configurations.getByName(Constants.Configurations.MINECRAFT_COMPILE_LIBRARIES))
-				.minus(configurations.getByName(Constants.Configurations.MINECRAFT_RUNTIME_LIBRARIES));
+		return project.files(configurations.named(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME))
+				.minus(project.files(configurations.named(Constants.Configurations.MINECRAFT_COMPILE_LIBRARIES)))
+				.minus(project.files(configurations.named(Constants.Configurations.MINECRAFT_RUNTIME_LIBRARIES)));
 	}
 
 	public enum ClasspathLibraries {

--- a/src/main/java/net/fabricmc/loom/task/service/UnpickService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/UnpickService.java
@@ -134,9 +134,9 @@ public class UnpickService extends Service<UnpickService.Options> {
 			options.getUnpickDefinitions().set(mappingConfiguration.getUnpickDefinitionsFile());
 			options.getUnpickOutputJar().set(task.getInputJarName().map(s -> project.getLayout()
 					.dir(project.provider(() -> mappingsWorkingDir)).get().file(s + "-unpicked.jar")));
-			options.getUnpickConstantJar().setFrom(configurations.getByName(Constants.Configurations.MAPPING_CONSTANTS));
-			options.getUnpickClasspath().setFrom(configurations.getByName(Constants.Configurations.MINECRAFT_COMPILE_LIBRARIES));
-			options.getUnpickClasspath().from(configurations.getByName(Constants.Configurations.MOD_COMPILE_CLASSPATH_MAPPED));
+			options.getUnpickConstantJar().setFrom(configurations.named(Constants.Configurations.MAPPING_CONSTANTS));
+			options.getUnpickClasspath().setFrom(configurations.named(Constants.Configurations.MINECRAFT_COMPILE_LIBRARIES));
+			options.getUnpickClasspath().from(configurations.named(Constants.Configurations.MOD_COMPILE_CLASSPATH_MAPPED));
 			options.getLenient().set(unpickMetadata instanceof UnpickMetadata.V1);
 			extension.getMinecraftJars(MappingsNamespace.NAMED).forEach(options.getUnpickClasspath()::from);
 			return true;

--- a/src/main/java/net/fabricmc/loom/util/gradle/SourceSetHelper.java
+++ b/src/main/java/net/fabricmc/loom/util/gradle/SourceSetHelper.java
@@ -44,6 +44,7 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.SourceSetOutput;
@@ -150,12 +151,12 @@ public final class SourceSetHelper {
 			boolean isDebof = isLoom && LoomGradleExtension.get(reference.project()).disableObfuscation();
 			String configurationName = isLoom && !isDebof
 					? Constants.Configurations.NAMED_ELEMENTS : JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME;
-			final Configuration namedElements = reference.project().getConfigurations().getByName(configurationName);
+			final Provider<Configuration> namedElements = reference.project().getConfigurations().named(configurationName);
 
 			// Note: We're not looking at the artifacts from configuration variants. It's probably not needed
 			// (certainly not with Loom's setup), but technically someone could add child variants that add additional
 			// dev jars that wouldn't be picked up by this.
-			for (File artifact : namedElements.getOutgoing().getArtifacts().getFiles()) {
+			for (File artifact : namedElements.get().getOutgoing().getArtifacts().getFiles()) {
 				classpath.add(artifact);
 			}
 		}

--- a/src/main/java/net/fabricmc/loom/util/gradle/SourceSetHelper.java
+++ b/src/main/java/net/fabricmc/loom/util/gradle/SourceSetHelper.java
@@ -39,12 +39,12 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.SourceSetOutput;
@@ -151,7 +151,7 @@ public final class SourceSetHelper {
 			boolean isDebof = isLoom && LoomGradleExtension.get(reference.project()).disableObfuscation();
 			String configurationName = isLoom && !isDebof
 					? Constants.Configurations.NAMED_ELEMENTS : JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME;
-			final Provider<Configuration> namedElements = reference.project().getConfigurations().named(configurationName);
+			final NamedDomainObjectProvider<? extends Configuration> namedElements = reference.project().getConfigurations().named(configurationName);
 
 			// Note: We're not looking at the artifacts from configuration variants. It's probably not needed
 			// (certainly not with Loom's setup), but technically someone could add child variants that add additional


### PR DESCRIPTION
As per discussion on discord, this PR migrates `extendsFrom` calls to use Providers, along with a bit of other laziness improvements in regards to Configurations.