### PR TITLE
Make unobf output jar reproducible

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/ManifestModificationAction.java
+++ b/src/main/java/net/fabricmc/loom/task/ManifestModificationAction.java
@@ -35,17 +35,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.jar.Manifest;
 
-import net.fabricmc.loom.util.ZipReprocessorUtil;
-
 import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.provider.Provider;
 import org.gradle.jvm.tasks.Jar;
 
 import net.fabricmc.loom.task.service.JarManifestService;
-import net.fabricmc.loom.util.Check;
 import net.fabricmc.loom.util.Constants;
-import net.fabricmc.loom.util.ZipUtils;
+import net.fabricmc.loom.util.ZipReprocessorUtil;
 
 /**
  * Action that modifies the manifest of a jar file to add Loom metadata.

--- a/src/main/java/net/fabricmc/loom/task/ManifestModificationAction.java
+++ b/src/main/java/net/fabricmc/loom/task/ManifestModificationAction.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.jar.Manifest;
 
+import net.fabricmc.loom.util.ZipReprocessorUtil;
+
 import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.provider.Provider;
@@ -94,7 +96,7 @@ public class ManifestModificationAction implements Action<Task>, Serializable {
 			manifestAttributes.put(Constants.Manifest.CLIENT_ENTRIES, String.join(";", clientOnlyEntries.get()));
 		}
 
-		int count = ZipUtils.transform(jarFile.toPath(), Map.of(Constants.Manifest.PATH, bytes -> {
+		ZipReprocessorUtil.transformZipEntry(jarFile.toPath(), Constants.Manifest.PATH, bytes -> {
 			var manifest = new Manifest(new ByteArrayInputStream(bytes));
 
 			// Apply standard Loom manifest attributes (Gradle version, Loom version, etc.)
@@ -103,8 +105,6 @@ public class ManifestModificationAction implements Action<Task>, Serializable {
 			ByteArrayOutputStream out = new ByteArrayOutputStream();
 			manifest.write(out);
 			return out.toByteArray();
-		}));
-
-		Check.require(count > 0, "Did not transform any jar manifest");
+		});
 	}
 }


### PR DESCRIPTION
Avoids using NIO for modifying the output jar `MANIFEST.MF`. This may be slower, but prevents ZipFS from adding a timezone dependent time field to the jar, which would cause output to differ between environments with different timezones.