### PR TITLE
Fix decomp cache handling with dangling inner class

### DIFF
--- a/src/main/java/net/fabricmc/loom/decompilers/cache/JarWalker.java
+++ b/src/main/java/net/fabricmc/loom/decompilers/cache/JarWalker.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -45,6 +46,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.gradle.api.JavaVersion;
@@ -73,6 +75,8 @@ public final class JarWalker {
 		List<String> outerClasses = new ArrayList<>();
 		Map<String, List<String>> innerClasses = new HashMap<>();
 
+		Map<String, Set<String>> innerClassesFromOuterCache = new HashMap<>();
+
 		// Iterate over all the classes in the jar, and store them into the sorted list.
 		try (Stream<Path> walk = Files.walk(fs.getRoot())) {
 			Iterator<Path> iterator = walk.iterator();
@@ -90,7 +94,7 @@ public final class JarWalker {
 					continue;
 				}
 
-				String outerClass = findOuterClass(fs, fileName);
+				String outerClass = findOuterClass(fs, fileName, innerClassesFromOuterCache);
 
 				if (outerClass == null) {
 					outerClasses.add(fileName);
@@ -131,7 +135,7 @@ public final class JarWalker {
 	/**
 	 * Check if the given class file denotes and inner class and find the corresponding outer class name.
 	 */
-	private static String findOuterClass(FileSystemUtil.Delegate fs, String classFile) throws IOException {
+	private static String findOuterClass(FileSystemUtil.Delegate fs, String classFile, Map<String, Set<String>> innerClassesFromOuterCache) throws IOException {
 		// this check can speed things up quite a bit, even if it does not follow the JVM spec
 		if (classFile.indexOf('$') < 0) {
 			return null;
@@ -148,14 +152,24 @@ public final class JarWalker {
 				if (innerClass.name.equals(classNode.name)) {
 					// only regular inner classes have the outer class in the inner class attribute
 					if (innerClass.outerName != null) {
-						return innerClass.outerName;
+						String candidate = innerClass.outerName;
+						Set<String> fromOuterClass = innerClassesFromOuterCache.computeIfAbsent(candidate, className -> enumerateInnerClasses(fs, className));
+
+						if (fromOuterClass.contains(classNode.name)) {
+							return candidate;
+						}
 					}
 
 					// local and anonymous classes have the outer class in the enclosing method attribute
 					// we check for both attributes because both should be present for decompilers to
 					// recognize a class as an inner class
 					if (classNode.outerClass != null) {
-						return classNode.outerClass;
+						String candidate = classNode.outerClass;
+						Set<String> fromOuterClass = innerClassesFromOuterCache.computeIfAbsent(candidate, className -> enumerateInnerClasses(fs, className));
+
+						if (fromOuterClass.contains(classNode.name)) {
+							return candidate;
+						}
 					}
 
 					// there are some Minecraft versions with one attribute stripped but not the other
@@ -165,6 +179,21 @@ public final class JarWalker {
 		}
 
 		return null;
+	}
+
+	private static Set<String> enumerateInnerClasses(FileSystemUtil.Delegate fs, String className) {
+		try (InputStream is = Files.newInputStream(fs.getPath(className + ".class"))) {
+			final ClassReader reader = new ClassReader(is);
+			final ClassNode classNode = new ClassNode();
+
+			reader.accept(classNode, ClassReader.SKIP_CODE | ClassReader.SKIP_FRAMES);
+
+			return classNode.innerClasses.stream()
+					.map(innerClassNode -> innerClassNode.name)
+					.collect(Collectors.toSet());
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
 	}
 
 	private static CompletableFuture<ClassEntry> getClassEntry(String outerClass, List<String> innerClasses, FileSystemUtil.Delegate fs, Executor executor) {

--- a/src/test/groovy/net/fabricmc/loom/test/unit/cache/CachedJarProcessorTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/cache/CachedJarProcessorTest.groovy
@@ -174,7 +174,7 @@ class CachedJarProcessorTest extends Specification {
 		ZipUtils.unpackNullable(outputJar, "net/fabricmc/other/Test.java") == "Test sources".bytes
 		ZipUtils.unpackNullable(outputJar, "net/fabricmc/other/Test\$Dangling.java") == "Test\$Dangling sources".bytes
 
-		// Expect two calls looking for the existingSources entry in the cache
+		// Expect 3 calls looking for the existingSources entry in the cache
 		1 * cache.getEntry(ExampleHash) >> null
 		1 * cache.getEntry(TestHash) >> null
 		1 * cache.getEntry(TestDanglingHash) >> null

--- a/src/test/groovy/net/fabricmc/loom/test/unit/cache/CachedJarProcessorTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/cache/CachedJarProcessorTest.groovy
@@ -44,16 +44,22 @@ import net.fabricmc.loom.util.ZipUtils
 class CachedJarProcessorTest extends Specification {
 	static Map<String, byte[]> jarEntries = [
 		"net/fabricmc/Example.class": newClass("net/fabricmc/Example"),
-		"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test"),
+		"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test", [] as String[], [
+			"net/fabricmc/other/Test\$Inner",
+			"net/fabricmc/other/Test\$1"
+		] as String[]),
 		"net/fabricmc/other/Test\$Inner.class": newInnerClass("net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test", "Inner"),
 		"net/fabricmc/other/Test\$1.class": newInnerClass("net/fabricmc/other/Test\$1", "net/fabricmc/other/Test"),
+		"net/fabricmc/other/Test\$Dangling.class": newInnerClass("net/fabricmc/other/Test\$Dangling", "net/fabricmc/other/Test"),
 	]
 
 	static String ExampleHash = "abc123/db5c3a2d04e0c6ea03aef0d217517aa0233f9b8198753d3c96574fe5825a13c4"
-	static String TestHash = "abc123/b49f74dc50847f8fefc0c6f850326bbe39ace0b381b827fe1a1f1ed1dea81330"
+	static String TestHash = "abc123/62db36eda67a8bdb19626126176aa0fccc64a509ac808db166e9795caac5a784"
+	static String TestDanglingHash = "abc123/6659d90f0ac7ee783c8b44e51c08d4388477ef3fa998f1d6d4fc95f4adf628ca"
 
 	static CachedData ExampleCachedData = new CachedData("net/fabricmc/Example", "Example sources", lineNumber("net/fabricmc/Example"))
 	static CachedData TestCachedData = new CachedData("net/fabricmc/other/Test", "Test sources", lineNumber("net/fabricmc/other/Test"))
+	static CachedData TestDanglingCachedData = new CachedData("net/fabricmc/other/Test\$Dangling", "Test\$Dangling sources", lineNumber("net/fabricmc/other/Test\$Dangling"))
 
 	@TempDir
 	Path testPath
@@ -70,10 +76,10 @@ class CachedJarProcessorTest extends Specification {
 
 		then:
 		workRequest.lineNumbers() == null
-		workJob.outputNameMap().size() == 2
+		workJob.outputNameMap().size() == 3
 
-		// Expect two calls looking for the existing entry in the cache
-		2 * cache.getEntry(_) >> null
+		// Expect 3 calls looking for the existing entry in the cache
+		3 * cache.getEntry(_) >> null
 
 		0 * _ // Strict mock
 	}
@@ -93,14 +99,14 @@ class CachedJarProcessorTest extends Specification {
 		lineMap.size() == 1
 		lineMap.get("net/fabricmc/Example") == ExampleCachedData.lineNumbers()
 
-		workJob.outputNameMap().size() == 1
+		workJob.outputNameMap().size() == 2
 		ZipUtils.unpackNullable(workJob.existingSources(), "net/fabricmc/Example.java") == "Example sources".bytes
 		ZipUtils.unpackNullable(workJob.existingClasses(), "net/fabricmc/Example.class") == newClass("net/fabricmc/Example")
 
 		// Provide one cached entry
-		// And then one call not finding the entry in the cache
+		// And then 2 calls not finding the entry in the cache
 		1 * cache.getEntry(ExampleHash) >> ExampleCachedData
-		1 * cache.getEntry(_) >> null
+		2 * cache.getEntry(_) >> null
 
 		0 * _ // Strict mock
 	}
@@ -117,18 +123,21 @@ class CachedJarProcessorTest extends Specification {
 		def lineMap = workRequest.lineNumbers().lineMap()
 
 		then:
-		lineMap.size() == 2
+		lineMap.size() == 3
 		lineMap.get("net/fabricmc/Example") == ExampleCachedData.lineNumbers()
 		lineMap.get("net/fabricmc/other/Test") == TestCachedData.lineNumbers()
+		lineMap.get("net/fabricmc/other/Test\$Dangling") == TestDanglingCachedData.lineNumbers()
 
 		workJob.completed() != null
 		ZipUtils.unpackNullable(workJob.completed(), "net/fabricmc/Example.java") == "Example sources".bytes
 		ZipUtils.unpackNullable(workJob.completed(), "net/fabricmc/other/Test.java") == "Test sources".bytes
+		ZipUtils.unpackNullable(workJob.completed(), "net/fabricmc/other/Test\$Dangling.java") == "Test\$Dangling sources".bytes
 
 		// Provide one cached entry
-		// And then two calls not finding the entry in the cache
+		// And then 3 calls not finding the entry in the cache
 		1 * cache.getEntry(ExampleHash) >> ExampleCachedData
 		1 * cache.getEntry(TestHash) >> TestCachedData
+		1 * cache.getEntry(TestDanglingHash) >> TestDanglingCachedData
 
 		0 * _ // Strict mock
 	}
@@ -146,29 +155,34 @@ class CachedJarProcessorTest extends Specification {
 		// Do the work, such as decompiling.
 		ZipUtils.add(workJob.output(), "net/fabricmc/Example.java", "Example sources")
 		ZipUtils.add(workJob.output(), "net/fabricmc/other/Test.java", "Test sources")
+		ZipUtils.add(workJob.output(), "net/fabricmc/other/Test\$Dangling.java", "Test\$Dangling sources")
 
 		def outputJar = Files.createTempFile("loom-test-output", ".jar")
 		Files.delete(outputJar)
 
 		ClassLineNumbers lineNumbers = lineNumbers([
 			"net/fabricmc/Example",
-			"net/fabricmc/other/Test"
+			"net/fabricmc/other/Test",
+			"net/fabricmc/other/Test\$Dangling"
 		])
 		processor.completeJob(outputJar, workJob, lineNumbers)
 
 		then:
-		workJob.outputNameMap().size() == 2
+		workJob.outputNameMap().size() == 3
 
 		ZipUtils.unpackNullable(outputJar, "net/fabricmc/Example.java") == "Example sources".bytes
 		ZipUtils.unpackNullable(outputJar, "net/fabricmc/other/Test.java") == "Test sources".bytes
+		ZipUtils.unpackNullable(outputJar, "net/fabricmc/other/Test\$Dangling.java") == "Test\$Dangling sources".bytes
 
 		// Expect two calls looking for the existingSources entry in the cache
 		1 * cache.getEntry(ExampleHash) >> null
 		1 * cache.getEntry(TestHash) >> null
+		1 * cache.getEntry(TestDanglingHash) >> null
 
 		// Expect the new work to be put into the cache
 		1 * cache.putEntry(ExampleHash, ExampleCachedData)
 		1 * cache.putEntry(TestHash, TestCachedData)
+		1 * cache.putEntry(TestDanglingHash, TestDanglingCachedData)
 
 		0 * _ // Strict mock
 	}
@@ -191,7 +205,8 @@ class CachedJarProcessorTest extends Specification {
 
 		ClassLineNumbers lineNumbers = lineNumbers([
 			"net/fabricmc/Example",
-			"net/fabricmc/other/Test"
+			"net/fabricmc/other/Test",
+			"net/fabricmc/other/Test\$Dangling"
 		])
 		processor.completeJob(outputJar, workJob, lineNumbers)
 
@@ -200,10 +215,12 @@ class CachedJarProcessorTest extends Specification {
 
 		ZipUtils.unpackNullable(outputJar, "net/fabricmc/Example.java") == "Example sources".bytes
 		ZipUtils.unpackNullable(outputJar, "net/fabricmc/other/Test.java") == "Test sources".bytes
+		ZipUtils.unpackNullable(outputJar, "net/fabricmc/other/Test\$Dangling.java") == "Test\$Dangling sources".bytes
 
 		// The cache already contains sources for example, but not for test
 		1 * cache.getEntry(ExampleHash) >> ExampleCachedData
 		1 * cache.getEntry(TestHash) >> null
+		1 * cache.getEntry(TestDanglingHash) >> TestDanglingCachedData
 
 		// Expect the new work to be put into the cache
 		1 * cache.putEntry(TestHash, TestCachedData)
@@ -226,17 +243,20 @@ class CachedJarProcessorTest extends Specification {
 
 		ClassLineNumbers lineNumbers = lineNumbers([
 			"net/fabricmc/Example",
-			"net/fabricmc/other/Test"
+			"net/fabricmc/other/Test",
+			"net/fabricmc/other/Test\$Dangling"
 		])
 		processor.completeJob(outputJar, workJob, lineNumbers)
 
 		then:
 		ZipUtils.unpackNullable(outputJar, "net/fabricmc/Example.java") == "Example sources".bytes
 		ZipUtils.unpackNullable(outputJar, "net/fabricmc/other/Test.java") == "Test sources".bytes
+		ZipUtils.unpackNullable(outputJar, "net/fabricmc/other/Test\$Dangling.java") == "Test\$Dangling sources".bytes
 
 		// The cache already contains sources for example, but not for test
 		1 * cache.getEntry(ExampleHash) >> ExampleCachedData
 		1 * cache.getEntry(TestHash) >> TestCachedData
+		1 * cache.getEntry(TestDanglingHash) >> TestDanglingCachedData
 
 		0 * _ // Strict mock
 	}
@@ -246,7 +266,10 @@ class CachedJarProcessorTest extends Specification {
 		def jar1 = ZipTestUtils.createZipFromBytes(
 				[
 					"net/fabricmc/Example.class": newClass("net/fabricmc/Example"),
-					"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test", ),
+					"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test", [] as String[], [
+						"net/fabricmc/other/Test\$Inner",
+						"net/fabricmc/other/Test\$1"
+					] as String[]),
 					"net/fabricmc/other/Test\$Inner.class": newInnerClass("net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test", "Inner", ["net/fabricmc/Example"] as String[]),
 					"net/fabricmc/other/Test\$1.class": newInnerClass("net/fabricmc/other/Test\$1", "net/fabricmc/other/Test"),
 				]
@@ -255,7 +278,10 @@ class CachedJarProcessorTest extends Specification {
 		def jar2 = ZipTestUtils.createZipFromBytes(
 				[
 					"net/fabricmc/Example.class": newClass("net/fabricmc/Example", ["java/lang/Runnable"] as String[]),
-					"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test", ),
+					"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test", [] as String[], [
+						"net/fabricmc/other/Test\$Inner",
+						"net/fabricmc/other/Test\$1"
+					] as String[]),
 					"net/fabricmc/other/Test\$Inner.class": newInnerClass("net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test", "Inner", ["net/fabricmc/Example"] as String[]),
 					"net/fabricmc/other/Test\$1.class": newInnerClass("net/fabricmc/other/Test\$1", "net/fabricmc/other/Test"),
 				]
@@ -298,9 +324,14 @@ class CachedJarProcessorTest extends Specification {
 		return new ClassLineNumbers.Entry(name, 0, 0, [:])
 	}
 
-	private static byte[] newClass(String name, String[] interfaces = null, String superName = "java/lang/Object") {
+	private static byte[] newClass(String name, String[] interfaces = null, String[] innerNames = null, String superName = "java/lang/Object") {
 		def writer = new ClassWriter(0)
 		writer.visit(Opcodes.V17, Opcodes.ACC_PUBLIC, name, null, superName, interfaces)
+		if (innerNames != null) {
+			for (String innerName : innerNames) {
+				writer.visitInnerClass(innerName, null, null, 0)
+			}
+		}
 		return writer.toByteArray()
 	}
 

--- a/src/test/groovy/net/fabricmc/loom/test/unit/cache/JarWalkerTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/cache/JarWalkerTest.groovy
@@ -37,7 +37,10 @@ class JarWalkerTest extends Specification {
 		given:
 		def jar = ZipTestUtils.createZipFromBytes([
 			"net/fabricmc/Test.class": newClass("net/fabricmc/Test"),
-			"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test", [] as String[], ["net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test\$1"] as String[]),
+			"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test", [] as String[], [
+				"net/fabricmc/other/Test\$Inner",
+				"net/fabricmc/other/Test\$1"
+			] as String[]),
 			"net/fabricmc/other/Test\$Inner.class": newInnerClass("net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test", "Inner"),
 			"net/fabricmc/other/Test\$1.class": newInnerClass("net/fabricmc/other/Test\$1", "net/fabricmc/other/Test"),
 			"net/fabricmc/other/Test\$NotInner.class": newClass("net/fabricmc/other/Test\$NotInner"),
@@ -84,14 +87,26 @@ class JarWalkerTest extends Specification {
 			"net/fabricmc/Test.class": newClass("net/fabricmc/Test"),
 		]
 		"8b295701fa90f0220840226a397cf4e96f255ef4f0b9eb2c19b1d84fe99ce855" | [
-			"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test", [] as String[], ["net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test\$Inner\$2", "net/fabricmc/other/Test\$1"] as String[]),
-			"net/fabricmc/other/Test\$Inner.class": newInnerClass("net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test", "Inner", null, "java/lang/Object", ["net/fabricmc/other/Test\$Inner\$2"] as String[]),
+			"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test", [] as String[], [
+				"net/fabricmc/other/Test\$Inner",
+				"net/fabricmc/other/Test\$Inner\$2",
+				"net/fabricmc/other/Test\$1"
+			] as String[]),
+			"net/fabricmc/other/Test\$Inner.class": newInnerClass("net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test", "Inner", null, "java/lang/Object", [
+				"net/fabricmc/other/Test\$Inner\$2"
+			] as String[]),
 			"net/fabricmc/other/Test\$Inner\$2.class": newInnerClass("net/fabricmc/other/Test\$Inner\$2", "net/fabricmc/other/Test\$Inner", "Inner"),
 			"net/fabricmc/other/Test\$1.class": newInnerClass("net/fabricmc/other/Test\$1", "net/fabricmc/other/Test"),
 		]
 		"8b295701fa90f0220840226a397cf4e96f255ef4f0b9eb2c19b1d84fe99ce855" | [
-			"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test", [] as String[], ["net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test\$Inner\$2", "net/fabricmc/other/Test\$1"] as String[]),
-			"net/fabricmc/other/Test\$Inner.class": newInnerClass("net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test", "Inner", null, "java/lang/Object", ["net/fabricmc/other/Test\$Inner\$2"] as String[]),
+			"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test", [] as String[], [
+				"net/fabricmc/other/Test\$Inner",
+				"net/fabricmc/other/Test\$Inner\$2",
+				"net/fabricmc/other/Test\$1"
+			] as String[]),
+			"net/fabricmc/other/Test\$Inner.class": newInnerClass("net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test", "Inner", null, "java/lang/Object", [
+				"net/fabricmc/other/Test\$Inner\$2"
+			] as String[]),
 			"net/fabricmc/other/Test\$Inner\$2.class": newInnerClass("net/fabricmc/other/Test\$Inner\$2", "net/fabricmc/other/Test\$Inner", "Inner"),
 			"net/fabricmc/other/Test\$1.class": newInnerClass("net/fabricmc/other/Test\$1", "net/fabricmc/other/Test"),
 		]
@@ -134,7 +149,10 @@ class JarWalkerTest extends Specification {
 	def "inner classes"() {
 		given:
 		def jarEntries = [
-			"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test", [] as String[], ["net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test\$1"] as String[]),
+			"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test", [] as String[], [
+				"net/fabricmc/other/Test\$Inner",
+				"net/fabricmc/other/Test\$1"
+			] as String[]),
 			"net/fabricmc/other/Test\$Inner.class": newInnerClass("net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test", "Inner", null, "net/fabricmc/other/Super"),
 			"net/fabricmc/other/Test\$1.class": newInnerClass("net/fabricmc/other/Test\$1", "net/fabricmc/other/Test", null, ["java/lang/Runnable"] as String[]),
 		]

--- a/src/test/groovy/net/fabricmc/loom/test/unit/cache/JarWalkerTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/cache/JarWalkerTest.groovy
@@ -37,29 +37,34 @@ class JarWalkerTest extends Specification {
 		given:
 		def jar = ZipTestUtils.createZipFromBytes([
 			"net/fabricmc/Test.class": newClass("net/fabricmc/Test"),
-			"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test"),
+			"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test", [] as String[], ["net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test\$1"] as String[]),
 			"net/fabricmc/other/Test\$Inner.class": newInnerClass("net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test", "Inner"),
 			"net/fabricmc/other/Test\$1.class": newInnerClass("net/fabricmc/other/Test\$1", "net/fabricmc/other/Test"),
 			"net/fabricmc/other/Test\$NotInner.class": newClass("net/fabricmc/other/Test\$NotInner"),
+			"net/fabricmc/other/Test\$Dangling.class": newClass("net/fabricmc/other/Test\$Dangling", "net/fabricmc/other/Test"),
 		])
 		when:
 		def entries = JarWalker.findClasses(jar)
 		then:
-		entries.size() == 3
+		entries.size() == 4
 
 		entries[0].name() == "net/fabricmc/Test.class"
 		entries[0].sourcesFileName() == "net/fabricmc/Test.java"
 		entries[0].innerClasses().size() == 0
 
-		entries[1].name() == "net/fabricmc/other/Test\$NotInner.class"
-		entries[1].sourcesFileName() == "net/fabricmc/other/Test\$NotInner.java"
+		entries[1].name() == "net/fabricmc/other/Test\$Dangling.class"
+		entries[1].sourcesFileName() == "net/fabricmc/other/Test\$Dangling.java"
 		entries[1].innerClasses().size() == 0
 
-		entries[2].name() == "net/fabricmc/other/Test.class"
-		entries[2].sourcesFileName() == "net/fabricmc/other/Test.java"
-		entries[2].innerClasses().size() == 2
-		entries[2].innerClasses()[0] == "net/fabricmc/other/Test\$1.class"
-		entries[2].innerClasses()[1] == "net/fabricmc/other/Test\$Inner.class"
+		entries[2].name() == "net/fabricmc/other/Test\$NotInner.class"
+		entries[2].sourcesFileName() == "net/fabricmc/other/Test\$NotInner.java"
+		entries[2].innerClasses().size() == 0
+
+		entries[3].name() == "net/fabricmc/other/Test.class"
+		entries[3].sourcesFileName() == "net/fabricmc/other/Test.java"
+		entries[3].innerClasses().size() == 2
+		entries[3].innerClasses()[0] == "net/fabricmc/other/Test\$1.class"
+		entries[3].innerClasses()[1] == "net/fabricmc/other/Test\$Inner.class"
 	}
 
 	def "Hash Classes"() {
@@ -78,15 +83,15 @@ class JarWalkerTest extends Specification {
 		"b055df8d9503b60050f6d0db387c84c47fedb4d9ed82c4f8174b4e465a9c479b" | [
 			"net/fabricmc/Test.class": newClass("net/fabricmc/Test"),
 		]
-		"b49f74dc50847f8fefc0c6f850326bbe39ace0b381b827fe1a1f1ed1dea81330" | [
-			"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test"),
-			"net/fabricmc/other/Test\$Inner.class": newInnerClass("net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test", "Inner"),
+		"8b295701fa90f0220840226a397cf4e96f255ef4f0b9eb2c19b1d84fe99ce855" | [
+			"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test", [] as String[], ["net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test\$Inner\$2", "net/fabricmc/other/Test\$1"] as String[]),
+			"net/fabricmc/other/Test\$Inner.class": newInnerClass("net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test", "Inner", null, "java/lang/Object", ["net/fabricmc/other/Test\$Inner\$2"] as String[]),
 			"net/fabricmc/other/Test\$Inner\$2.class": newInnerClass("net/fabricmc/other/Test\$Inner\$2", "net/fabricmc/other/Test\$Inner", "Inner"),
 			"net/fabricmc/other/Test\$1.class": newInnerClass("net/fabricmc/other/Test\$1", "net/fabricmc/other/Test"),
 		]
-		"b49f74dc50847f8fefc0c6f850326bbe39ace0b381b827fe1a1f1ed1dea81330" | [
-			"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test"),
-			"net/fabricmc/other/Test\$Inner.class": newInnerClass("net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test", "Inner"),
+		"8b295701fa90f0220840226a397cf4e96f255ef4f0b9eb2c19b1d84fe99ce855" | [
+			"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test", [] as String[], ["net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test\$Inner\$2", "net/fabricmc/other/Test\$1"] as String[]),
+			"net/fabricmc/other/Test\$Inner.class": newInnerClass("net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test", "Inner", null, "java/lang/Object", ["net/fabricmc/other/Test\$Inner\$2"] as String[]),
 			"net/fabricmc/other/Test\$Inner\$2.class": newInnerClass("net/fabricmc/other/Test\$Inner\$2", "net/fabricmc/other/Test\$Inner", "Inner"),
 			"net/fabricmc/other/Test\$1.class": newInnerClass("net/fabricmc/other/Test\$1", "net/fabricmc/other/Test"),
 		]
@@ -129,7 +134,7 @@ class JarWalkerTest extends Specification {
 	def "inner classes"() {
 		given:
 		def jarEntries = [
-			"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test"),
+			"net/fabricmc/other/Test.class": newClass("net/fabricmc/other/Test", [] as String[], ["net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test\$1"] as String[]),
 			"net/fabricmc/other/Test\$Inner.class": newInnerClass("net/fabricmc/other/Test\$Inner", "net/fabricmc/other/Test", "Inner", null, "net/fabricmc/other/Super"),
 			"net/fabricmc/other/Test\$1.class": newInnerClass("net/fabricmc/other/Test\$1", "net/fabricmc/other/Test", null, ["java/lang/Runnable"] as String[]),
 		]
@@ -151,18 +156,28 @@ class JarWalkerTest extends Specification {
 		]
 	}
 
-	private static byte[] newClass(String name, String[] interfaces = null, String superName = "java/lang/Object") {
+	private static byte[] newClass(String name, String[] interfaces = null, String[] innerNames = null, String superName = "java/lang/Object") {
 		def writer = new ClassWriter(0)
 		writer.visit(Opcodes.V17, Opcodes.ACC_PUBLIC, name, null, superName, interfaces)
+		if (innerNames != null) {
+			for (String innerName : innerNames) {
+				writer.visitInnerClass(innerName, null, null, 0)
+			}
+		}
 		return writer.toByteArray()
 	}
 
-	private static byte[] newInnerClass(String name, String outerClass, String innerName = null, String[] interfaces = null, String superName = "java/lang/Object") {
+	private static byte[] newInnerClass(String name, String outerClass, String innerName = null, String[] interfaces = null, String superName = "java/lang/Object", String[] innerNames = null) {
 		def writer = new ClassWriter(0)
 		writer.visit(Opcodes.V17, Opcodes.ACC_PUBLIC, name, null, superName, interfaces)
 		writer.visitInnerClass(name, outerClass, innerName, 0)
 		if (innerName == null) {
 			writer.visitOuterClass(outerClass, null, null)
+		}
+		if (innerNames != null) {
+			for (String innerName1 : innerNames) {
+				writer.visitInnerClass(innerName1, null, null, 0)
+			}
 		}
 		return writer.toByteArray()
 	}


### PR DESCRIPTION
Java requires inner classes and the parent to reference each other, but the decompiler cache logic only ever checked that the inner class referencing the parent, not the other way round. This causes decompiler cache to treat these classes as inner classes while the decompilers do not. This PR adds a sanity check for this case. 

This is currently known to happen on NeoForge patched jars on 1.21.11 and 1.21.1. 