### PR TITLE
fix unresolved %ECLIPSE_PROJECT% reference in Eclipse run configs

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/GenEclipseRunsTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenEclipseRunsTask.java
@@ -118,8 +118,8 @@ public abstract class GenEclipseRunsTask extends AbstractLoomTask {
 
 		dummyConfig = dummyConfig.replace("%NAME%", RunConfigUtils.getDisplayName(run, project));
 		dummyConfig = dummyConfig.replace("%MAIN_CLASS%", run.getDevLaunchMainClass().get());
-		dummyConfig = dummyConfig.replace("%ECLIPSE_PROJECT%", eclipseProjectName);
 		dummyConfig = dummyConfig.replace("%RUN_DIRECTORY%", runDir);
+		dummyConfig = dummyConfig.replace("%ECLIPSE_PROJECT%", eclipseProjectName);
 		dummyConfig = dummyConfig.replace("%PROGRAM_ARGS%", Arguments.join(run.getProgramArguments().get()).replaceAll("\"", "&quot;"));
 		dummyConfig = dummyConfig.replace("%VM_ARGS%", Arguments.join(run.getJvmArguments().get()).replaceAll("\"", "&quot;"));
 		dummyConfig = dummyConfig.replace("%ECLIPSE_ENV_VARS%", RunConfigUtils.formatEnvVars(run, "<mapEntry key=\"%s\" value=\"%s\"/>"));


### PR DESCRIPTION
The `%ECLIPSE_PROJECT%` variable was resolved before the last reference was added, leading to an error when running the config. Simply swapping two lines around fixes this.