### PR TITLE
Fix `supportsJava19OrLater` on 26.2-pre-1 and later

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/LibraryContext.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/library/LibraryContext.java
@@ -61,7 +61,7 @@ public final class LibraryContext {
 		return versionMeta.libraries().stream().filter(library -> library.name().startsWith("org.lwjgl:lwjgl:")).anyMatch(library -> {
 			final String[] split = library.name().split(":");
 
-			if (split.length != 3) {
+			if (split.length < 3) {
 				return false;
 			}
 


### PR DESCRIPTION
As of 26.2-pre-1 minecraft now uses the `-unsafe` variant of lwjgl which causes this check to always return false.

Fixes #1569