### PR TITLE
Publish Checkstyle and CodeNarc errors as GitHub checks

### DIFF
--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -29,6 +29,12 @@ jobs:
       - uses: actions/checkout@v6
       - uses: gradle/actions/wrapper-validation@v6
       - run: ./gradlew build check -x test --stacktrace --warning-mode fail
+      - uses: FabricMCBot/publish-checkstyle-report@v3
+        if: failure()
+        with:
+          reports: |
+            build/reports/checkstyle/*.xml
+            build/reports/codenarc/*.xml
 
   build_windows:
     if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.extended_tests == 'true' }}

--- a/build.gradle
+++ b/build.gradle
@@ -220,6 +220,10 @@ checkstyle {
 codenarc {
 	toolVersion = libs.versions.codenarc.get()
 	configFile = file("codenarc.groovy")
+
+	if (ENV.CI) {
+		reportFormat = 'xml'
+	}
 }
 
 gradlePlugin {


### PR DESCRIPTION
The config is otherwise the same as for the other repos where this action is used but it additionally reads the CodeNarc reports for Groovy code. The default CodeNarc report format is HTML which I feel is useful for dev envs, so the format is only set to XML for CI.