### PR TITLE
Allow using custom Minecraft versions for client prod run tasks

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMetadataProvider.java
@@ -55,9 +55,7 @@ public final class MinecraftMetadataProvider {
 		this.download = download;
 	}
 
-	public static MinecraftMetadataProvider create(ConfigContext configContext) {
-		final String minecraftVersion = resolveMinecraftVersion(configContext.project());
-
+	public static MinecraftMetadataProvider create(ConfigContext configContext, String minecraftVersion) {
 		return new MinecraftMetadataProvider(
 				MinecraftMetadataProvider.Options.create(
 						minecraftVersion,
@@ -65,6 +63,10 @@ public final class MinecraftMetadataProvider {
 				),
 				configContext.extension()::download
 		);
+	}
+
+	public static MinecraftMetadataProvider create(ConfigContext configContext) {
+		return create(configContext, resolveMinecraftVersion(configContext.project()));
 	}
 
 	private static String resolveMinecraftVersion(Project project) {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftProvider.java
@@ -79,6 +79,13 @@ public abstract class MinecraftProvider {
 	}
 
 	public void provide() throws Exception {
+		provideJars();
+
+		final MinecraftLibraryProvider libraryProvider = new MinecraftLibraryProvider(this, configContext.project());
+		libraryProvider.provide();
+	}
+
+	public void provideJars() throws Exception {
 		initFiles();
 
 		verifyJavaVersion();
@@ -96,9 +103,6 @@ public abstract class MinecraftProvider {
 		if (didDownload) {
 			verifyJars();
 		}
-
-		final MinecraftLibraryProvider libraryProvider = new MinecraftLibraryProvider(this, configContext.project());
-		libraryProvider.provide();
 	}
 
 	private void verifyJavaVersion() {

--- a/src/main/java/net/fabricmc/loom/task/DownloadAssetsTask.java
+++ b/src/main/java/net/fabricmc/loom/task/DownloadAssetsTask.java
@@ -80,14 +80,21 @@ public abstract class DownloadAssetsTask extends AbstractLoomTask {
 
 	@Inject
 	public DownloadAssetsTask() {
-		final MinecraftVersionMeta versionInfo = getExtension().getMinecraftProvider().getVersionInfo();
+		configureForVersion(getExtension().getMinecraftProvider().getVersionInfo());
+
+		getDownloadThreads().convention(Math.min(Runtime.getRuntime().availableProcessors(), 10));
+
+		getResourcesBaseUrl().set(MirrorUtil.getResourcesBase(getProject()));
+		getResourcesBaseUrl().finalizeValue();
+	}
+
+	public void configureForVersion(MinecraftVersionMeta versionInfo) {
 		final File assetsDir = new File(getExtension().getFiles().getUserCache(), "assets");
 
 		getAssetsDirectory().set(assetsDir);
 		getAssetsHash().set(versionInfo.assetIndex().sha1());
-		getDownloadThreads().convention(Math.min(Runtime.getRuntime().availableProcessors(), 10));
 		getMinecraftVersion().set(versionInfo.id());
-		getMinecraftVersion().finalizeValue();
+		getMinecraftVersion().finalizeValueOnRead();
 
 		if (versionInfo.assets().equals("legacy")) {
 			getLegacyResourcesDirectory().set(new File(assetsDir, "/legacy/" + versionInfo.id()));
@@ -98,12 +105,9 @@ public abstract class DownloadAssetsTask extends AbstractLoomTask {
 			getLegacyResourcesDirectory().set(new File(runDir, "resources"));
 		}
 
-		getResourcesBaseUrl().set(MirrorUtil.getResourcesBase(getProject()));
-		getResourcesBaseUrl().finalizeValue();
+		getAssetsIndexJson().set(LoomGradlePlugin.GSON.toJson(versionInfo.assetIndex()));
 
-		getAssetsIndexJson().set(LoomGradlePlugin.GSON.toJson(getExtension().getMinecraftProvider().getVersionInfo().assetIndex()));
-
-		getAssetsHash().finalizeValue();
+		getAssetsHash().finalizeValueOnRead();
 		getAssetsDirectory().finalizeValueOnRead();
 		getLegacyResourcesDirectory().finalizeValueOnRead();
 	}

--- a/src/main/java/net/fabricmc/loom/task/prod/ClientProductionRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/prod/ClientProductionRunTask.java
@@ -30,10 +30,14 @@ import java.io.IOException;
 import javax.inject.Inject;
 
 import org.gradle.api.Action;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
@@ -43,9 +47,18 @@ import org.gradle.work.DisableCachingByDefault;
 import org.jetbrains.annotations.ApiStatus;
 
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
+import net.fabricmc.loom.configuration.ConfigContext;
+import net.fabricmc.loom.configuration.ConfigContextImpl;
+import net.fabricmc.loom.configuration.providers.minecraft.MinecraftJarConfiguration;
+import net.fabricmc.loom.configuration.providers.minecraft.MinecraftMetadataProvider;
+import net.fabricmc.loom.configuration.providers.minecraft.library.Library;
+import net.fabricmc.loom.configuration.providers.minecraft.library.MinecraftLibraryHelper;
+import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
+import net.fabricmc.loom.task.DownloadAssetsTask;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.Platform;
 import net.fabricmc.loom.util.XVFBExistsValueSource;
+import net.fabricmc.loom.util.service.ScopedServiceFactory;
 
 /**
  * A task that runs the Minecraft client in a similar way to a production launcher. You must manually register a task of this type to use it.
@@ -62,6 +75,14 @@ public abstract non-sealed class ClientProductionRunTask extends AbstractProduct
 	 */
 	@Input
 	public abstract Property<Boolean> getUseXVFB();
+
+	/**
+	 * The version of Minecraft to use.
+	 *
+	 * <p>Defaults to the version of Minecraft that the project is using.
+	 */
+	@Input
+	public abstract Property<String> getMinecraftVersion();
 
 	@Nested
 	@Optional
@@ -86,6 +107,9 @@ public abstract non-sealed class ClientProductionRunTask extends AbstractProduct
 	@PathSensitive(PathSensitivity.ABSOLUTE)
 	protected abstract DirectoryProperty getAssetsDir();
 
+	@Internal
+	protected abstract Property<MinecraftProvider> getMinecraftProvider();
+
 	@Inject
 	public ClientProductionRunTask() {
 		getUseXVFB().convention(getProject().getProviders().environmentVariable("CI")
@@ -93,27 +117,75 @@ public abstract non-sealed class ClientProductionRunTask extends AbstractProduct
 				.orElse(false)
 		);
 
-		getAssetsIndex().set(getExtension().getMinecraftVersion()
-				.map(minecraftVersion -> getExtension()
-						.getMinecraftProvider()
-						.getVersionInfo()
-						.assetIndex()
-						.fabricId(minecraftVersion)
-				)
-		);
+		getMinecraftVersion().convention(getExtension().getMinecraftVersion());
+		getMinecraftVersion().finalizeValueOnRead();
+
+		getMinecraftProvider().set(getMinecraftVersion().map(version -> version.equals(getExtension().getMinecraftVersion().get()) ? getExtension().getMinecraftProvider() : createVersionProvider(version)));
+		getMinecraftProvider().finalizeValueOnRead();
+
+		getClasspath().from(getMinecraftVersion().map(version -> {
+			if (version.equals(getExtension().getMinecraftVersion().get())) {
+				return getProject().getConfigurations().getByName(Constants.Configurations.MINECRAFT_TEST_CLIENT_RUNTIME_LIBRARIES);
+			}
+
+			final Dependency[] libraries = MinecraftLibraryHelper.getLibrariesForPlatform(getMinecraftProvider().get().getVersionInfo(), Platform.CURRENT)
+					.stream()
+					.filter(library -> library.target() == Library.Target.COMPILE || library.target() == Library.Target.RUNTIME || library.target() == Library.Target.NATIVES)
+					.map(Library::mavenNotation)
+					.map(notation -> getProject().getDependencies().create(notation))
+					.peek(dep -> {
+						if (dep instanceof ModuleDependency moduleDep) {
+							moduleDep.setTransitive(false);
+						}
+					})
+					.toArray(Dependency[]::new);
+			final Configuration librariesConfiguration = getProject().getConfigurations().detachedConfiguration(libraries);
+			librariesConfiguration.setTransitive(false);
+
+			return new Configuration[] {
+					librariesConfiguration,
+					getProject().getConfigurations().getByName(Constants.Configurations.LOADER_DEPENDENCIES)
+			};
+		}));
+
+		dependsOn(getMinecraftVersion().map(version -> {
+			if (version.equals(getExtension().getMinecraftVersion().get())) {
+				return getProject().getTasks().named("downloadAssets");
+			}
+
+			return getProject().getTasks().register(
+					"download" + getName() + "Assets",
+					DownloadAssetsTask.class,
+					task -> {
+						task.setDescription("Downloads required game assets for Minecraft.");
+						task.configureForVersion(getMinecraftProvider().get().getVersionInfo());
+					}
+			);
+		}));
+
+		getAssetsIndex().set(getMinecraftProvider().map(minecraftProvider -> minecraftProvider.getVersionInfo().assetIndex().fabricId(getMinecraftVersion().get())));
 		getAssetsDir().set(new File(getExtension().getFiles().getUserCache(), "assets"));
 		getMainClass().convention("net.fabricmc.loader.impl.launch.knot.KnotClient");
 
-		getClasspath().from(getExtension().getMinecraftProvider().getMinecraftClientJar());
+		getClasspath().from(getMinecraftProvider().map(MinecraftProvider::getMinecraftClientJar));
 		getClasspath().from(detachedConfigurationProvider("net.fabricmc:fabric-loader:%s", getProjectLoaderVersion()));
 
 		if (getExtension().getProductionNamespaceEnum().get() == MappingsNamespace.INTERMEDIARY) {
-			getClasspath().from(detachedConfigurationProvider("net.fabricmc:intermediary:%s", getExtension().getMinecraftVersion()));
+			getClasspath().from(detachedConfigurationProvider("net.fabricmc:intermediary:%s", getMinecraftVersion()));
 		}
+	}
 
-		getClasspath().from(getProject().getConfigurations().named(Constants.Configurations.MINECRAFT_TEST_CLIENT_RUNTIME_LIBRARIES));
+	private MinecraftProvider createVersionProvider(final String minecraftVersion) {
+		try (var serviceFactory = new ScopedServiceFactory()) {
+			final ConfigContext configContext = new ConfigContextImpl(getProject(), serviceFactory, getExtension());
+			final MinecraftMetadataProvider metadataProvider = MinecraftMetadataProvider.create(configContext, minecraftVersion);
+			final MinecraftProvider minecraftProvider = MinecraftJarConfiguration.CLIENT_ONLY.createMinecraftProvider(metadataProvider, configContext);
 
-		dependsOn("downloadAssets");
+			minecraftProvider.provideJars();
+			return minecraftProvider;
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to provide Minecraft " + minecraftVersion + " jar", e);
+		}
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/task/prod/ClientProductionRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/prod/ClientProductionRunTask.java
@@ -34,10 +34,10 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
-import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
@@ -51,9 +51,9 @@ import net.fabricmc.loom.configuration.ConfigContext;
 import net.fabricmc.loom.configuration.ConfigContextImpl;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftJarConfiguration;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftMetadataProvider;
+import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.library.Library;
 import net.fabricmc.loom.configuration.providers.minecraft.library.MinecraftLibraryHelper;
-import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
 import net.fabricmc.loom.task.DownloadAssetsTask;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.Platform;
@@ -107,9 +107,6 @@ public abstract non-sealed class ClientProductionRunTask extends AbstractProduct
 	@PathSensitive(PathSensitivity.ABSOLUTE)
 	protected abstract DirectoryProperty getAssetsDir();
 
-	@Internal
-	protected abstract Property<MinecraftProvider> getMinecraftProvider();
-
 	@Inject
 	public ClientProductionRunTask() {
 		getUseXVFB().convention(getProject().getProviders().environmentVariable("CI")
@@ -120,15 +117,14 @@ public abstract non-sealed class ClientProductionRunTask extends AbstractProduct
 		getMinecraftVersion().convention(getExtension().getMinecraftVersion());
 		getMinecraftVersion().finalizeValueOnRead();
 
-		getMinecraftProvider().set(getMinecraftVersion().map(version -> version.equals(getExtension().getMinecraftVersion().get()) ? getExtension().getMinecraftProvider() : createVersionProvider(version)));
-		getMinecraftProvider().finalizeValueOnRead();
+		final Provider<MinecraftProvider> minecraftProvider = getProject().provider(() -> getMinecraftVersion().get().equals(getExtension().getMinecraftVersion().get()) ? getExtension().getMinecraftProvider() : createVersionProvider(getMinecraftVersion().get()));
 
-		getClasspath().from(getMinecraftVersion().map(version -> {
-			if (version.equals(getExtension().getMinecraftVersion().get())) {
+		getClasspath().from(minecraftProvider.map(provider -> {
+			if (provider.getVersionInfo().id().equals(getExtension().getMinecraftVersion().get())) {
 				return getProject().getConfigurations().getByName(Constants.Configurations.MINECRAFT_TEST_CLIENT_RUNTIME_LIBRARIES);
 			}
 
-			final Dependency[] libraries = MinecraftLibraryHelper.getLibrariesForPlatform(getMinecraftProvider().get().getVersionInfo(), Platform.CURRENT)
+			final Dependency[] libraries = MinecraftLibraryHelper.getLibrariesForPlatform(provider.getVersionInfo(), Platform.CURRENT)
 					.stream()
 					.filter(library -> library.target() == Library.Target.COMPILE || library.target() == Library.Target.RUNTIME || library.target() == Library.Target.NATIVES)
 					.map(Library::mavenNotation)
@@ -141,15 +137,13 @@ public abstract non-sealed class ClientProductionRunTask extends AbstractProduct
 					.toArray(Dependency[]::new);
 			final Configuration librariesConfiguration = getProject().getConfigurations().detachedConfiguration(libraries);
 			librariesConfiguration.setTransitive(false);
+			librariesConfiguration.getDependencies().addAll(getProject().getConfigurations().getByName(Constants.Configurations.LOADER_DEPENDENCIES).getAllDependencies());
 
-			return new Configuration[] {
-					librariesConfiguration,
-					getProject().getConfigurations().getByName(Constants.Configurations.LOADER_DEPENDENCIES)
-			};
+			return librariesConfiguration;
 		}));
 
-		dependsOn(getMinecraftVersion().map(version -> {
-			if (version.equals(getExtension().getMinecraftVersion().get())) {
+		dependsOn(minecraftProvider.map(provider -> {
+			if (provider.getVersionInfo().id().equals(getExtension().getMinecraftVersion().get())) {
 				return getProject().getTasks().named("downloadAssets");
 			}
 
@@ -158,16 +152,16 @@ public abstract non-sealed class ClientProductionRunTask extends AbstractProduct
 					DownloadAssetsTask.class,
 					task -> {
 						task.setDescription("Downloads required game assets for Minecraft.");
-						task.configureForVersion(getMinecraftProvider().get().getVersionInfo());
+						task.configureForVersion(provider.getVersionInfo());
 					}
 			);
 		}));
 
-		getAssetsIndex().set(getMinecraftProvider().map(minecraftProvider -> minecraftProvider.getVersionInfo().assetIndex().fabricId(getMinecraftVersion().get())));
+		getAssetsIndex().set(minecraftProvider.map(provider -> provider.getVersionInfo().assetIndex().fabricId(getMinecraftVersion().get())));
 		getAssetsDir().set(new File(getExtension().getFiles().getUserCache(), "assets"));
 		getMainClass().convention("net.fabricmc.loader.impl.launch.knot.KnotClient");
 
-		getClasspath().from(getMinecraftProvider().map(MinecraftProvider::getMinecraftClientJar));
+		getClasspath().from(minecraftProvider.map(MinecraftProvider::getMinecraftClientJar));
 		getClasspath().from(detachedConfigurationProvider("net.fabricmc:fabric-loader:%s", getProjectLoaderVersion()));
 
 		if (getExtension().getProductionNamespaceEnum().get() == MappingsNamespace.INTERMEDIARY) {

--- a/src/test/groovy/net/fabricmc/loom/test/integration/RunConfigTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/RunConfigTest.groovy
@@ -243,6 +243,69 @@ class RunConfigTest extends Specification implements GradleProjectTestTrait {
 		version << STANDARD_TEST_VERSIONS
 	}
 
+	@Timeout(value = 10, unit = TimeUnit.MINUTES)
+	@Unroll
+	@IgnoreIf({ !os.linux }) // XVFB is installed on the CI for this test
+	def "prod client 1.21.6 on 1.21.4 (gradle #version)"() {
+		setup:
+		def gradle = gradleProject(project: "minimalBase", version: version)
+		gradle.buildGradle << """
+                dependencies {
+                    minecraft "com.mojang:minecraft:1.21.4"
+                    mappings "net.fabricmc:yarn:1.21.4+build.4:v2"
+                    modImplementation "${LoomTestVersions.FABRIC_LOADER.mavenNotation()}"
+                    modImplementation "net.fabricmc.fabric-api:fabric-api:0.114.0+1.21.4"
+
+                    productionRuntimeMods "net.fabricmc.fabric-api:fabric-api:0.128.2+1.21.6"
+                }
+
+                tasks.register("prodClient", net.fabricmc.loom.task.prod.ClientProductionRunTask) {
+                	jvmArgs.add("-Dfabric.client.gametest")
+                	minecraftVersion = "1.21.6"
+                }
+            """
+
+		when:
+		def result = gradle.run(task: "prodClient")
+
+		then:
+		result.task(":prodClient").outcome == SUCCESS
+
+		where:
+		version << STANDARD_TEST_VERSIONS
+	}
+
+	@Timeout(value = 10, unit = TimeUnit.MINUTES)
+	@Unroll
+	@IgnoreIf({ !os.linux }) // XVFB is installed on the CI for this test
+	def "prod client 26.1 on 26.1.2 (gradle #version)"() {
+		setup:
+		def gradle = gradleProject(project: "minimalBaseNoRemap", version: version)
+		gradle.buildGradle << """
+                dependencies {
+                    minecraft "com.mojang:minecraft:26.1.2"
+                    implementation "${LoomTestVersions.FABRIC_LOADER.mavenNotation()}"
+                    implementation "net.fabricmc.fabric-api:fabric-api:0.152.1+26.1.2"
+
+                    productionRuntimeMods "net.fabricmc.fabric-api:fabric-api:0.145.1+26.1"
+                }
+
+                tasks.register("prodClient", net.fabricmc.loom.task.prod.ClientProductionRunTask) {
+                	jvmArgs.add("-Dfabric.client.gametest")
+                	minecraftVersion = "26.1"
+                }
+            """
+
+		when:
+		def result = gradle.run(task: "prodClient")
+
+		then:
+		result.task(":prodClient").outcome == SUCCESS
+
+		where:
+		version << STANDARD_TEST_VERSIONS
+	}
+
 	@Unroll
 	@IgnoreIf({ !os.linux })
 	def "client game tests with XVFB (gradle #version)"() {


### PR DESCRIPTION
I've currently tested with a template generated for 26.1.2, where adding a prod client run for 26.1 works and launches into the main menu, and a template project for 1.21.11, where a prod run for 1.20.1 also launches fine.