### PR TITLE
New: `getInheritRunConfigs` in `GameTestSettings`

### DIFF
--- a/src/main/java/net/fabricmc/loom/api/fabricapi/GameTestSettings.java
+++ b/src/main/java/net/fabricmc/loom/api/fabricapi/GameTestSettings.java
@@ -95,6 +95,16 @@ public interface GameTestSettings {
 	Property<String> getUsername();
 
 	/**
+	 * Contains a boolean property indicating whether the created game test run configs inherit the default
+	 * client and server run configs.
+	 *
+	 * <p>This only works when {@link #getEnableGameTests()} or {@link #getEnableClientGameTests()} is enabled.
+	 *
+	 * <p>Default: true
+	 */
+	Property<Boolean> getInheritRunConfigs();
+
+	/**
 	 * Sets {@link #getModId()} property based on the {@code id} field defined in the provided file.
 	 */
 	default void modId(File fabricModJsonFile) {

--- a/src/main/java/net/fabricmc/loom/configuration/fabricapi/FabricApiTesting.java
+++ b/src/main/java/net/fabricmc/loom/configuration/fabricapi/FabricApiTesting.java
@@ -100,7 +100,7 @@ public abstract class FabricApiTesting extends FabricApiAbstractSourceSet {
 				} else {
 					run.server();
 				}
-				
+
 				run.property("fabric-api.gametest");
 				run.runDir("build/run/gameTest");
 				configureBase.accept(run);

--- a/src/main/java/net/fabricmc/loom/configuration/fabricapi/FabricApiTesting.java
+++ b/src/main/java/net/fabricmc/loom/configuration/fabricapi/FabricApiTesting.java
@@ -75,6 +75,7 @@ public abstract class FabricApiTesting extends FabricApiAbstractSourceSet {
 		settings.getEula().convention(false);
 		settings.getClearRunDirectory().convention(true);
 		settings.getUsername().convention("Player0");
+		settings.getInheritRunConfigs().convention(true);
 
 		action.execute(settings);
 
@@ -94,7 +95,12 @@ public abstract class FabricApiTesting extends FabricApiAbstractSourceSet {
 
 		if (settings.getEnableGameTests().get()) {
 			RunConfiguration gameTest = extension.getRunConfigs().create("gameTest", run -> {
-				run.inherit(extension.getRunConfigs().getByName("server"));
+				if (settings.getInheritRunConfigs().get()) {
+					run.inherit(extension.getRunConfigs().getByName("server"));
+				} else {
+					run.server();
+				}
+				
 				run.property("fabric-api.gametest");
 				run.runDir("build/run/gameTest");
 				configureBase.accept(run);
@@ -108,7 +114,12 @@ public abstract class FabricApiTesting extends FabricApiAbstractSourceSet {
 			final File resourcesDir = testSourceSet.getResources().getSrcDirs().stream().findFirst().orElse(null);
 
 			RunConfigSettings clientGameTest = extension.getRunConfigs().create("clientGameTest", run -> {
-				run.inherit(extension.getRunConfigs().getByName("client"));
+				if (settings.getInheritRunConfigs().get()) {
+					run.inherit(extension.getRunConfigs().getByName("client"));
+				} else {
+					run.client();
+				}
+
 				run.property("fabric.client.gametest");
 
 				if (resourcesDir != null) {


### PR DESCRIPTION
Adds a new property that prevents `FabricApiTesting` from attempting to resolve `client` and `server` run configs, and instead start afresh.