### PR TITLE
Use Gradle to resolve minecraft dependency

### DIFF
--- a/gradle/runtime.libs.versions.toml
+++ b/gradle/runtime.libs.versions.toml
@@ -10,6 +10,7 @@ fabric-log4j-util = "1.0.2"
 jetbrains-annotations = "26.0.2"
 native-support = "1.0.1"
 fabric-installer = "1.0.3"
+fabric-loader = "0.19.2"
 
 # Dev tools
 renderdoc = "1.37"
@@ -27,6 +28,7 @@ fabric-log4j-util = { module = "net.fabricmc:fabric-log4j-util", version.ref = "
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
 native-support = { module = "net.fabricmc:fabric-loom-native-support", version.ref = "native-support" }
 fabric-installer = { module = "net.fabricmc:fabric-installer", version.ref = "fabric-installer" }
+fabric-loader = { module = "net.fabricmc:fabric-loader", version.ref = "fabric-loader" }
 
 # Dev tools
 renderdoc = { module = "org.renderdoc:renderdoc", version.ref = "renderdoc" } # Not a maven dependency

--- a/src/main/java/net/fabricmc/loom/configuration/LoomConfigurations.java
+++ b/src/main/java/net/fabricmc/loom/configuration/LoomConfigurations.java
@@ -91,7 +91,21 @@ public abstract class LoomConfigurations implements Runnable {
 		registerNonTransitive(Constants.Configurations.MINECRAFT_NATIVES, Role.RESOLVABLE);
 		registerNonTransitive(Constants.Configurations.LOADER_DEPENDENCIES, Role.RESOLVABLE);
 
-		registerNonTransitive(Constants.Configurations.MINECRAFT, Role.NONE);
+		var minecraft = registerNonTransitive(Constants.Configurations.MINECRAFT, Role.NONE);
+		registerNonTransitive(Constants.Configurations.MINECRAFT_VERSION_RESOLVE, Role.RESOLVABLE).configure(configuration -> {
+			configuration.extendsFrom(minecraft.get());
+		});
+		registerNonTransitive(Constants.Configurations.MINECRAFT_VERSION_NORMALIZER, Role.RESOLVABLE).configure(configuration -> {
+			configuration.defaultDependencies(dependencies -> dependencies.add(getDependencies().create(LoomVersions.FABRIC_LOADER.mavenNotation())));
+		});
+
+		getDependencies().getComponents().all(details -> {
+			if (details.getId().getGroup().equals("net.minecraft") && details.getId().getName().equals("minecraft")) {
+				// Normalized snapshots include a pre-release separator. Marking them as integration
+				// lets Gradle's latest.release selector ignore snapshots.
+				details.setStatus(details.getId().getVersion().contains("-") ? "integration" : "release");
+			}
+		});
 
 		Provider<Configuration> include = register(Constants.Configurations.INCLUDE, Role.NONE);
 		register(Constants.Configurations.INCLUDE_INTERNAL, Role.RESOLVABLE).configure(configuration -> {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/FabricLoaderMinecraftVersionNormalizer.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/FabricLoaderMinecraftVersionNormalizer.java
@@ -1,0 +1,158 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.configuration.providers.minecraft;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.WrongMethodTypeException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Optional;
+import java.util.Set;
+
+import org.gradle.api.Project;
+
+import net.fabricmc.loom.util.Constants;
+
+final class FabricLoaderMinecraftVersionNormalizer implements MinecraftVersionNormalizer {
+	private final URLClassLoader classLoader;
+	private final MethodHandle getRelease;
+	private final MethodHandle normalizeVersion;
+	private final MethodHandle parseSemanticVersion;
+
+	static FabricLoaderMinecraftVersionNormalizer create(Project project) {
+		Set<File> files = project.getConfigurations()
+				.getByName(Constants.Configurations.MINECRAFT_VERSION_NORMALIZER)
+				.resolve();
+		URL[] urls = files.stream()
+				.map(FabricLoaderMinecraftVersionNormalizer::toUrl)
+				.toArray(URL[]::new);
+
+		return new FabricLoaderMinecraftVersionNormalizer(urls);
+	}
+
+	private FabricLoaderMinecraftVersionNormalizer(URL[] urls) {
+		this.classLoader = new FabricLoaderClassLoader(urls, FabricLoaderMinecraftVersionNormalizer.class.getClassLoader());
+
+		try {
+			MethodHandles.Lookup publicLookup = MethodHandles.publicLookup();
+			Class<?> lookup = this.classLoader.loadClass("net.fabricmc.loader.impl.game.minecraft.McVersionLookup");
+			this.getRelease = publicLookup.findStatic(lookup, "getRelease", MethodType.methodType(String.class, String.class));
+			this.normalizeVersion = publicLookup.findStatic(lookup, "normalizeVersion", MethodType.methodType(String.class, String.class, String.class));
+
+			Class<?> semanticVersion = this.classLoader.loadClass("net.fabricmc.loader.api.SemanticVersion");
+			this.parseSemanticVersion = publicLookup.findStatic(semanticVersion, "parse", MethodType.methodType(semanticVersion, String.class));
+		} catch (ReflectiveOperationException e) {
+			closeQuietly(this.classLoader);
+			throw new RuntimeException("Failed to load Fabric Loader Minecraft version normalizer", e);
+		}
+	}
+
+	@Override
+	public Optional<String> normalize(String version) {
+		try {
+			String release = (String) this.getRelease.invoke(version);
+			String normalized = (String) this.normalizeVersion.invoke(version, release);
+			this.parseSemanticVersion.invoke(normalized);
+			return Optional.of(normalized);
+		} catch (WrongMethodTypeException | ClassCastException e) {
+			throw new RuntimeException("Failed to normalize Minecraft version: " + version, e);
+		} catch (LinkageError e) {
+			throw e;
+		} catch (Throwable e) {
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public int compare(String a, String b) {
+		try {
+			final Comparable parsedA = (Comparable) this.parseSemanticVersion.invoke(a);
+			final Object parsedB = this.parseSemanticVersion.invoke(b);
+			return parsedA.compareTo(parsedB);
+		} catch (Throwable e) {
+			throw new RuntimeException("Failed to compare Minecraft versions: %s and %s".formatted(a, b), e);
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		this.classLoader.close();
+	}
+
+	private static URL toUrl(File file) {
+		try {
+			return file.toURI().toURL();
+		} catch (IOException e) {
+			throw new RuntimeException("Failed to create URL for: " + file, e);
+		}
+	}
+
+	private static void closeQuietly(Closeable closeable) {
+		try {
+			closeable.close();
+		} catch (IOException e) {
+			// ignored
+		}
+	}
+
+	private static final class FabricLoaderClassLoader extends URLClassLoader {
+		private FabricLoaderClassLoader(URL[] urls, ClassLoader parent) {
+			super(urls, parent);
+		}
+
+		@Override
+		protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+			if (!name.startsWith("net.fabricmc.loader.")) {
+				return super.loadClass(name, resolve);
+			}
+
+			synchronized (getClassLoadingLock(name)) {
+				Class<?> loadedClass = findLoadedClass(name);
+
+				if (loadedClass == null) {
+					try {
+						// The normalizer version is intentionally configurable. Prefer the configured
+						// Loader classes over any Loader already present on Loom's/test classpath.
+						loadedClass = findClass(name);
+					} catch (ClassNotFoundException e) {
+						loadedClass = super.loadClass(name, false);
+					}
+				}
+
+				if (resolve) {
+					resolveClass(loadedClass);
+				}
+
+				return loadedClass;
+			}
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/GradleMinecraftVersionResolver.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/GradleMinecraftVersionResolver.java
@@ -1,0 +1,409 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.configuration.providers.minecraft;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ExternalModuleDependency;
+import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.jspecify.annotations.Nullable;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.LoomGradlePlugin;
+import net.fabricmc.loom.configuration.providers.minecraft.ManifestLocations.ManifestLocation;
+import net.fabricmc.loom.configuration.providers.minecraft.VersionsManifest.Version;
+import net.fabricmc.loom.util.Constants;
+import net.fabricmc.loom.util.download.DownloadBuilder;
+
+final class GradleMinecraftVersionResolver {
+	private static final String GROUP = "net.minecraft";
+	private static final String MODULE = "minecraft";
+	private static final DateTimeFormatter MAVEN_TIMESTAMP = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+	private final Project project;
+	private final LoomGradleExtension extension;
+	private final Function<String, DownloadBuilder> download;
+
+	private GradleMinecraftVersionResolver(Project project, LoomGradleExtension extension, Function<String, DownloadBuilder> download) {
+		this.project = project;
+		this.extension = extension;
+		this.download = download;
+	}
+
+	static boolean isGradleResolvedMinecraft(Dependency dependency) {
+		return GROUP.equals(dependency.getGroup()) && MODULE.equals(dependency.getName());
+	}
+
+	static String resolve(Project project, Dependency dependency, Function<String, DownloadBuilder> download) {
+		return new GradleMinecraftVersionResolver(project, LoomGradleExtension.get(project), download).resolve(dependency);
+	}
+
+	private String resolve(Dependency dependency) {
+		if (extension.getCustomMinecraftMetadata().isPresent()) {
+			return resolveCustomMetadataDependency(dependency);
+		}
+
+		try (MinecraftVersionNormalizer normalizer = FabricLoaderMinecraftVersionNormalizer.create(project)) {
+			Metadata metadata = createMetadata(normalizer, false);
+			Optional<String> directVersion = getDirectVersion(dependency);
+
+			if (directVersion.isPresent() && metadata.isDirectUnnormalizedVersion(directVersion.get())) {
+				// Exact manifest ids still need to work for versions that Loader cannot normalize.
+				return directVersion.get();
+			}
+
+			validateRangeSelectors(dependency, metadata);
+			publish(metadata);
+
+			try {
+				return resolveFromGradle(metadata);
+			} catch (RuntimeException e) {
+				Metadata refreshedMetadata = createMetadata(normalizer, true);
+
+				if (directVersion.isPresent() && refreshedMetadata.isDirectUnnormalizedVersion(directVersion.get())) {
+					// Keep the same direct-id escape hatch after refreshing stale manifest data.
+					return directVersion.get();
+				}
+
+				validateRangeSelectors(dependency, refreshedMetadata);
+				publish(refreshedMetadata);
+				return resolveFromGradle(refreshedMetadata);
+			}
+		} catch (IOException e) {
+			throw new UncheckedIOException("Failed to close Minecraft version normalizer", e);
+		}
+	}
+
+	private String resolveCustomMetadataDependency(Dependency dependency) {
+		final Optional<String> directVersion = getDirectVersion(dependency);
+
+		if (directVersion.isPresent()) {
+			return directVersion.get();
+		}
+
+		throw new IllegalArgumentException("Cannot use dynamic or ranged net.minecraft:minecraft versions with custom Minecraft metadata");
+	}
+
+	private Metadata createMetadata(MinecraftVersionNormalizer normalizer, boolean forceDownload) {
+		final Map<String, String> normalizedToRaw = new LinkedHashMap<>();
+		final Set<String> unnormalized = new LinkedHashSet<>();
+		String latest = null;
+		String release = null;
+
+		for (ManifestLocation location : extension.getVersionsManifests()) {
+			final VersionsManifest manifest = readManifest(location, forceDownload);
+
+			for (Version version : manifest.versions()) {
+				final Optional<String> normalized = normalizer.normalize(version.id());
+
+				if (normalized.isPresent()) {
+					final String normalizedVersion = normalized.get();
+					// Publish only normalized coordinates so Gradle's version ordering never sees raw
+					// snapshot ids such as 24w46a.
+					normalizedToRaw.putIfAbsent(normalizedVersion, version.id());
+					latest = max(normalizer, latest, normalizedVersion);
+
+					if (!normalizedVersion.contains("-")) {
+						release = max(normalizer, release, normalizedVersion);
+					}
+				} else {
+					unnormalized.add(version.id());
+				}
+			}
+		}
+
+		return new Metadata(normalizedToRaw, unnormalized, latest, release);
+	}
+
+	private static String max(MinecraftVersionNormalizer normalizer, @Nullable String a, String b) {
+		if (a == null) {
+			return b;
+		}
+
+		return normalizer.compare(a, b) < 0 ? b : a;
+	}
+
+	private VersionsManifest readManifest(ManifestLocation location, boolean forceDownload) {
+		try {
+			DownloadBuilder builder = download.apply(location.url());
+
+			if (forceDownload) {
+				builder = builder.forceDownload();
+			} else {
+				builder = builder.defaultCache();
+			}
+
+			final Path cacheFile = location.cacheFile(extension.getFiles().getUserCache().toPath());
+			final String versionManifest = builder.downloadString(cacheFile);
+			return LoomGradlePlugin.GSON.fromJson(versionManifest, VersionsManifest.class);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Failed to read Minecraft versions manifest: " + location.url(), e);
+		}
+	}
+
+	private void publish(Metadata metadata) {
+		try {
+			// Mojang does not publish net.minecraft:minecraft metadata. Loom publishes a tiny
+			// local module so Gradle can do selector/range resolution against normalized ids.
+			final Path moduleDir = extension.getFiles().getGlobalMinecraftRepo().toPath()
+					.resolve(GROUP.replace('.', '/'))
+					.resolve(MODULE);
+			Files.createDirectories(moduleDir);
+
+			final List<String> versions = new ArrayList<>(metadata.normalizedToRaw().keySet());
+
+			for (String version : versions) {
+				writePom(moduleDir, version);
+			}
+
+			writeMavenMetadata(moduleDir.resolve("maven-metadata.xml"), versions, metadata);
+		} catch (IOException | ParserConfigurationException | TransformerException e) {
+			throw new RuntimeException("Failed to publish Minecraft version metadata", e);
+		}
+	}
+
+	private void writePom(Path moduleDir, String version) throws IOException, ParserConfigurationException, TransformerException {
+		final Path versionDir = moduleDir.resolve(version);
+		Files.createDirectories(versionDir);
+		final Path pom = versionDir.resolve("%s-%s.pom".formatted(MODULE, version));
+
+		final Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+		final Element project = document.createElement("project");
+		project.setAttribute("xmlns", "http://maven.apache.org/POM/4.0.0");
+		project.setAttribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
+		project.setAttribute("xsi:schemaLocation", "http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd");
+		document.appendChild(project);
+
+		appendText(document, project, "modelVersion", "4.0.0");
+		appendText(document, project, "groupId", GROUP);
+		appendText(document, project, "artifactId", MODULE);
+		appendText(document, project, "version", version);
+
+		writeXml(pom, document);
+	}
+
+	private void writeMavenMetadata(Path metadataFile, List<String> versions, Metadata metadata) throws IOException, ParserConfigurationException, TransformerException {
+		final String latest = metadata.latest() == null ? "" : metadata.latest();
+		final String release = metadata.release() == null ? latest : metadata.release();
+
+		final Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+		final Element root = document.createElement("metadata");
+		document.appendChild(root);
+
+		appendText(document, root, "groupId", GROUP);
+		appendText(document, root, "artifactId", MODULE);
+
+		final Element versioning = document.createElement("versioning");
+		root.appendChild(versioning);
+		appendText(document, versioning, "latest", latest);
+		appendText(document, versioning, "release", release);
+
+		final Element versionsElement = document.createElement("versions");
+		versioning.appendChild(versionsElement);
+
+		for (String version : versions) {
+			appendText(document, versionsElement, "version", version);
+		}
+
+		appendText(document, versioning, "lastUpdated", LocalDateTime.now(ZoneOffset.UTC).format(MAVEN_TIMESTAMP));
+
+		writeXml(metadataFile, document);
+	}
+
+	private static Element appendText(Document document, Element parent, String name, String text) {
+		final Element element = document.createElement(name);
+		element.setTextContent(text);
+		parent.appendChild(element);
+		return element;
+	}
+
+	private static void writeXml(Path path, Document document) throws IOException, TransformerException {
+		final Transformer transformer = TransformerFactory.newInstance().newTransformer();
+		transformer.setOutputProperty(OutputKeys.ENCODING, StandardCharsets.UTF_8.name());
+		transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+
+		try (Writer writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
+			transformer.transform(new DOMSource(document), new StreamResult(writer));
+		}
+	}
+
+	private String resolveFromGradle(Metadata metadata) {
+		// Resolve a copy so reading metadata here does not mutate the user's minecraft configuration.
+		final Configuration configuration = project.getConfigurations()
+				.getByName(Constants.Configurations.MINECRAFT_VERSION_RESOLVE)
+				.copyRecursive();
+		configuration.setCanBeResolved(true);
+		configuration.setCanBeConsumed(false);
+
+		for (ResolvedComponentResult component : configuration.getIncoming().getResolutionResult().getAllComponents()) {
+			final ComponentIdentifier id = component.getId();
+
+			if (id instanceof ModuleComponentIdentifier module
+					&& GROUP.equals(module.getGroup())
+					&& MODULE.equals(module.getModule())) {
+				final String rawVersion = metadata.normalizedToRaw().get(module.getVersion());
+
+				if (rawVersion != null) {
+					return rawVersion;
+				}
+
+				throw new IllegalStateException("Resolved Minecraft version is not known to Loom: " + module.getVersion());
+			}
+		}
+
+		throw new IllegalStateException("Gradle did not resolve a net.minecraft:minecraft version");
+	}
+
+	private static Optional<String> getDirectVersion(Dependency dependency) {
+		if (dependency instanceof ExternalModuleDependency externalModuleDependency) {
+			final VersionConstraint versionConstraint = externalModuleDependency.getVersionConstraint();
+
+			if (isDirectVersion(versionConstraint.getStrictVersion())) {
+				return Optional.of(versionConstraint.getStrictVersion());
+			}
+
+			if (isDirectVersion(versionConstraint.getRequiredVersion())) {
+				return Optional.of(versionConstraint.getRequiredVersion());
+			}
+		}
+
+		if (isDirectVersion(dependency.getVersion())) {
+			return Optional.of(dependency.getVersion());
+		}
+
+		return Optional.empty();
+	}
+
+	private static void validateRangeSelectors(Dependency dependency, Metadata metadata) {
+		for (String selector : getVersionSelectors(dependency)) {
+			if (!isVersionRange(selector)) {
+				continue;
+			}
+
+			for (String endpoint : getRangeEndpoints(selector)) {
+				if (metadata.unnormalized().contains(endpoint)) {
+					// Ranges over unknown ordering are ambiguous; direct exact ids are the supported
+					// compatibility path for unnormalizable versions.
+					throw new IllegalArgumentException("Cannot use unnormalizable Minecraft version in a range: " + endpoint);
+				}
+			}
+		}
+	}
+
+	private static List<String> getVersionSelectors(Dependency dependency) {
+		final List<String> selectors = new ArrayList<>();
+
+		if (dependency.getVersion() != null) {
+			selectors.add(dependency.getVersion());
+		}
+
+		if (dependency instanceof ExternalModuleDependency externalModuleDependency) {
+			final VersionConstraint versionConstraint = externalModuleDependency.getVersionConstraint();
+			addIfNotEmpty(selectors, versionConstraint.getStrictVersion());
+			addIfNotEmpty(selectors, versionConstraint.getRequiredVersion());
+			addIfNotEmpty(selectors, versionConstraint.getPreferredVersion());
+			selectors.addAll(versionConstraint.getRejectedVersions());
+		}
+
+		return selectors;
+	}
+
+	private static List<String> getRangeEndpoints(String range) {
+		final int comma = range.indexOf(',');
+
+		if (comma < 0 || range.length() < 2) {
+			return List.of(range);
+		}
+
+		final String lower = range.substring(1, comma).trim();
+		final String upper = range.substring(comma + 1, range.length() - 1).trim();
+		final List<String> endpoints = new ArrayList<>();
+		addIfNotEmpty(endpoints, lower);
+		addIfNotEmpty(endpoints, upper);
+		return endpoints;
+	}
+
+	private static void addIfNotEmpty(List<String> values, @Nullable String value) {
+		if (value != null && !value.isEmpty()) {
+			values.add(value);
+		}
+	}
+
+	private static boolean isDirectVersion(@Nullable String version) {
+		return version != null && !version.isEmpty() && !isVersionRange(version) && !isDynamicVersion(version);
+	}
+
+	private static boolean isVersionRange(String version) {
+		return version.startsWith("[") || version.startsWith("(");
+	}
+
+	private static boolean isDynamicVersion(String version) {
+		return version.endsWith("+") || version.startsWith("latest.");
+	}
+
+	private record Metadata(
+			Map<String, String> normalizedToRaw,
+			Set<String> unnormalized,
+			@Nullable String latest,
+			@Nullable String release
+	) {
+		boolean isDirectUnnormalizedVersion(String version) {
+			return unnormalized.contains(version);
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.provider.Property;
 import org.jspecify.annotations.Nullable;
 
@@ -56,7 +57,7 @@ public final class MinecraftMetadataProvider {
 	}
 
 	public static MinecraftMetadataProvider create(ConfigContext configContext) {
-		final String minecraftVersion = resolveMinecraftVersion(configContext.project());
+		final String minecraftVersion = resolveMinecraftVersion(configContext);
 
 		return new MinecraftMetadataProvider(
 				MinecraftMetadataProvider.Options.create(
@@ -67,9 +68,16 @@ public final class MinecraftMetadataProvider {
 		);
 	}
 
-	private static String resolveMinecraftVersion(Project project) {
+	private static String resolveMinecraftVersion(ConfigContext configContext) {
+		final Project project = configContext.project();
 		final DependencyInfo dependency = DependencyInfo.create(project, Constants.Configurations.MINECRAFT);
-		return dependency.getDependency().getVersion();
+		final Dependency minecraftDependency = dependency.getDependency();
+
+		if (GradleMinecraftVersionResolver.isGradleResolvedMinecraft(minecraftDependency)) {
+			return GradleMinecraftVersionResolver.resolve(project, minecraftDependency, configContext.extension()::download);
+		}
+
+		return minecraftDependency.getVersion();
 	}
 
 	public String getMinecraftVersion() {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftVersionNormalizer.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftVersionNormalizer.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.configuration.providers.minecraft;
+
+import java.io.IOException;
+import java.util.Optional;
+
+interface MinecraftVersionNormalizer extends AutoCloseable {
+	Optional<String> normalize(String version);
+
+	int compare(String a, String b);
+
+	@Override
+	default void close() throws IOException {
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -52,6 +52,8 @@ public class Constants {
 		public static final String INCLUDE = "include";
 		public static final String INCLUDE_INTERNAL = "includeInternal";
 		public static final String MINECRAFT = "minecraft";
+		public static final String MINECRAFT_VERSION_RESOLVE = "minecraftVersionResolve";
+		public static final String MINECRAFT_VERSION_NORMALIZER = "minecraftVersionNormalizerClasspath";
 
 		public static final String MINECRAFT_COMPILE_LIBRARIES = "minecraftLibraries";
 		public static final String MINECRAFT_RUNTIME_LIBRARIES = "minecraftRuntimeLibraries";

--- a/src/test/groovy/net/fabricmc/loom/test/unit/providers/GradleMinecraftVersionResolverTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/providers/GradleMinecraftVersionResolverTest.groovy
@@ -1,0 +1,162 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit.providers
+
+import org.gradle.api.Project
+
+import net.fabricmc.loom.LoomGradleExtension
+import net.fabricmc.loom.LoomGradlePlugin
+import net.fabricmc.loom.configuration.ConfigContextImpl
+import net.fabricmc.loom.configuration.providers.minecraft.MinecraftMetadataProvider
+import net.fabricmc.loom.test.LoomTestConstants
+import net.fabricmc.loom.test.unit.download.DownloadTest
+import net.fabricmc.loom.test.util.GradleTestUtil
+import net.fabricmc.loom.util.Constants
+
+class GradleMinecraftVersionResolverTest extends DownloadTest {
+	File testDir
+
+	def setup() {
+		testDir = LoomTestConstants.TEST_DIR.toPath().resolve("GradleMinecraftVersionResolverTest").toFile()
+		testDir.deleteDir()
+		testDir.mkdirs()
+
+		server.get("/versionManifest") {
+			it.result(VERSION_MANIFEST)
+		}
+		server.get("/emptyVersionManifest") {
+			it.result(EMPTY_VERSION_MANIFEST)
+		}
+	}
+
+	def "range resolution uses normalized Minecraft ordering"() {
+		setup:
+		def project = project("net.minecraft:minecraft:[1.21.4-alpha.24.46.a,1.21.4]")
+
+		when:
+		def version = resolve(project)
+
+		then:
+		version == "1.21.4"
+	}
+
+	def "latest release ignores older snapshots"() {
+		setup:
+		def project = project("net.minecraft:minecraft:latest.release")
+
+		when:
+		def version = resolve(project)
+
+		then:
+		version == "1.21.4"
+	}
+
+	def "range resolution supports new snapshot format"() {
+		setup:
+		def project = project("net.minecraft:minecraft:[26.1-alpha.1,26.1-alpha.3]")
+
+		when:
+		def version = resolve(project)
+
+		then:
+		version == "26.1-snapshot-2"
+	}
+
+	def "direct unnormalizable version is accepted"() {
+		setup:
+		def project = project("net.minecraft:minecraft:this_is_not_semver")
+
+		when:
+		def version = resolve(project)
+
+		then:
+		version == "this_is_not_semver"
+	}
+
+	def "range endpoint using unnormalizable version fails"() {
+		setup:
+		def project = project("net.minecraft:minecraft:[this_is_not_semver,1.21.4]")
+
+		when:
+		resolve(project)
+
+		then:
+		def e = thrown(IllegalArgumentException)
+		e.message == "Cannot use unnormalizable Minecraft version in a range: this_is_not_semver"
+	}
+
+	private static String resolve(Project project) {
+		def extension = LoomGradleExtension.get(project)
+		def context = new ConfigContextImpl(project, null, extension)
+		return MinecraftMetadataProvider.create(context).getMinecraftVersion()
+	}
+
+	private Project project(String dependency) {
+		def project = GradleTestUtil.realProject(new File(testDir, UUID.randomUUID().toString()))
+		project.extensions.extraProperties.set("loom_version_manifests", "$PATH/versionManifest")
+		project.extensions.extraProperties.set("loom_experimental_versions", "$PATH/emptyVersionManifest")
+		project.pluginManager.apply(LoomGradlePlugin)
+		project.dependencies.add(Constants.Configurations.MINECRAFT, dependency)
+		return project
+	}
+
+	private static final String VERSION_MANIFEST = """
+{
+  "latest": {
+    "release": "1.21.4",
+    "snapshot": "24w46a"
+  },
+  "versions": [
+    {
+      "id": "24w46a",
+      "type": "snapshot",
+      "url": "https://example.invalid/24w46a.json"
+    },
+    {
+      "id": "1.21.4",
+      "type": "release",
+      "url": "https://example.invalid/1.21.4.json"
+    },
+    {
+      "id": "26.1-snapshot-2",
+      "type": "snapshot",
+      "url": "https://example.invalid/26.1-snapshot-2.json"
+    },
+    {
+      "id": "this_is_not_semver",
+      "type": "snapshot",
+      "url": "https://example.invalid/this_is_not_semver.json"
+    }
+  ]
+}
+"""
+
+	private static final String EMPTY_VERSION_MANIFEST = """
+{
+  "latest": {},
+  "versions": []
+}
+"""
+}

--- a/src/test/groovy/net/fabricmc/loom/test/util/GradleTestUtil.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/util/GradleTestUtil.groovy
@@ -70,6 +70,12 @@ class GradleTestUtil {
 		return realProject
 	}
 
+	static Project realProject(File projectDir) {
+		return ProjectBuilder.builder()
+				.withProjectDir(projectDir)
+				.build()
+	}
+
 	static LoomGradleExtension mockLoomGradleExtension() {
 		def mock = mock(LoomGradleExtension.class)
 		def loomFiles = mockLoomFiles()


### PR DESCRIPTION
- This PR allows Loom to resolve the Minecraft dependency via Gradle, rather than doing it itself.
- This allows for proper use of version ranges like `net.minecraft:minecraft:[1.21.1,1.21.4]`
- Loom publishes a metadata-only maven repository into global cache, so Gradle can resolve through it
- Loom uses Fabric Loader's `McVersionLookup` utility to normalise versions so Gradle can parse semver and use version ranges correctly
- A new `minecraftVersionNormalizerClasspath` configuration where you can add a future version of Fabric Loader onto it to get its normalization improvements for future version formats.
- Retain current behaviour on `com.mojang:minecraft` for backwards compatibility, since normalized versions may not match, moved to `net.minecraft:minecraft` for this new resolution behaviour.
