### PR TITLE
Fix NPE when calling NestableJarCreationTask#from multiple times.

### DIFF
--- a/src/main/java/net/fabricmc/loom/build/nesting/NestableJarGenerationTask.java
+++ b/src/main/java/net/fabricmc/loom/build/nesting/NestableJarGenerationTask.java
@@ -118,7 +118,7 @@ public abstract class NestableJarGenerationTask extends AbstractLoomTask {
 		});
 		getJars().from(artifacts.getFiles());
 		dependsOn(configuration);
-		getJarIds().set(artifacts.getArtifacts().getResolvedArtifacts().map(set -> {
+		getJarIds().putAll(artifacts.getArtifacts().getResolvedArtifacts().map(set -> {
 			Map<String, Metadata> map = new HashMap<>();
 			set.forEach(artifact -> {
 				ResolvedVariantResult variant = artifact.getVariant();


### PR DESCRIPTION
When `from()` is called more than once on the same task, the `getJarIds()` map is overwritten with each call (via `set()`). This discards metadata for earlier configurations, causing missing entries. Later during task execution the task tries to look up these missing entries which causes a NullPointerException.

See https://github.com/WilderForge/WilderWorkspace/issues/171