### PR TITLE
Be resilient to strict version resolution for Minecraft dependencies

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
@@ -32,6 +32,9 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ExternalModuleDependency;
+import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.provider.Property;
 import org.jspecify.annotations.Nullable;
 
@@ -69,7 +72,30 @@ public final class MinecraftMetadataProvider {
 
 	private static String resolveMinecraftVersion(Project project) {
 		final DependencyInfo dependency = DependencyInfo.create(project, Constants.Configurations.MINECRAFT);
-		return dependency.getDependency().getVersion();
+		return getMinecraftVersion(dependency.getDependency());
+	}
+
+	private static String getMinecraftVersion(Dependency dependency) {
+		if (dependency instanceof ExternalModuleDependency externalModuleDependency) {
+			final VersionConstraint versionConstraint = externalModuleDependency.getVersionConstraint();
+			final String preferredVersion = versionConstraint.getPreferredVersion();
+
+			if (!preferredVersion.isEmpty()) {
+				return preferredVersion;
+			}
+
+			final String strictVersion = versionConstraint.getStrictVersion();
+
+			if (!strictVersion.isEmpty() && !isVersionRange(strictVersion)) {
+				return strictVersion;
+			}
+		}
+
+		return dependency.getVersion();
+	}
+
+	private static boolean isVersionRange(String version) {
+		return version.startsWith("[") || version.startsWith("(");
 	}
 
 	public String getMinecraftVersion() {

--- a/src/test/groovy/net/fabricmc/loom/test/integration/StrictlyVersionTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/StrictlyVersionTest.groovy
@@ -1,0 +1,27 @@
+package net.fabricmc.loom.test.integration
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import net.fabricmc.loom.test.util.GradleProjectTestTrait
+
+import static net.fabricmc.loom.test.LoomTestConstants.STANDARD_TEST_VERSIONS
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class StrictlyVersionTest extends Specification implements GradleProjectTestTrait {
+	@Unroll
+	def "strictlyVersion (gradle #version)"() {
+		setup:
+		def gradle = gradleProject(project: "strictlyVersion", version: version)
+
+		when:
+		def result = gradle.run(task: "build")
+
+		then:
+		result.task(":build").outcome == SUCCESS
+
+		where:
+		version << STANDARD_TEST_VERSIONS
+	}
+}
+

--- a/src/test/resources/projects/strictlyVersion/build.gradle
+++ b/src/test/resources/projects/strictlyVersion/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+	id 'net.fabricmc.fabric-loom'
+}
+
+
+dependencies {
+	minecraft("com.mojang:minecraft") {
+		version {
+			prefer "26.1.2"
+			strictly "[26.1.2,26.2)"
+		}
+	}
+	implementation "net.fabricmc:fabric-loader:0.19.2"
+}
+
+base {
+	archivesName = "fabric-example-mod"
+}

--- a/src/test/resources/projects/strictlyVersion/gradle.properties
+++ b/src/test/resources/projects/strictlyVersion/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx1G

--- a/src/test/resources/projects/strictlyVersion/settings.gradle
+++ b/src/test/resources/projects/strictlyVersion/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "fabric-example-mod"
+


### PR DESCRIPTION
When someone does this:

```kt
dependencies {
	minecraft("com.mojang:minecraft") {
		version {
			prefer("26.1.2")
			strictly("[26.1.2,26.2)")
		}
	}
}
```

Loom previously tried to use the version range and failed to find a matching Minecraft version:

```
Caused by: java.lang.RuntimeException: Failed to find minecraft version: [26.1.2,26.2)
	at net.fabricmc.loom.configuration.providers.minecraft.MinecraftMetadataProvider.getVersionEntry(MinecraftMetadataProvider.java:130)
```

This PR tries to use `prefer` instead.

### Why do this in the first place?

Yes, doing the example above is stupid because strictly doesn't do anything.

But when using Gradle version catalogs:

```toml
[versions]
minecraft = { prefer = "26.1.2", strictly = "[26.1.2,26.2)" }

[libraries]
minecraft = { module = "com.mojang:minecraft", version.ref = "minecraft" }
```

You can then make use of the strictly version in other ways:

```kotlin
publishingMetadata {
    supportedMinecraftVersionRanges = libs.versions.minecraft.strictly.get()
}
```