### PR TITLE
Add task for validating injected interfaces

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ gson = "2.14.0"
 
 stitch = "0.6.2"
 tiny-remapper = "0.14.0"
-clazz-tweaker = "0.3.0-beta.2"
+clazz-tweaker = "0.3.0"
 mapping-io = "0.8.0"
 lorenz-tiny = "4.0.2"
 mercury = "0.4.3"

--- a/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
@@ -241,7 +241,7 @@ public abstract class InterfaceInjectionProcessor implements MinecraftJarProcess
 		return commentBuilder.toString();
 	}
 
-	private record InjectedInterface(String modId, String className, String ifaceName, @Nullable String generics) {
+	public record InjectedInterface(String modId, String className, String ifaceName, @Nullable String generics) {
 		public static List<InjectedInterface> fromMod(FabricModJson fabricModJson) {
 			final String modId = fabricModJson.getId();
 			final JsonElement jsonElement = fabricModJson.getCustom(Constants.CustomModJsonKeys.INJECTED_INTERFACE);

--- a/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
@@ -203,14 +203,23 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 
 	private void checkInjectedInterface(byte[] classBytes, Consumer<Violation> violationConsumer) {
 		ClassVisitor visitor = new ClassVisitor(Opcodes.ASM9) {
-			private @Nullable String className;
+			private @Nullable String packageName;
+			private @Nullable String simpleClassName;
 			private @Nullable String sourceFile;
 
 			@Override
 			public void visit(int version, int access, String name, @Nullable String signature, @Nullable String superName, String @Nullable [] interfaces) {
-				// Strip the package to make the error messages more concise.
+				// Only the simple name is used in the error messages to make them more concise.
+				// The package is needed for resolving the source code file based on package + file name.
 				int slashIndex = name.lastIndexOf('/');
-				className = slashIndex >= 0 ? name.substring(slashIndex + 1) : name;
+
+				if (slashIndex >= 0) {
+					simpleClassName = name.substring(slashIndex + 1);
+					packageName = name.substring(0, slashIndex);
+				} else {
+					simpleClassName = name;
+					packageName = null;
+				}
 			}
 
 			@Override
@@ -223,7 +232,7 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 			@Override
 			public @Nullable MethodVisitor visitMethod(int access, String name, String descriptor, @Nullable String signature, String @Nullable [] exceptions) {
 				if ((access & Opcodes.ACC_ABSTRACT) != 0) {
-					violationConsumer.accept(new Violation(className, name, descriptor, resolveSourceFile(className, sourceFile)));
+					violationConsumer.accept(new Violation(simpleClassName, name, descriptor, resolveSourceFile(packageName, sourceFile)));
 				}
 
 				return null;
@@ -232,14 +241,12 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 		new ClassReader(classBytes).accept(visitor, ClassReader.SKIP_CODE | ClassReader.SKIP_FRAMES);
 	}
 
-	private @Nullable File resolveSourceFile(String className, @Nullable String sourceFileName) {
+	private @Nullable File resolveSourceFile(@Nullable String packageName, @Nullable String sourceFileName) {
 		if (sourceFileName == null) {
 			return null;
 		}
 
-		int slashIndex = className.lastIndexOf('/');
-		String directory = slashIndex >= 0 ? className.substring(0, className.lastIndexOf('/') + 1) : "";
-		String relativeSourcePath = directory + sourceFileName;
+		String relativeSourcePath = packageName != null ? packageName + File.separator + sourceFileName : sourceFileName;
 
 		for (File sourceRoot : getSourceRoots()) {
 			File sourceFile = new File(sourceRoot, relativeSourcePath);

--- a/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
@@ -117,7 +117,7 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 
 	public ValidateInjectedInterfacesTask() {
 		setGroup(JavaBasePlugin.VERIFICATION_GROUP);
-		problemReportingOptions = ProblemReportingOptions.createDefault(getProject());
+		problemReportingOptions = getProject().getObjects().newInstance(ProblemReportingOptions.class);
 
 		// Ignore outputs for up-to-date checks as there aren't any (so only inputs are checked)
 		getOutputs().upToDateWhen(task -> true);

--- a/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
@@ -77,7 +77,7 @@ import net.fabricmc.loom.util.problem.ProblemReportingOptions;
  *
  * <p>{@snippet lang=groovy :
  * tasks.register('validateInjectedInterfaces', net.fabricmc.loom.task.ValidateInjectedInterfacesTask) {
- * 	modJar = tasks.jar.flatMap { it.archiveFile }
+ * 	modJar = tasks.named('jar').flatMap { it.archiveFile }
  * 	sourceRoots.from(sourceSets.main.java.srcDirs)
  * }
  * }
@@ -97,6 +97,8 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 	/**
 	 * A collection of source code roots where the mod jar was built from.
 	 * This is used for resolving the corresponding source code files where report details are attached.
+	 *
+	 * <p>Adding source roots is optional. If not added, the file paths simply won't show up in error reports.
  	 */
 	@InputFiles
 	@PathSensitive(PathSensitivity.ABSOLUTE)

--- a/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
@@ -224,9 +224,7 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 
 			@Override
 			public void visitSource(@Nullable String source, @Nullable String debug) {
-				if (source != null) {
-					sourceFile = source;
-				}
+				sourceFile = source;
 			}
 
 			@Override

--- a/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
@@ -1,0 +1,249 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import javax.inject.Inject;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.problems.ProblemId;
+import org.gradle.api.problems.Problems;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.fabricmc.classtweaker.api.ClassTweakerReader;
+import net.fabricmc.classtweaker.api.visitor.ClassTweakerVisitor;
+import net.fabricmc.loom.configuration.ifaceinject.InterfaceInjectionProcessor;
+import net.fabricmc.loom.util.ExceptionUtil;
+import net.fabricmc.loom.util.LoomProblems;
+import net.fabricmc.loom.util.fmj.FabricModJson;
+import net.fabricmc.loom.util.fmj.FabricModJsonFactory;
+import net.fabricmc.loom.util.github.GithubActionsAnnotations;
+
+@DisableCachingByDefault
+public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
+	private static final Logger LOGGER = LoggerFactory.getLogger(ValidateInjectedInterfacesTask.class);
+	private static final ProblemId ABSTRACT_METHOD_IN_INJECTED_INTERFACE = LoomProblems.problemId("abstract-method-in-injected-interface", "Abstract method in injected interface");
+
+	/**
+	 * The mod jar to check.
+	 */
+	@InputFile
+	@PathSensitive(PathSensitivity.NONE)
+	public abstract RegularFileProperty getModJar();
+
+	/**
+	 * A collection of source code roots where the mod jar was built from.
+	 * This is used for resolving the corresponding source code files where report details are attached.
+ 	 */
+	@InputFiles
+	@PathSensitive(PathSensitivity.ABSOLUTE)
+	public abstract ConfigurableFileCollection getSourceRoots();
+
+	/**
+	 * If true, GitHub Actions annotations will be created and printed to stdout for each error detected by this task.
+	 */
+	@Input
+	public abstract Property<Boolean> getDisplayGithubActionsAnnotations();
+
+	@ApiStatus.Internal
+	@Inject
+	protected abstract Problems getProblems();
+
+	public ValidateInjectedInterfacesTask() {
+		setGroup(JavaBasePlugin.VERIFICATION_GROUP);
+		getDisplayGithubActionsAnnotations().convention(false);
+	}
+
+	@TaskAction
+	protected void check() throws IOException {
+		List<Violation> violations = new ArrayList<>();
+		Path modJar = getModJar().get().getAsFile().toPath();
+		FabricModJson fabricModJson = FabricModJsonFactory.createFromZip(modJar);
+		Set<String> injectedInterfaces = new HashSet<>();
+
+		// Look for injected interfaces in fabric.mod.json "custom" section
+		for (InterfaceInjectionProcessor.InjectedInterface injectedInterface : InterfaceInjectionProcessor.InjectedInterface.fromMod(fabricModJson)) {
+			injectedInterfaces.add(injectedInterface.ifaceName());
+		}
+
+		try (var zip = new ZipFile(modJar.toFile())) {
+			// Look for injected interfaces in class tweakers
+			for (String classTweaker : fabricModJson.getClassTweakers().keySet()) {
+				findInjectedInterfacesFromClassTweaker(zip, classTweaker, injectedInterfaces::add);
+			}
+
+			// Check injected interfaces
+			for (String itf : injectedInterfaces) {
+				ZipEntry classEntry = zip.getEntry(itf + ".class");
+
+				if (classEntry == null) {
+					LOGGER.info("Injected interface {} not found in mod jar {}, skipping validation", itf, modJar);
+					continue;
+				}
+
+				try (InputStream in = zip.getInputStream(classEntry)) {
+					checkInjectedInterface(in.readAllBytes(), violations::add);
+				}
+			}
+		}
+
+		if (!violations.isEmpty()) {
+			if (getDisplayGithubActionsAnnotations().get()) {
+				for (Violation violation : violations) {
+					if (violation.sourceFile == null) {
+						continue;
+					}
+
+					GithubActionsAnnotations.error("Injected interface has abstract method " + violation.methodName + violation.methodDesc)
+							.file(violation.sourceFile)
+							.build()
+							.printToStdout();
+				}
+			}
+
+			var messageBuilder = new StringBuilder("Found abstract methods in injected interfaces:");
+
+			for (Violation violation : violations) {
+				messageBuilder.append("\n - ").append(violation.itf).append('.').append(violation.methodName).append(violation.methodDesc);
+				getProblems().getReporter().report(ABSTRACT_METHOD_IN_INJECTED_INTERFACE, spec -> {
+					spec.contextualLabel("%s.%s%s".formatted(violation.itf, violation.methodName, violation.methodDesc));
+					spec.details("Method %s.%s%s is abstract.\nAll injected interface methods must have a default implementation.".formatted(violation.itf, violation.methodName, violation.methodDesc));
+					spec.solution("Add a default implementation to the method.");
+
+					if (violation.sourceFile != null) {
+						spec.fileLocation(violation.sourceFile.getAbsolutePath());
+					}
+				});
+			}
+
+			throw new RuntimeException(messageBuilder.toString());
+		}
+	}
+
+	private void findInjectedInterfacesFromClassTweaker(ZipFile zip, String classTweaker, Consumer<String> consumer) {
+		ZipEntry ctEntry = zip.getEntry(classTweaker);
+		ClassTweakerVisitor visitor = new ClassTweakerVisitor() {
+			@Override
+			public void visitInjectedInterface(String owner, String iface, boolean transitive) {
+				// Strip generics in case we have a signature instead of a class name
+				int genericsIndex = iface.indexOf('<');
+
+				if (genericsIndex >= 0) {
+					iface = iface.substring(0, genericsIndex);
+				}
+
+				consumer.accept(iface);
+			}
+		};
+
+		try (InputStream in = zip.getInputStream(ctEntry)) {
+			ClassTweakerReader.create(visitor).read(in.readAllBytes());
+		} catch (IOException e) {
+			throw ExceptionUtil.createDescriptiveWrapper(UncheckedIOException::new, "Could not read class tweaker " + classTweaker, e);
+		}
+	}
+
+	private void checkInjectedInterface(byte[] classBytes, Consumer<Violation> violationConsumer) {
+		ClassVisitor visitor = new ClassVisitor(Opcodes.ASM9) {
+			private @Nullable String className;
+			private @Nullable String sourceFile;
+
+			@Override
+			public void visit(int version, int access, String name, @Nullable String signature, @Nullable String superName, String @Nullable [] interfaces) {
+				className = name;
+			}
+
+			@Override
+			public void visitSource(@Nullable String source, @Nullable String debug) {
+				if (source != null) {
+					sourceFile = source;
+				}
+			}
+
+			@Override
+			public @Nullable MethodVisitor visitMethod(int access, String name, String descriptor, @Nullable String signature, String @Nullable [] exceptions) {
+				if ((access & Opcodes.ACC_ABSTRACT) != 0) {
+					violationConsumer.accept(new Violation(className, name,descriptor, resolveSourceFile(className, sourceFile)));
+				}
+
+				return null;
+			}
+		};
+		new ClassReader(classBytes).accept(visitor, ClassReader.SKIP_CODE | ClassReader.SKIP_FRAMES);
+	}
+
+	private @Nullable File resolveSourceFile(String className, @Nullable String sourceFileName) {
+		if (sourceFileName == null) {
+			return null;
+		}
+
+		int slashIndex = className.lastIndexOf('/');
+		String directory = slashIndex >= 0 ? className.substring(0, className.lastIndexOf('/') + 1) : "";
+		String relativeSourcePath = directory + sourceFileName;
+
+		for (File sourceRoot : getSourceRoots()) {
+			File sourceFile = new File(sourceRoot, relativeSourcePath);
+
+			if (sourceFile.exists()) {
+				return sourceFile;
+			}
+		}
+
+		return null;
+	}
+
+	private record Violation(String itf, String methodName, String methodDesc, @Nullable File sourceFile) {
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
@@ -73,6 +73,7 @@ import net.fabricmc.classtweaker.api.ClassTweakerReader;
 import net.fabricmc.classtweaker.api.visitor.ClassTweakerVisitor;
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.configuration.ifaceinject.InterfaceInjectionProcessor;
+import net.fabricmc.loom.configuration.providers.minecraft.MinecraftSourceSets;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.FileSystemUtil;
 import net.fabricmc.loom.util.fmj.FabricModJson;
@@ -90,7 +91,7 @@ import net.fabricmc.loom.util.problem.ProblemReportingOptions;
  * 	// By default, this task is set up for the default mod jar - the "jar" or "remapJar" task depending
  * 	// on the project configuration - and the main source set. To modify the defaults:
  * 	modJar = tasks.named('otherJar').flatMap { it.archiveFile }
- * 	sourceRoots.setFrom(sourceSets.other.java.srcDirs)
+ * 	source(sourceSets.other) // Add a new source set.
  * }
  * }
  */
@@ -111,6 +112,9 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 	 * This is used for resolving the corresponding source code files where report details are attached.
 	 *
 	 * <p>Adding source roots is optional. If not added, the file paths simply won't show up in error reports.
+	 *
+	 * <p>Sources from source sets can be added with {@link #source}. By default, the {@code main}
+	 * and {@code client} (if using split source sets) will be present in this collection.
 	 */
 	@InputFiles
 	@PathSensitive(PathSensitivity.ABSOLUTE)
@@ -137,17 +141,29 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 	}
 
 	private void configureForDefaultSetup() {
-		if (LoomGradleExtension.get(getProject()).dontRemapOutputs()) {
+		final LoomGradleExtension extension = LoomGradleExtension.get(getProject());
+
+		if (extension.dontRemapOutputs()) {
 			getModJar().convention(getProject().getTasks().named(JavaPlugin.JAR_TASK_NAME, Jar.class).flatMap(Jar::getArchiveFile));
 		} else {
 			getModJar().convention(getProject().getTasks().named(RemapTaskConfiguration.REMAP_JAR_TASK_NAME, Jar.class).flatMap(Jar::getArchiveFile));
 		}
 
-		getSourceRoots().from(
-				SourceSetHelper.getSourceSets(getProject())
-						.named(SourceSet.MAIN_SOURCE_SET_NAME)
-						.map(sourceSet -> sourceSet.getJava().getSrcDirs())
-		);
+		source(SourceSetHelper.getMainSourceSet(getProject()));
+
+		if (extension.areEnvironmentSourceSetsSplit()) {
+			source(SourceSetHelper.getSourceSetByName(MinecraftSourceSets.Split.CLIENT_ONLY_SOURCE_SET_NAME, getProject()));
+		}
+	}
+
+	/**
+	 * Adds all sources from a {@link SourceSet} to the {@linkplain #getSourceRoots() source roots}
+	 * for error messages.
+	 *
+	 * @param sourceSet the source set to add
+	 */
+	public void source(SourceSet sourceSet) {
+		getSourceRoots().from(sourceSet.getAllSource().getSrcDirs());
 	}
 
 	public void problemReportingOptions(Action<? super ProblemReportingOptions> action) {

--- a/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
@@ -160,24 +160,22 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 			}
 		}
 
-		if (!violations.isEmpty()) {
-			var reporter = new LoomProblemReporter(getProblems().getReporter(), getProblemReportingOptions());
+		var reporter = new LoomProblemReporter(getProblems().getReporter(), getProblemReportingOptions());
 
-			for (Violation violation : violations) {
-				reporter.problem(ABSTRACT_METHOD_IN_INJECTED_INTERFACE, builder -> {
-					builder.contextualLabel("%s.%s%s".formatted(violation.itf, violation.methodName, violation.methodDesc));
-					builder.message("Injected interface %s has abstract method %s%s".formatted(violation.itf, violation.methodName, violation.methodDesc));
-					builder.details("Method %s.%s%s is abstract.\nAll injected interface methods must have a default implementation.".formatted(violation.itf, violation.methodName, violation.methodDesc));
-					builder.solution("Add a default implementation to the method.");
+		for (Violation violation : violations) {
+			reporter.problem(ABSTRACT_METHOD_IN_INJECTED_INTERFACE, builder -> {
+				builder.contextualLabel("%s.%s%s".formatted(violation.itf, violation.methodName, violation.methodDesc));
+				builder.message("Injected interface %s has abstract method %s%s".formatted(violation.itf, violation.methodName, violation.methodDesc));
+				builder.details("Method %s.%s%s is abstract.\nAll injected interface methods must have a default implementation.".formatted(violation.itf, violation.methodName, violation.methodDesc));
+				builder.solution("Add a default implementation to the method.");
 
-					if (violation.sourceFile != null) {
-						builder.fileLocation(violation.sourceFile.toPath());
-					}
-				});
-			}
-
-			reporter.reportAndThrow(ABSTRACT_METHOD_IN_INJECTED_INTERFACE);
+				if (violation.sourceFile != null) {
+					builder.fileLocation(violation.sourceFile.toPath());
+				}
+			});
 		}
+
+		reporter.reportAndThrow(ABSTRACT_METHOD_IN_INJECTED_INTERFACE);
 	}
 
 	private void findInjectedInterfacesFromClassTweaker(ZipFile zip, String classTweaker, Consumer<String> consumer) {

--- a/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
@@ -39,13 +39,13 @@ import java.util.zip.ZipFile;
 
 import javax.inject.Inject;
 
+import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.Problems;
-import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Nested;
@@ -103,18 +103,26 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 	public abstract ConfigurableFileCollection getSourceRoots();
 
 	@Nested
-	public abstract Property<ProblemReportingOptions> getProblemReportingOptions();
+	public ProblemReportingOptions getProblemReportingOptions() {
+		return problemReportingOptions;
+	}
 
 	@ApiStatus.Internal
 	@Inject
 	protected abstract Problems getProblems();
 
+	private final ProblemReportingOptions problemReportingOptions;
+
 	public ValidateInjectedInterfacesTask() {
 		setGroup(JavaBasePlugin.VERIFICATION_GROUP);
-		getProblemReportingOptions().convention(ProblemReportingOptions.createDefault(getProject()));
+		problemReportingOptions = ProblemReportingOptions.createDefault(getProject());
 
 		// Ignore outputs for up-to-date checks as there aren't any (so only inputs are checked)
 		getOutputs().upToDateWhen(task -> true);
+	}
+
+	public void problemReportingOptions(Action<? super ProblemReportingOptions> action) {
+		action.execute(getProblemReportingOptions());
 	}
 
 	@TaskAction
@@ -151,7 +159,7 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 		}
 
 		if (!violations.isEmpty()) {
-			var reporter = new LoomProblemReporter(getProblems().getReporter(), getProblemReportingOptions().get());
+			var reporter = new LoomProblemReporter(getProblems().getReporter(), getProblemReportingOptions());
 
 			for (Violation violation : violations) {
 				reporter.problem(ABSTRACT_METHOD_IN_INJECTED_INTERFACE, builder -> {

--- a/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
@@ -99,7 +99,7 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 	 * This is used for resolving the corresponding source code files where report details are attached.
 	 *
 	 * <p>Adding source roots is optional. If not added, the file paths simply won't show up in error reports.
- 	 */
+	 */
 	@InputFiles
 	@PathSensitive(PathSensitivity.ABSOLUTE)
 	public abstract ConfigurableFileCollection getSourceRoots();
@@ -223,7 +223,7 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 			@Override
 			public @Nullable MethodVisitor visitMethod(int access, String name, String descriptor, @Nullable String signature, String @Nullable [] exceptions) {
 				if ((access & Opcodes.ACC_ABSTRACT) != 0) {
-					violationConsumer.accept(new Violation(className, name,descriptor, resolveSourceFile(className, sourceFile)));
+					violationConsumer.accept(new Violation(className, name, descriptor, resolveSourceFile(className, sourceFile)));
 				}
 
 				return null;

--- a/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
@@ -46,9 +46,9 @@ import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.Problems;
 import org.gradle.api.provider.Property;
-import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
@@ -66,11 +66,22 @@ import net.fabricmc.classtweaker.api.ClassTweakerReader;
 import net.fabricmc.classtweaker.api.visitor.ClassTweakerVisitor;
 import net.fabricmc.loom.configuration.ifaceinject.InterfaceInjectionProcessor;
 import net.fabricmc.loom.util.ExceptionUtil;
-import net.fabricmc.loom.util.LoomProblems;
 import net.fabricmc.loom.util.fmj.FabricModJson;
 import net.fabricmc.loom.util.fmj.FabricModJsonFactory;
-import net.fabricmc.loom.util.github.GithubActionsAnnotations;
+import net.fabricmc.loom.util.problem.LoomProblemReporter;
+import net.fabricmc.loom.util.problem.LoomProblems;
+import net.fabricmc.loom.util.problem.ProblemReportingOptions;
 
+/**
+ * Checks that injected interfaces are valid, i.e. that all their instance methods have a default implementation.
+ *
+ * <p>{@snippet lang=groovy :
+ * tasks.register('validateInjectedInterfaces', net.fabricmc.loom.task.ValidateInjectedInterfacesTask) {
+ * 	modJar = tasks.jar.flatMap { it.archiveFile }
+ * 	sourceRoots.from(sourceSets.main.java.srcDirs)
+ * }
+ * }
+ */
 @DisableCachingByDefault
 public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ValidateInjectedInterfacesTask.class);
@@ -91,11 +102,8 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 	@PathSensitive(PathSensitivity.ABSOLUTE)
 	public abstract ConfigurableFileCollection getSourceRoots();
 
-	/**
-	 * If true, GitHub Actions annotations will be created and printed to stdout for each error detected by this task.
-	 */
-	@Input
-	public abstract Property<Boolean> getDisplayGithubActionsAnnotations();
+	@Nested
+	public abstract Property<ProblemReportingOptions> getProblemReportingOptions();
 
 	@ApiStatus.Internal
 	@Inject
@@ -103,7 +111,10 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 
 	public ValidateInjectedInterfacesTask() {
 		setGroup(JavaBasePlugin.VERIFICATION_GROUP);
-		getDisplayGithubActionsAnnotations().convention(false);
+		getProblemReportingOptions().convention(ProblemReportingOptions.createDefault(getProject()));
+
+		// Ignore outputs for up-to-date checks as there aren't any (so only inputs are checked)
+		getOutputs().upToDateWhen(task -> true);
 	}
 
 	@TaskAction
@@ -140,35 +151,23 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 		}
 
 		if (!violations.isEmpty()) {
-			if (getDisplayGithubActionsAnnotations().get()) {
-				for (Violation violation : violations) {
-					if (violation.sourceFile == null) {
-						continue;
-					}
-
-					GithubActionsAnnotations.error("Injected interface has abstract method " + violation.methodName + violation.methodDesc)
-							.file(violation.sourceFile)
-							.build()
-							.printToStdout();
-				}
-			}
-
-			var messageBuilder = new StringBuilder("Found abstract methods in injected interfaces:");
+			var reporter = new LoomProblemReporter(getProblems().getReporter(), getProblemReportingOptions().get());
 
 			for (Violation violation : violations) {
-				messageBuilder.append("\n - ").append(violation.itf).append('.').append(violation.methodName).append(violation.methodDesc);
-				getProblems().getReporter().report(ABSTRACT_METHOD_IN_INJECTED_INTERFACE, spec -> {
-					spec.contextualLabel("%s.%s%s".formatted(violation.itf, violation.methodName, violation.methodDesc));
-					spec.details("Method %s.%s%s is abstract.\nAll injected interface methods must have a default implementation.".formatted(violation.itf, violation.methodName, violation.methodDesc));
-					spec.solution("Add a default implementation to the method.");
+				reporter.problem(ABSTRACT_METHOD_IN_INJECTED_INTERFACE, builder -> {
+					String qualifiedMethodName = "%s.%s%s".formatted(violation.itf, violation.methodName, violation.methodDesc);
+					builder.contextualLabel(qualifiedMethodName);
+					builder.message(qualifiedMethodName);
+					builder.details("Method %s.%s%s is abstract.\nAll injected interface methods must have a default implementation.".formatted(violation.itf, violation.methodName, violation.methodDesc));
+					builder.solution("Add a default implementation to the method.");
 
 					if (violation.sourceFile != null) {
-						spec.fileLocation(violation.sourceFile.getAbsolutePath());
+						builder.fileLocation(violation.sourceFile.toPath());
 					}
 				});
 			}
 
-			throw new RuntimeException(messageBuilder.toString());
+			reporter.reportAndThrow(ABSTRACT_METHOD_IN_INJECTED_INTERFACE);
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
@@ -42,10 +42,12 @@ import javax.inject.Inject;
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.Problems;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Nested;
@@ -53,6 +55,10 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.work.DisableCachingByDefault;
+import org.gradle.workers.WorkAction;
+import org.gradle.workers.WorkParameters;
+import org.gradle.workers.WorkQueue;
+import org.gradle.workers.WorkerExecutor;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.Nullable;
 import org.objectweb.asm.ClassReader;
@@ -111,7 +117,7 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 
 	@ApiStatus.Internal
 	@Inject
-	protected abstract Problems getProblems();
+	protected abstract WorkerExecutor getWorkerExecutor();
 
 	private final ProblemReportingOptions problemReportingOptions;
 
@@ -129,56 +135,16 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 
 	@TaskAction
 	protected void check() throws IOException {
-		List<Violation> violations = new ArrayList<>();
-		Path modJar = getModJar().get().getAsFile().toPath();
-		FabricModJson fabricModJson = FabricModJsonFactory.createFromZip(modJar);
-		Set<String> injectedInterfaces = new HashSet<>();
+		final WorkQueue workQueue = getWorkerExecutor().noIsolation();
 
-		// Look for injected interfaces in fabric.mod.json "custom" section
-		for (InterfaceInjectionProcessor.InjectedInterface injectedInterface : InterfaceInjectionProcessor.InjectedInterface.fromMod(fabricModJson)) {
-			injectedInterfaces.add(injectedInterface.ifaceName());
-		}
-
-		try (var zip = new ZipFile(modJar.toFile())) {
-			// Look for injected interfaces in class tweakers
-			for (String classTweaker : fabricModJson.getClassTweakers().keySet()) {
-				findInjectedInterfacesFromClassTweaker(zip, classTweaker, injectedInterfaces::add);
-			}
-
-			// Check injected interfaces
-			for (String itf : injectedInterfaces) {
-				ZipEntry classEntry = zip.getEntry(itf + ".class");
-
-				if (classEntry == null) {
-					LOGGER.info("Injected interface {} not found in mod jar {}, skipping validation", itf, modJar);
-					continue;
-				}
-
-				try (InputStream in = zip.getInputStream(classEntry)) {
-					checkInjectedInterface(in.readAllBytes(), violations::add);
-				}
-			}
-		}
-
-		var reporter = new LoomProblemReporter(getProblems().getReporter(), getProblemReportingOptions());
-
-		for (Violation violation : violations) {
-			reporter.problem(ABSTRACT_METHOD_IN_INJECTED_INTERFACE, builder -> {
-				builder.contextualLabel("%s.%s%s".formatted(violation.itf, violation.methodName, violation.methodDesc));
-				builder.message("Injected interface %s has abstract method %s%s".formatted(violation.itf, violation.methodName, violation.methodDesc));
-				builder.details("Method %s.%s%s is abstract.\nAll injected interface methods must have a default implementation.".formatted(violation.itf, violation.methodName, violation.methodDesc));
-				builder.solution("Add a default implementation to the method.");
-
-				if (violation.sourceFile != null) {
-					builder.fileLocation(violation.sourceFile.toPath());
-				}
-			});
-		}
-
-		reporter.reportAndThrow(ABSTRACT_METHOD_IN_INJECTED_INTERFACE);
+		workQueue.submit(ValidateInjectedInterfacesAction.class, params -> {
+			params.getModJar().set(getModJar());
+			params.getSourceRoots().from(getSourceRoots());
+			params.getProblemReportingOptions().set(getProblemReportingOptions());
+		});
 	}
 
-	private void findInjectedInterfacesFromClassTweaker(ZipFile zip, String classTweaker, Consumer<String> consumer) {
+	private static void findInjectedInterfacesFromClassTweaker(ZipFile zip, String classTweaker, Consumer<String> consumer) {
 		ZipEntry ctEntry = zip.getEntry(classTweaker);
 		ClassTweakerVisitor visitor = new ClassTweakerVisitor() {
 			@Override
@@ -201,7 +167,7 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 		}
 	}
 
-	private void checkInjectedInterface(byte[] classBytes, Consumer<Violation> violationConsumer) {
+	private static void checkInjectedInterface(byte[] classBytes, FileCollection sourceRoots, Consumer<Violation> violationConsumer) {
 		ClassVisitor visitor = new ClassVisitor(Opcodes.ASM9) {
 			private @Nullable String packageName;
 			private @Nullable String simpleClassName;
@@ -230,7 +196,7 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 			@Override
 			public @Nullable MethodVisitor visitMethod(int access, String name, String descriptor, @Nullable String signature, String @Nullable [] exceptions) {
 				if ((access & Opcodes.ACC_ABSTRACT) != 0) {
-					violationConsumer.accept(new Violation(simpleClassName, name, descriptor, resolveSourceFile(packageName, sourceFile)));
+					violationConsumer.accept(new Violation(simpleClassName, name, descriptor, resolveSourceFile(packageName, sourceFile, sourceRoots)));
 				}
 
 				return null;
@@ -239,14 +205,14 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 		new ClassReader(classBytes).accept(visitor, ClassReader.SKIP_CODE | ClassReader.SKIP_FRAMES);
 	}
 
-	private @Nullable File resolveSourceFile(@Nullable String packageName, @Nullable String sourceFileName) {
+	private static @Nullable File resolveSourceFile(@Nullable String packageName, @Nullable String sourceFileName, FileCollection sourceRoots) {
 		if (sourceFileName == null) {
 			return null;
 		}
 
 		String relativeSourcePath = packageName != null ? packageName + File.separator + sourceFileName : sourceFileName;
 
-		for (File sourceRoot : getSourceRoots()) {
+		for (File sourceRoot : sourceRoots) {
 			File sourceFile = new File(sourceRoot, relativeSourcePath);
 
 			if (sourceFile.exists()) {
@@ -255,6 +221,78 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 		}
 
 		return null;
+	}
+
+	@ApiStatus.Internal
+	public interface ValidateInjectedInterfacesParams extends WorkParameters {
+		RegularFileProperty getModJar();
+		ConfigurableFileCollection getSourceRoots();
+		Property<ProblemReportingOptions> getProblemReportingOptions();
+	}
+
+	@ApiStatus.Internal
+	public abstract static class ValidateInjectedInterfacesAction implements WorkAction<ValidateInjectedInterfacesParams> {
+		@Inject
+		protected abstract Problems getProblems();
+
+		@Override
+		public void execute() {
+			try {
+				check();
+			} catch (IOException e) {
+				throw new UncheckedIOException(e);
+			}
+		}
+
+		private void check() throws IOException {
+			List<Violation> violations = new ArrayList<>();
+			Path modJar = getParameters().getModJar().get().getAsFile().toPath();
+			FabricModJson fabricModJson = FabricModJsonFactory.createFromZip(modJar);
+			Set<String> injectedInterfaces = new HashSet<>();
+
+			// Look for injected interfaces in fabric.mod.json "custom" section
+			for (InterfaceInjectionProcessor.InjectedInterface injectedInterface : InterfaceInjectionProcessor.InjectedInterface.fromMod(fabricModJson)) {
+				injectedInterfaces.add(injectedInterface.ifaceName());
+			}
+
+			try (var zip = new ZipFile(modJar.toFile())) {
+				// Look for injected interfaces in class tweakers
+				for (String classTweaker : fabricModJson.getClassTweakers().keySet()) {
+					findInjectedInterfacesFromClassTweaker(zip, classTweaker, injectedInterfaces::add);
+				}
+
+				// Check injected interfaces
+				for (String itf : injectedInterfaces) {
+					ZipEntry classEntry = zip.getEntry(itf + ".class");
+
+					if (classEntry == null) {
+						LOGGER.info("Injected interface {} not found in mod jar {}, skipping validation", itf, modJar);
+						continue;
+					}
+
+					try (InputStream in = zip.getInputStream(classEntry)) {
+						checkInjectedInterface(in.readAllBytes(), getParameters().getSourceRoots(), violations::add);
+					}
+				}
+			}
+
+			var reporter = new LoomProblemReporter(getProblems().getReporter(), getParameters().getProblemReportingOptions().get());
+
+			for (Violation violation : violations) {
+				reporter.problem(ABSTRACT_METHOD_IN_INJECTED_INTERFACE, builder -> {
+					builder.contextualLabel("%s.%s%s".formatted(violation.itf, violation.methodName, violation.methodDesc));
+					builder.message("Injected interface %s has abstract method %s%s".formatted(violation.itf, violation.methodName, violation.methodDesc));
+					builder.details("Method %s.%s%s is abstract.\nAll injected interface methods must have a default implementation.".formatted(violation.itf, violation.methodName, violation.methodDesc));
+					builder.solution("Add a default implementation to the method.");
+
+					if (violation.sourceFile != null) {
+						builder.fileLocation(violation.sourceFile.toPath());
+					}
+				});
+			}
+
+			reporter.reportAndThrow(ABSTRACT_METHOD_IN_INJECTED_INTERFACE);
+		}
 	}
 
 	private record Violation(String itf, String methodName, String methodDesc, @Nullable File sourceFile) {

--- a/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
@@ -26,17 +26,15 @@ package net.fabricmc.loom.task;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Modifier;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 import javax.inject.Inject;
 
@@ -72,7 +70,7 @@ import net.fabricmc.classtweaker.api.ClassTweakerReader;
 import net.fabricmc.classtweaker.api.visitor.ClassTweakerVisitor;
 import net.fabricmc.loom.configuration.ifaceinject.InterfaceInjectionProcessor;
 import net.fabricmc.loom.util.Constants;
-import net.fabricmc.loom.util.ExceptionUtil;
+import net.fabricmc.loom.util.FileSystemUtil;
 import net.fabricmc.loom.util.fmj.FabricModJson;
 import net.fabricmc.loom.util.fmj.FabricModJsonFactory;
 import net.fabricmc.loom.util.problem.LoomProblemReporter;
@@ -145,8 +143,7 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 		});
 	}
 
-	private static void findInjectedInterfacesFromClassTweaker(ZipFile zip, String classTweaker, Consumer<String> consumer) {
-		ZipEntry ctEntry = zip.getEntry(classTweaker);
+	private static void findInjectedInterfacesFromClassTweaker(byte[] ctBytes, Consumer<String> consumer) {
 		ClassTweakerVisitor visitor = new ClassTweakerVisitor() {
 			@Override
 			public void visitInjectedInterface(String owner, String iface, boolean transitive) {
@@ -161,11 +158,7 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 			}
 		};
 
-		try (InputStream in = zip.getInputStream(ctEntry)) {
-			ClassTweakerReader.create(visitor).read(in.readAllBytes());
-		} catch (IOException e) {
-			throw ExceptionUtil.createDescriptiveWrapper(UncheckedIOException::new, "Could not read class tweaker " + classTweaker, e);
-		}
+		ClassTweakerReader.create(visitor).read(ctBytes);
 	}
 
 	private static void checkInjectedInterface(byte[] classBytes, FileCollection sourceRoots, Consumer<Violation> violationConsumer) {
@@ -256,24 +249,24 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 				injectedInterfaces.add(injectedInterface.ifaceName());
 			}
 
-			try (var zip = new ZipFile(modJar.toFile())) {
+			try (FileSystemUtil.Delegate fs = FileSystemUtil.getJarFileSystem(modJar)) {
 				// Look for injected interfaces in class tweakers
 				for (String classTweaker : fabricModJson.getClassTweakers().keySet()) {
-					findInjectedInterfacesFromClassTweaker(zip, classTweaker, injectedInterfaces::add);
+					byte[] ctBytes = Files.readAllBytes(fs.getPath(classTweaker));
+					findInjectedInterfacesFromClassTweaker(ctBytes, injectedInterfaces::add);
 				}
 
 				// Check injected interfaces
 				for (String itf : injectedInterfaces) {
-					ZipEntry classEntry = zip.getEntry(itf + ".class");
+					Path interfacePath = fs.getPath(itf + ".class");
 
-					if (classEntry == null) {
+					if (!Files.exists(interfacePath)) {
 						LOGGER.info("Injected interface {} not found in mod jar {}, skipping validation", itf, modJar);
 						continue;
 					}
 
-					try (InputStream in = zip.getInputStream(classEntry)) {
-						checkInjectedInterface(in.readAllBytes(), getParameters().getSourceRoots(), violations::add);
-					}
+					byte[] classBytes = Files.readAllBytes(interfacePath);
+					checkInjectedInterface(classBytes, getParameters().getSourceRoots(), violations::add);
 				}
 			}
 

--- a/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
@@ -44,6 +44,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.Problems;
 import org.gradle.api.provider.Property;
@@ -52,7 +53,9 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.jvm.tasks.Jar;
 import org.gradle.work.DisableCachingByDefault;
 import org.gradle.workers.WorkAction;
 import org.gradle.workers.WorkParameters;
@@ -68,11 +71,13 @@ import org.slf4j.LoggerFactory;
 
 import net.fabricmc.classtweaker.api.ClassTweakerReader;
 import net.fabricmc.classtweaker.api.visitor.ClassTweakerVisitor;
+import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.configuration.ifaceinject.InterfaceInjectionProcessor;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.FileSystemUtil;
 import net.fabricmc.loom.util.fmj.FabricModJson;
 import net.fabricmc.loom.util.fmj.FabricModJsonFactory;
+import net.fabricmc.loom.util.gradle.SourceSetHelper;
 import net.fabricmc.loom.util.problem.LoomProblemReporter;
 import net.fabricmc.loom.util.problem.LoomProblems;
 import net.fabricmc.loom.util.problem.ProblemReportingOptions;
@@ -82,8 +87,10 @@ import net.fabricmc.loom.util.problem.ProblemReportingOptions;
  *
  * <p>{@snippet lang=groovy :
  * tasks.register('validateInjectedInterfaces', net.fabricmc.loom.task.ValidateInjectedInterfacesTask) {
- * 	modJar = tasks.named('jar').flatMap { it.archiveFile }
- * 	sourceRoots.from(sourceSets.main.java.srcDirs)
+ * 	// By default, this task is set up for the default mod jar - the "jar" or "remapJar" task depending
+ * 	// on the project configuration - and the main source set. To modify the defaults:
+ * 	modJar = tasks.named('otherJar').flatMap { it.archiveFile }
+ * 	sourceRoots.setFrom(sourceSets.other.java.srcDirs)
  * }
  * }
  */
@@ -123,9 +130,24 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 	public ValidateInjectedInterfacesTask() {
 		setGroup(JavaBasePlugin.VERIFICATION_GROUP);
 		problemReportingOptions = getProject().getObjects().newInstance(ProblemReportingOptions.class);
+		configureForDefaultSetup();
 
 		// Ignore outputs for up-to-date checks as there aren't any (so only inputs are checked)
 		getOutputs().upToDateWhen(task -> true);
+	}
+
+	private void configureForDefaultSetup() {
+		if (LoomGradleExtension.get(getProject()).dontRemapOutputs()) {
+			getModJar().convention(getProject().getTasks().named(JavaPlugin.JAR_TASK_NAME, Jar.class).flatMap(Jar::getArchiveFile));
+		} else {
+			getModJar().convention(getProject().getTasks().named(RemapTaskConfiguration.REMAP_JAR_TASK_NAME, Jar.class).flatMap(Jar::getArchiveFile));
+		}
+
+		getSourceRoots().from(
+				SourceSetHelper.getSourceSets(getProject())
+						.named(SourceSet.MAIN_SOURCE_SET_NAME)
+						.map(sourceSet -> sourceSet.getJava().getSrcDirs())
+		);
 	}
 
 	public void problemReportingOptions(Action<? super ProblemReportingOptions> action) {

--- a/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
@@ -203,7 +203,7 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 		ClassVisitor visitor = new ClassVisitor(Constants.ASM_VERSION) {
 			private @Nullable String packageName;
 			private @Nullable String simpleClassName;
-			private @Nullable String sourceFile;
+			private @Nullable String sourceFileName;
 
 			@Override
 			public void visit(int version, int access, String name, @Nullable String signature, @Nullable String superName, String @Nullable [] interfaces) {
@@ -222,13 +222,14 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 
 			@Override
 			public void visitSource(@Nullable String source, @Nullable String debug) {
-				sourceFile = source;
+				sourceFileName = source;
 			}
 
 			@Override
 			public @Nullable MethodVisitor visitMethod(int access, String name, String descriptor, @Nullable String signature, String @Nullable [] exceptions) {
 				if (Modifier.isAbstract(access)) {
-					violationConsumer.accept(new Violation(simpleClassName, name, descriptor, resolveSourceFile(packageName, sourceFile, sourceRoots)));
+					final File sourceFile = resolveSourceFile(simpleClassName, packageName, sourceFileName, sourceRoots);
+					violationConsumer.accept(new Violation(simpleClassName, name, descriptor, sourceFile));
 				}
 
 				return null;
@@ -237,8 +238,9 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 		new ClassReader(classBytes).accept(visitor, ClassReader.SKIP_CODE | ClassReader.SKIP_FRAMES);
 	}
 
-	private static @Nullable File resolveSourceFile(@Nullable String packageName, @Nullable String sourceFileName, FileCollection sourceRoots) {
+	private static @Nullable File resolveSourceFile(String className, @Nullable String packageName, @Nullable String sourceFileName, FileCollection sourceRoots) {
 		if (sourceFileName == null) {
+			LOGGER.warn("No source file name present for injected interface {} (package {})", className, packageName);
 			return null;
 		}
 

--- a/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.lang.reflect.Modifier;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -64,13 +65,13 @@ import org.jspecify.annotations.Nullable;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.fabricmc.classtweaker.api.ClassTweakerReader;
 import net.fabricmc.classtweaker.api.visitor.ClassTweakerVisitor;
 import net.fabricmc.loom.configuration.ifaceinject.InterfaceInjectionProcessor;
+import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.ExceptionUtil;
 import net.fabricmc.loom.util.fmj.FabricModJson;
 import net.fabricmc.loom.util.fmj.FabricModJsonFactory;
@@ -168,7 +169,7 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 	}
 
 	private static void checkInjectedInterface(byte[] classBytes, FileCollection sourceRoots, Consumer<Violation> violationConsumer) {
-		ClassVisitor visitor = new ClassVisitor(Opcodes.ASM9) {
+		ClassVisitor visitor = new ClassVisitor(Constants.ASM_VERSION) {
 			private @Nullable String packageName;
 			private @Nullable String simpleClassName;
 			private @Nullable String sourceFile;
@@ -195,7 +196,7 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 
 			@Override
 			public @Nullable MethodVisitor visitMethod(int access, String name, String descriptor, @Nullable String signature, String @Nullable [] exceptions) {
-				if ((access & Opcodes.ACC_ABSTRACT) != 0) {
+				if (Modifier.isAbstract(access)) {
 					violationConsumer.accept(new Violation(simpleClassName, name, descriptor, resolveSourceFile(packageName, sourceFile, sourceRoots)));
 				}
 

--- a/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ValidateInjectedInterfacesTask.java
@@ -165,9 +165,8 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 
 			for (Violation violation : violations) {
 				reporter.problem(ABSTRACT_METHOD_IN_INJECTED_INTERFACE, builder -> {
-					String qualifiedMethodName = "%s.%s%s".formatted(violation.itf, violation.methodName, violation.methodDesc);
-					builder.contextualLabel(qualifiedMethodName);
-					builder.message(qualifiedMethodName);
+					builder.contextualLabel("%s.%s%s".formatted(violation.itf, violation.methodName, violation.methodDesc));
+					builder.message("Injected interface %s has abstract method %s%s".formatted(violation.itf, violation.methodName, violation.methodDesc));
 					builder.details("Method %s.%s%s is abstract.\nAll injected interface methods must have a default implementation.".formatted(violation.itf, violation.methodName, violation.methodDesc));
 					builder.solution("Add a default implementation to the method.");
 
@@ -211,7 +210,9 @@ public abstract class ValidateInjectedInterfacesTask extends DefaultTask {
 
 			@Override
 			public void visit(int version, int access, String name, @Nullable String signature, @Nullable String superName, String @Nullable [] interfaces) {
-				className = name;
+				// Strip the package to make the error messages more concise.
+				int slashIndex = name.lastIndexOf('/');
+				className = slashIndex >= 0 ? name.substring(slashIndex + 1) : name;
 			}
 
 			@Override

--- a/src/main/java/net/fabricmc/loom/task/ValidateMixinNameTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ValidateMixinNameTask.java
@@ -39,6 +39,7 @@ import javax.inject.Inject;
 
 import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.SourceTask;
@@ -82,7 +83,7 @@ public abstract class ValidateMixinNameTask extends SourceTask {
 
 	@Inject
 	public ValidateMixinNameTask() {
-		setGroup("verification");
+		setGroup(JavaBasePlugin.VERIFICATION_GROUP);
 		getProject().getTasks().getByName("check").dependsOn(this);
 		getSoftFailures().convention(false);
 	}

--- a/src/main/java/net/fabricmc/loom/task/tool/ModEnigmaTask.java
+++ b/src/main/java/net/fabricmc/loom/task/tool/ModEnigmaTask.java
@@ -47,8 +47,8 @@ import org.gradle.process.ExecOperations;
 import org.jetbrains.annotations.ApiStatus;
 
 import net.fabricmc.loom.task.AbstractLoomTask;
-import net.fabricmc.loom.util.LoomProblems;
 import net.fabricmc.loom.util.LoomVersions;
+import net.fabricmc.loom.util.problem.LoomProblems;
 
 /**
  * Add this task to a mod development environment to use Enigma against the game jars.

--- a/src/main/java/net/fabricmc/loom/task/tool/ValidateModProvidedJavadocTask.java
+++ b/src/main/java/net/fabricmc/loom/task/tool/ValidateModProvidedJavadocTask.java
@@ -37,6 +37,7 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import org.gradle.api.Action;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.problems.ProblemId;
 import org.gradle.api.problems.Problems;
@@ -104,24 +105,32 @@ public abstract class ValidateModProvidedJavadocTask extends AbstractLoomTask {
 	public abstract Property<String> getExpectedNamespace();
 
 	@Nested
-	public abstract Property<ProblemReportingOptions> getProblemReportingOptions();
+	public ProblemReportingOptions getProblemReportingOptions() {
+		return problemReportingOptions;
+	}
 
 	@ApiStatus.Internal
 	@Inject
 	protected abstract Problems getProblems();
 
+	private final ProblemReportingOptions problemReportingOptions;
+
 	public ValidateModProvidedJavadocTask() {
 		getMinecraftJars().convention(getExtension().getProductionNamespaceEnum().map(getExtension()::getMinecraftJarsCollection));
 		getExpectedNamespace().convention(getExtension().getProductionNamespace());
-		getProblemReportingOptions().convention(ProblemReportingOptions.createDefault(getProject()));
+		problemReportingOptions = ProblemReportingOptions.createDefault(getProject());
 
 		// Ignore outputs for up-to-date checks as there aren't any (so only inputs are checked)
 		getOutputs().upToDateWhen(task -> true);
 	}
 
+	public void problemReportingOptions(Action<? super ProblemReportingOptions> action) {
+		action.execute(getProblemReportingOptions());
+	}
+
 	@TaskAction
 	protected void check() throws IOException {
-		final var reporter = new LoomProblemReporter(getProblems().getReporter(), getProblemReportingOptions().get());
+		final var reporter = new LoomProblemReporter(getProblems().getReporter(), getProblemReportingOptions());
 		final ErrorReporter errorReporter = (problemId, currentPath, details, cause) -> reporter.problem(problemId, builder -> {
 			builder.fileLocation(currentPath);
 

--- a/src/main/java/net/fabricmc/loom/task/tool/ValidateModProvidedJavadocTask.java
+++ b/src/main/java/net/fabricmc/loom/task/tool/ValidateModProvidedJavadocTask.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2025 FabricMC
+ * Copyright (c) 2025-2026 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,12 +39,12 @@ import javax.inject.Inject;
 
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.problems.ProblemId;
-import org.gradle.api.problems.ProblemReporter;
 import org.gradle.api.problems.Problems;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
@@ -60,7 +60,9 @@ import org.objectweb.asm.tree.MethodNode;
 
 import net.fabricmc.loom.task.AbstractLoomTask;
 import net.fabricmc.loom.util.FileSystemUtil;
-import net.fabricmc.loom.util.LoomProblems;
+import net.fabricmc.loom.util.problem.LoomProblemReporter;
+import net.fabricmc.loom.util.problem.LoomProblems;
+import net.fabricmc.loom.util.problem.ProblemReportingOptions;
 import net.fabricmc.mappingio.FlatMappingVisitor;
 import net.fabricmc.mappingio.MappedElementKind;
 import net.fabricmc.mappingio.MappingReader;
@@ -101,6 +103,9 @@ public abstract class ValidateModProvidedJavadocTask extends AbstractLoomTask {
 	@Input
 	public abstract Property<String> getExpectedNamespace();
 
+	@Nested
+	public abstract Property<ProblemReportingOptions> getProblemReportingOptions();
+
 	@ApiStatus.Internal
 	@Inject
 	protected abstract Problems getProblems();
@@ -108,6 +113,7 @@ public abstract class ValidateModProvidedJavadocTask extends AbstractLoomTask {
 	public ValidateModProvidedJavadocTask() {
 		getMinecraftJars().convention(getExtension().getProductionNamespaceEnum().map(getExtension()::getMinecraftJarsCollection));
 		getExpectedNamespace().convention(getExtension().getProductionNamespace());
+		getProblemReportingOptions().convention(ProblemReportingOptions.createDefault(getProject()));
 
 		// Ignore outputs for up-to-date checks as there aren't any (so only inputs are checked)
 		getOutputs().upToDateWhen(task -> true);
@@ -115,28 +121,26 @@ public abstract class ValidateModProvidedJavadocTask extends AbstractLoomTask {
 
 	@TaskAction
 	protected void check() throws IOException {
-		try (var validator = new Validator(this::reportError, getMinecraftJars().getFiles())) {
+		final var reporter = new LoomProblemReporter(getProblems().getReporter(), getProblemReportingOptions().get());
+		final ErrorReporter errorReporter = (problemId, currentPath, details, cause) -> reporter.problem(problemId, builder -> {
+			builder.fileLocation(currentPath);
+
+			if (details != null) {
+				builder.details(details);
+			}
+
+			if (cause != null) {
+				builder.cause(cause);
+			}
+		});
+
+		try (var validator = new Validator(errorReporter, getMinecraftJars().getFiles())) {
 			for (File mappingFile : getMappingFiles()) {
 				validator.check(mappingFile.toPath(), getExpectedNamespace().get());
 			}
 		}
-	}
 
-	private void reportError(ProblemId problemId, Path currentPath, @Nullable String details, @Nullable Exception cause) throws IOException {
-		final ProblemReporter reporter = getProblems().getReporter();
-		final String message = details != null ? details : problemId.getDisplayName();
-		reporter.throwing(new IOException(message, cause), problemId,
-				spec -> {
-					spec.fileLocation(currentPath.toAbsolutePath().toString());
-
-					if (details != null) {
-						spec.details(details);
-					}
-
-					if (cause != null) {
-						spec.withException(cause);
-					}
-				});
+		reporter.reportAndThrow("Found issues in mod-provided javadoc");
 	}
 
 	@VisibleForTesting

--- a/src/main/java/net/fabricmc/loom/task/tool/ValidateModProvidedJavadocTask.java
+++ b/src/main/java/net/fabricmc/loom/task/tool/ValidateModProvidedJavadocTask.java
@@ -118,7 +118,7 @@ public abstract class ValidateModProvidedJavadocTask extends AbstractLoomTask {
 	public ValidateModProvidedJavadocTask() {
 		getMinecraftJars().convention(getExtension().getProductionNamespaceEnum().map(getExtension()::getMinecraftJarsCollection));
 		getExpectedNamespace().convention(getExtension().getProductionNamespace());
-		problemReportingOptions = ProblemReportingOptions.createDefault(getProject());
+		problemReportingOptions = getProject().getObjects().newInstance(ProblemReportingOptions.class);
 
 		// Ignore outputs for up-to-date checks as there aren't any (so only inputs are checked)
 		getOutputs().upToDateWhen(task -> true);

--- a/src/main/java/net/fabricmc/loom/util/github/GithubActionsAnnotations.java
+++ b/src/main/java/net/fabricmc/loom/util/github/GithubActionsAnnotations.java
@@ -1,0 +1,137 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util.github;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
+
+public final class GithubActionsAnnotations {
+	// See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-a-notice-message
+	private static final String ERROR_COMMAND = "error";
+	private static final String WARNING_COMMAND = "warning";
+	private static final String NOTICE_COMMAND = "notice";
+
+	private GithubActionsAnnotations() {
+	}
+
+	public static Builder error(String message) {
+		return new Builder(ERROR_COMMAND, message);
+	}
+
+	public static Builder warning(String message) {
+		return new Builder(WARNING_COMMAND, message);
+	}
+
+	public static Builder notice(String message) {
+		return new Builder(NOTICE_COMMAND, message);
+	}
+
+	public static final class Builder {
+		private final String command;
+		private final String message;
+		private @Nullable String file;
+		private @Nullable String title;
+		private int startLine = 1;
+		private int endLine;
+		private int startColumn;
+		private int endColumn;
+
+		private Builder(String command, String message) {
+			this.command = command;
+			this.message = message;
+		}
+
+		public Builder file(String file) {
+			this.file = file;
+			return this;
+		}
+
+		public Builder file(File file) {
+			return file(file.getAbsolutePath());
+		}
+
+		public Builder file(Path file) {
+			return file(file.toAbsolutePath().toString());
+		}
+
+		public Builder title(String title) {
+			this.title = title;
+			return this;
+		}
+
+		public Builder line(int line) {
+			this.startLine = line;
+			return this;
+		}
+
+		public Builder line(int start, int end) {
+			this.startLine = start;
+			this.endLine = end;
+			return this;
+		}
+
+		public Builder column(int column) {
+			this.startColumn = column;
+			return this;
+		}
+
+		public Builder column(int start, int end) {
+			this.startColumn = start;
+			this.endColumn = end;
+			return this;
+		}
+
+		public GithubActionsCommand build() {
+			Map<String, @Nullable Object> properties = new LinkedHashMap<>();
+
+			if (file != null) {
+				properties.put("file", file);
+				properties.put("line", startLine);
+
+				if (endLine != 0) {
+					properties.put("endLine", endLine);
+				}
+
+				if (startColumn != 0) {
+					properties.put("col", startColumn);
+				}
+
+				if (endColumn != 0) {
+					properties.put("endColumn", endColumn);
+				}
+			}
+
+			if (title != null) {
+				properties.put("title", title);
+			}
+
+			return new GithubActionsCommand(command, message, properties);
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/github/GithubActionsAnnotations.java
+++ b/src/main/java/net/fabricmc/loom/util/github/GithubActionsAnnotations.java
@@ -31,6 +31,8 @@ import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
 
+import net.fabricmc.loom.util.problem.Problem;
+
 public final class GithubActionsAnnotations {
 	// See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-a-notice-message
 	private static final String ERROR_COMMAND = "error";
@@ -78,6 +80,20 @@ public final class GithubActionsAnnotations {
 
 		public Builder file(Path file) {
 			return file(file.toAbsolutePath().toString());
+		}
+
+		public Builder file(Problem.FileLocation fileLocation) {
+			file(fileLocation.file());
+
+			if (fileLocation.startLine() > 0) {
+				line(fileLocation.startLine(), fileLocation.endLine());
+			}
+
+			if (fileLocation.startColumn() > 0) {
+				column(fileLocation.startColumn(), fileLocation.endColumn());
+			}
+
+			return this;
 		}
 
 		public Builder title(String title) {

--- a/src/main/java/net/fabricmc/loom/util/github/GithubActionsCommand.java
+++ b/src/main/java/net/fabricmc/loom/util/github/GithubActionsCommand.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util.github;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+import org.jspecify.annotations.Nullable;
+
+public record GithubActionsCommand(String command, String message, Map<String, @Nullable Object> properties) {
+	public String toCommandString() {
+		var sb = new StringBuilder("::").append(command);
+
+		if (!properties.isEmpty()) {
+			var propertiesJoiner = new StringJoiner(",");
+			properties.forEach((key, value) -> propertiesJoiner.add(key + '=' + escapeProperty(Objects.toString(value))));
+			sb.append(' ').append(propertiesJoiner);
+		}
+
+		sb.append("::").append(escapeMessage(message));
+		return sb.toString();
+	}
+
+	public void printToStdout() {
+		System.out.println(toCommandString());
+	}
+
+	private static String escapeProperty(String value) {
+		// See https://github.com/actions/toolkit/blob/0786132e6a1a4451c2d392bbbf481c2b172d4312/packages/core/src/command.ts#L110
+		return value
+				.replace("%", "%25")
+				.replace("\r", "%0D")
+				.replace("\n", "%0A")
+				.replace(":", "%3A")
+				.replace(",", "%2C");
+	}
+
+	private static String escapeMessage(String value) {
+		// See https://github.com/actions/toolkit/blob/0786132e6a1a4451c2d392bbbf481c2b172d4312/packages/core/src/command.ts#L103
+		return value
+				.replace("%", "%25")
+				.replace("\r", "%0D")
+				.replace("\n", "%0A");
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/github/package-info.java
+++ b/src/main/java/net/fabricmc/loom/util/github/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.util.github;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/util/problem/LoomProblemReporter.java
+++ b/src/main/java/net/fabricmc/loom/util/problem/LoomProblemReporter.java
@@ -110,8 +110,8 @@ public final class LoomProblemReporter {
 				};
 
 				if (problem.details() != null) {
-					// We have details in the body so we can put the message in the title.
-					builder.title(problem.message());
+					// We have details in the body so we can put the short context-free display name in the title.
+					builder.title(problem.id().getDisplayName());
 				}
 
 				if (problem.fileLocation() != null) {

--- a/src/main/java/net/fabricmc/loom/util/problem/LoomProblemReporter.java
+++ b/src/main/java/net/fabricmc/loom/util/problem/LoomProblemReporter.java
@@ -1,0 +1,172 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util.problem;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.gradle.api.Action;
+import org.gradle.api.problems.ProblemId;
+import org.gradle.api.problems.ProblemReporter;
+
+import net.fabricmc.loom.util.github.GithubActionsAnnotations;
+
+/**
+ * A wrapper for {@link ProblemReporter}. This class can manage multiple problems at a time
+ * and report them as GitHub Actions checks.
+ */
+public final class LoomProblemReporter {
+	private final ProblemReporter reporter;
+	private final ProblemReportingOptions options;
+	private final List<Problem> problems = new ArrayList<>();
+
+	public LoomProblemReporter(ProblemReporter reporter, ProblemReportingOptions options) {
+		this.reporter = reporter;
+		this.options = options;
+	}
+
+	public LoomProblemReporter problem(ProblemId problemId, Action<? super Problem.Builder> action) {
+		Problem.Builder builder = Problem.builder(problemId);
+		action.execute(builder);
+		problem(builder.build());
+		return this;
+	}
+
+	public LoomProblemReporter problem(Problem problem) {
+		problems.add(problem);
+		return this;
+	}
+
+	public void report() {
+		for (Problem problem : problems) {
+			reporter.report(problem.id(), spec -> {
+				if (problem.details() != null) {
+					spec.details(problem.details());
+				}
+
+				if (problem.contextualLabel() != null) {
+					spec.contextualLabel(problem.contextualLabel());
+				}
+
+				if (problem.solution() != null) {
+					spec.solution(problem.solution());
+				}
+
+				if (problem.cause() != null) {
+					spec.withException(problem.cause());
+				}
+
+				if (problem.fileLocation() != null) {
+					String path = problem.fileLocation().file().toAbsolutePath().toString();
+					int line = problem.fileLocation().startLine();
+					int column = problem.fileLocation().startColumn();
+
+					if (line > 0) {
+						if (column > 0) {
+							spec.lineInFileLocation(path, line, column);
+						} else {
+							spec.lineInFileLocation(path, line);
+						}
+					} else {
+						spec.fileLocation(path);
+					}
+				}
+			});
+
+			if (options.getDisplayGithubActionsAnnotations().get()) {
+				String message = Objects.requireNonNullElse(problem.details(), problem.message());
+
+				if (problem.solution() != null) {
+					message += "\n\nSolution: " + problem.solution();
+				}
+
+				GithubActionsAnnotations.Builder builder = switch (problem.severity()) {
+				case ERROR-> GithubActionsAnnotations.error(message);
+				case WARNING -> GithubActionsAnnotations.warning(message);
+				case ADVICE -> GithubActionsAnnotations.notice(message);
+				};
+
+				if (problem.details() != null) {
+					// We have details in the body so we can put the message in the title.
+					builder.title(problem.message());
+				}
+
+				if (problem.fileLocation() != null) {
+					builder.file(problem.fileLocation());
+				}
+
+				builder.build().printToStdout();
+			}
+		}
+	}
+
+	/**
+	 * Reports any issues and throws a {@link RuntimeException} if issues were found.
+	 *
+	 * @param contextProblem the problem used as the exception detail message when multiple issues are found
+	 */
+	public void reportAndThrow(ProblemId contextProblem) {
+		reportAndThrow(contextProblem.getDisplayName());
+	}
+
+	/**
+	 * Reports any issues and throws a {@link RuntimeException} if issues were found.
+	 *
+	 * @param messageForMultipleProblems the exception detail message used when multiple issues are found
+	 */
+	public void reportAndThrow(String messageForMultipleProblems) {
+		if (problems.isEmpty()) {
+			return;
+		}
+
+		report();
+
+		if (problems.size() == 1) {
+			Problem problem = problems.getFirst();
+			throw new RuntimeException(problem.message(), problem.cause());
+		} else {
+			var messageBuilder = new StringBuilder(messageForMultipleProblems).append(':');
+			List<Throwable> causes = new ArrayList<>();
+
+			for (Problem problem : problems) {
+				messageBuilder.append("\n - ").append(problem.message());
+
+				if (problem.cause() != null) {
+					causes.add(problem.cause());
+				}
+			}
+
+			Throwable cause = !causes.isEmpty() ? causes.getFirst() : null;
+			RuntimeException exception = new RuntimeException(messageBuilder.toString(), cause);
+
+			for (int i = 1; i < causes.size(); i++) {
+				exception.addSuppressed(causes.get(i));
+			}
+
+			throw exception;
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/problem/LoomProblemReporter.java
+++ b/src/main/java/net/fabricmc/loom/util/problem/LoomProblemReporter.java
@@ -104,7 +104,7 @@ public final class LoomProblemReporter {
 				}
 
 				GithubActionsAnnotations.Builder builder = switch (problem.severity()) {
-				case ERROR-> GithubActionsAnnotations.error(message);
+				case ERROR -> GithubActionsAnnotations.error(message);
 				case WARNING -> GithubActionsAnnotations.warning(message);
 				case ADVICE -> GithubActionsAnnotations.notice(message);
 				};

--- a/src/main/java/net/fabricmc/loom/util/problem/LoomProblemReporter.java
+++ b/src/main/java/net/fabricmc/loom/util/problem/LoomProblemReporter.java
@@ -109,7 +109,7 @@ public final class LoomProblemReporter {
 				case ADVICE -> GithubActionsAnnotations.notice(message);
 				};
 
-				if (problem.details() != null) {
+				if (!message.equals(problem.id().getDisplayName())) {
 					// We have details in the body so we can put the short context-free display name in the title.
 					builder.title(problem.id().getDisplayName());
 				}

--- a/src/main/java/net/fabricmc/loom/util/problem/LoomProblems.java
+++ b/src/main/java/net/fabricmc/loom/util/problem/LoomProblems.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2025-2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util.problem;
+
+import org.gradle.api.problems.ProblemGroup;
+import org.gradle.api.problems.ProblemId;
+
+/**
+ * Contains the Loom problem group for the Gradle Problem API.
+ */
+public final class LoomProblems {
+	public static final ProblemGroup PROBLEM_GROUP = ProblemGroup.create("loom", "Loom");
+
+	private LoomProblems() {
+	}
+
+	public static ProblemId problemId(String name, String displayName) {
+		return ProblemId.create(name, displayName, PROBLEM_GROUP);
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/problem/Problem.java
+++ b/src/main/java/net/fabricmc/loom/util/problem/Problem.java
@@ -1,0 +1,133 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util.problem;
+
+import java.nio.file.Path;
+
+import org.gradle.api.problems.ProblemId;
+import org.gradle.api.problems.Severity;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Problem details. This type is converted into Gradle {@link org.gradle.api.problems.Problem} instances,
+ * exceptions and GitHub Actions annotations.
+ *
+ * @param id              the Gradle problem ID
+ * @param message         the exception message for this problem
+ * @param details         a detailed description, can be null
+ * @param severity        the severity level
+ * @param contextualLabel the contextual label used as a subsection title in the problem report, can be null
+ * @param solution        a user-facing solution message, can be null
+ * @param fileLocation    the file where this error originated, can be null
+ * @param cause           a throwable cause, can be null
+ */
+public record Problem(ProblemId id, String message, @Nullable String details, Severity severity, @Nullable String contextualLabel, @Nullable String solution, @Nullable FileLocation fileLocation, @Nullable Throwable cause) {
+	public static Builder builder(ProblemId problemId) {
+		return new Builder(problemId);
+	}
+
+	public static final class Builder {
+		private final ProblemId problemId;
+		private @Nullable String message;
+		private @Nullable String details;
+		private Severity severity = Severity.ERROR;
+		private @Nullable String contextualLabel;
+		private @Nullable String solution;
+		private @Nullable FileLocation fileLocation;
+		private @Nullable Throwable cause;
+
+		public Builder(ProblemId problemId) {
+			this.problemId = problemId;
+		}
+
+		public Builder message(String message) {
+			this.message = message;
+			return this;
+		}
+
+		public Builder details(String details) {
+			this.details = details;
+			return this;
+		}
+
+		public Builder severity(Severity severity) {
+			this.severity = severity;
+			return this;
+		}
+
+		public Builder contextualLabel(String contextualLabel) {
+			this.contextualLabel = contextualLabel;
+			return this;
+		}
+
+		public Builder solution(String solution) {
+			this.solution = solution;
+			return this;
+		}
+
+		public Builder fileLocation(Path file) {
+			this.fileLocation = new FileLocation(file, 0, 0, 0, 0);
+			return this;
+		}
+
+		public Builder fileLocation(Path file, int line) {
+			this.fileLocation = new FileLocation(file, line, 0, 0, 0);
+			return this;
+		}
+
+		public Builder fileLocation(Path file, int line, int column) {
+			this.fileLocation = new FileLocation(file, line, 0, column, 0);
+			return this;
+		}
+
+		public Builder fileLocation(Path file, int startLine, int endLine, int startColumn, int endColumn) {
+			this.fileLocation = new FileLocation(file, startLine, endLine, startColumn, endColumn);
+			return this;
+		}
+
+		public Builder cause(@Nullable Throwable cause) {
+			this.cause = cause;
+			return this;
+		}
+
+		public Problem build() {
+			final String message;
+
+			if (this.message != null) {
+				message = this.message;
+			} else if (details != null) {
+				message = details;
+			} else {
+				message = problemId.getDisplayName();
+			}
+
+			return new Problem(problemId, message, details, severity, contextualLabel, solution, fileLocation, cause);
+		}
+	}
+
+	// Lines and columns are missing if they're less than or equal to 0
+	public record FileLocation(Path file, int startLine, int endLine, int startColumn, int endColumn) {
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/problem/ProblemReportingOptions.java
+++ b/src/main/java/net/fabricmc/loom/util/problem/ProblemReportingOptions.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util.problem;
+
+import org.gradle.api.Project;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Input;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Options for tasks that report problems.
+ */
+public interface ProblemReportingOptions {
+	/**
+	 * If true, GitHub Actions file annotations will be displayed for detected problems.
+	 */
+	@Input
+	Property<Boolean> getDisplayGithubActionsAnnotations();
+
+	@ApiStatus.Internal
+	static Provider<ProblemReportingOptions> createDefault(Project project) {
+		return project.provider(() -> {
+			final ProblemReportingOptions options = project.getObjects().newInstance(ProblemReportingOptions.class);
+			options.getDisplayGithubActionsAnnotations().convention(false);
+			return options;
+		});
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/problem/ProblemReportingOptions.java
+++ b/src/main/java/net/fabricmc/loom/util/problem/ProblemReportingOptions.java
@@ -26,7 +26,6 @@ package net.fabricmc.loom.util.problem;
 
 import org.gradle.api.Project;
 import org.gradle.api.provider.Property;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -41,11 +40,9 @@ public interface ProblemReportingOptions {
 	Property<Boolean> getDisplayGithubActionsAnnotations();
 
 	@ApiStatus.Internal
-	static Provider<ProblemReportingOptions> createDefault(Project project) {
-		return project.provider(() -> {
-			final ProblemReportingOptions options = project.getObjects().newInstance(ProblemReportingOptions.class);
-			options.getDisplayGithubActionsAnnotations().convention(false);
-			return options;
-		});
+	static ProblemReportingOptions createDefault(Project project) {
+		final ProblemReportingOptions options = project.getObjects().newInstance(ProblemReportingOptions.class);
+		options.getDisplayGithubActionsAnnotations().convention(false);
+		return options;
 	}
 }

--- a/src/main/java/net/fabricmc/loom/util/problem/ProblemReportingOptions.java
+++ b/src/main/java/net/fabricmc/loom/util/problem/ProblemReportingOptions.java
@@ -24,25 +24,20 @@
 
 package net.fabricmc.loom.util.problem;
 
-import org.gradle.api.Project;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
-import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Options for tasks that report problems.
  */
-public interface ProblemReportingOptions {
+public abstract class ProblemReportingOptions {
 	/**
 	 * If true, GitHub Actions file annotations will be displayed for detected problems.
 	 */
 	@Input
-	Property<Boolean> getDisplayGithubActionsAnnotations();
+	public abstract Property<Boolean> getDisplayGithubActionsAnnotations();
 
-	@ApiStatus.Internal
-	static ProblemReportingOptions createDefault(Project project) {
-		final ProblemReportingOptions options = project.getObjects().newInstance(ProblemReportingOptions.class);
-		options.getDisplayGithubActionsAnnotations().convention(false);
-		return options;
+	public ProblemReportingOptions() {
+		getDisplayGithubActionsAnnotations().convention(false);
 	}
 }

--- a/src/main/java/net/fabricmc/loom/util/problem/package-info.java
+++ b/src/main/java/net/fabricmc/loom/util/problem/package-info.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2025 FabricMC
+ * Copyright (c) 2026 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,18 +22,7 @@
  * SOFTWARE.
  */
 
-package net.fabricmc.loom.util;
+@NullMarked
+package net.fabricmc.loom.util.problem;
 
-import org.gradle.api.problems.ProblemGroup;
-import org.gradle.api.problems.ProblemId;
-
-public final class LoomProblems {
-	public static final ProblemGroup PROBLEM_GROUP = ProblemGroup.create("loom", "Loom");
-
-	private LoomProblems() {
-	}
-
-	public static ProblemId problemId(String name, String displayName) {
-		return ProblemId.create(name, displayName, PROBLEM_GROUP);
-	}
-}
+import org.jspecify.annotations.NullMarked;

--- a/src/test/groovy/net/fabricmc/loom/test/integration/InterfaceInjectionTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/InterfaceInjectionTest.groovy
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2016-2021 FabricMC
+ * Copyright (c) 2016-2026 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,16 +25,22 @@
 package net.fabricmc.loom.test.integration
 
 import org.gradle.testkit.runner.BuildResult
+import org.intellij.lang.annotations.Language
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import net.fabricmc.loom.test.LoomTestVersions
 import net.fabricmc.loom.test.util.GradleProjectTestTrait
 import net.fabricmc.loom.util.ZipUtils
 
 import static net.fabricmc.loom.test.LoomTestConstants.STANDARD_TEST_VERSIONS
+import static org.gradle.testkit.runner.TaskOutcome.FAILED
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 class InterfaceInjectionTest extends Specification implements GradleProjectTestTrait {
+	@Language("JAVA")
+	private static final String INJECTED_INTERFACE_WITH_ABSTRACT_METHOD = "interface TestItf { void foo(); }"
+
 	@Unroll
 	def "interface injection (gradle #version)"() {
 		setup:
@@ -111,5 +117,70 @@ class InterfaceInjectionTest extends Specification implements GradleProjectTestT
 
 		where:
 		version << STANDARD_TEST_VERSIONS
+	}
+
+	@Unroll
+	def "validate invalid injected interfaces (gradle #version, class tweaker: #useCt)"() {
+		setup:
+		def gradle = gradleProject(project: 'minimalBaseNoRemap', version: version)
+		gradle.buildGradle << """
+ 			dependencies {
+ 				minecraft "com.mojang:minecraft:26.2"
+ 				implementation "${LoomTestVersions.FABRIC_LOADER.mavenNotation()}"
+ 			}
+
+ 			tasks.register('validateInjectedInterfaces', net.fabricmc.loom.task.ValidateInjectedInterfacesTask) {
+ 				modJar = tasks.named('jar').flatMap { it.archiveFile }
+ 				problemReportingOptions.displayGithubActionsAnnotations = true
+ 			}
+
+ 			tasks.named('check') {
+ 				dependsOn 'validateInjectedInterfaces'
+ 			}
+			"""
+		new File(gradle.projectDir, 'src/main/java').mkdirs()
+		new File(gradle.projectDir, 'src/main/resources').mkdirs()
+		new File(gradle.projectDir, 'src/main/java/TestItf.java').text = INJECTED_INTERFACE_WITH_ABSTRACT_METHOD
+
+		if (useCt) {
+			new File(gradle.projectDir, 'src/main/resources/fabric.mod.json').text = """
+				{
+					"schemaVersion": 1,
+					"id": "test",
+					"version": "1.0.0",
+					"accessWidener": "test.classtweaker"
+				}
+				"""
+			new File(gradle.projectDir, 'src/main/resources/test.classtweaker').text = """\
+				classTweaker v2 official
+				inject-interface net/minecraft/world/level/block/Block TestItf
+				""".stripIndent()
+		} else {
+			new File(gradle.projectDir, 'src/main/resources/fabric.mod.json').text = """
+				{
+					"schemaVersion": 1,
+					"id": "test",
+					"version": "1.0.0",
+					"custom": {
+						"loom:injected_interfaces": {
+							"net/minecraft/class_2248": ["TestItf"]
+						}
+					}
+				}
+				"""
+		}
+
+		when:
+		def result = gradle.run(task: 'build', expectFailure: true)
+
+		then:
+		result.task(':validateInjectedInterfaces').outcome == FAILED
+		result.output.contains('Injected interface TestItf has abstract method foo()V')
+		// Check that the output has the GH Actions command.
+		result.output.contains('::error title=Abstract method in injected interface::Method TestItf.foo()V is abstract.')
+
+		where:
+		version << STANDARD_TEST_VERSIONS
+		useCt << [true, false]
 	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/integration/InterfaceInjectionTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/InterfaceInjectionTest.groovy
@@ -130,7 +130,6 @@ class InterfaceInjectionTest extends Specification implements GradleProjectTestT
  			}
 
  			tasks.register('validateInjectedInterfaces', net.fabricmc.loom.task.ValidateInjectedInterfacesTask) {
- 				modJar = tasks.named('jar').flatMap { it.archiveFile }
  				problemReportingOptions.displayGithubActionsAnnotations = true
  			}
 
@@ -177,7 +176,12 @@ class InterfaceInjectionTest extends Specification implements GradleProjectTestT
 		result.task(':validateInjectedInterfaces').outcome == FAILED
 		result.output.contains('Injected interface TestItf has abstract method foo()V')
 		// Check that the output has the GH Actions command.
-		result.output.contains('::error title=Abstract method in injected interface::Method TestItf.foo()V is abstract.')
+		result.output.lines()
+				.anyMatch {
+					// Note: the final .+ is for catching the rest of the message. We don't care about the exact
+					// message contents in this test.
+					it.matches("::error file=.+TestItf\\.java,line=1,title=Abstract method in injected interface::Method TestItf\\.foo\\(\\)V is abstract\\..+")
+				}
 
 		where:
 		version << STANDARD_TEST_VERSIONS

--- a/src/test/groovy/net/fabricmc/loom/test/unit/GithubActionsAnnotationsTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/GithubActionsAnnotationsTest.groovy
@@ -1,0 +1,74 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit
+
+import spock.lang.Specification
+
+import net.fabricmc.loom.util.github.GithubActionsAnnotations
+
+class GithubActionsAnnotationsTest extends Specification {
+	def "test command strings"() {
+		when:
+		def builder = GithubActionsAnnotations.error(message)
+
+		if (file) {
+			builder.file(file)
+		}
+
+		if (title) {
+			builder.title(title)
+		}
+
+		if (positions) {
+			if (positions.lines) {
+				if (positions.lines.size() == 2) {
+					builder.line(positions.lines[0], positions.lines[1])
+				} else {
+					builder.line(positions.lines[0])
+				}
+			}
+
+			if (positions.columns) {
+				if (positions.columns.size() == 2) {
+					builder.column(positions.columns[0], positions.columns[1])
+				} else {
+					builder.column(positions.columns[0])
+				}
+			}
+		}
+
+		then:
+		builder.build().toCommandString() == expected
+
+		where:
+		message | file | title | positions | expected
+		'Hello, world!' | null | null | null | '::error::Hello, world!'
+		'Hello, world!' | '/Hello.java' | null | null | '::error file=/Hello.java,line=1::Hello, world!'
+		'Hello, world!' | '/Hello.java' | null | [lines: [10]] | '::error file=/Hello.java,line=10::Hello, world!'
+		'Hello, world!' | '/Hello.java' | null | [lines: [10], columns: [32]] | '::error file=/Hello.java,line=10,col=32::Hello, world!'
+		'Hello, world!' | '/Hello.java' | null | [lines: [10, 12]] | '::error file=/Hello.java,line=10,endLine=12::Hello, world!'
+		'Hello,\nworld!' | 'C:\\Hello.java' | 'Custom,Title' | [lines: [10, 12], columns: [44, 47]] | '::error file=C%3A\\Hello.java,line=10,endLine=12,col=44,endColumn=47,title=Custom%2CTitle::Hello,%0Aworld!'
+	}
+}

--- a/src/test/resources/projects/interfaceInjection/build.gradle
+++ b/src/test/resources/projects/interfaceInjection/build.gradle
@@ -21,3 +21,11 @@ dependencies {
 base {
 	archivesName = "fabric-example-mod"
 }
+
+tasks.register('validateInjectedInterfaces', net.fabricmc.loom.task.ValidateInjectedInterfacesTask) {
+	modJar = tasks.named('jar').flatMap { it.archiveFile }
+}
+
+tasks.named('check') {
+	dependsOn 'validateInjectedInterfaces'
+}

--- a/src/test/resources/projects/interfaceInjection/build.gradle
+++ b/src/test/resources/projects/interfaceInjection/build.gradle
@@ -22,9 +22,7 @@ base {
 	archivesName = "fabric-example-mod"
 }
 
-tasks.register('validateInjectedInterfaces', net.fabricmc.loom.task.ValidateInjectedInterfacesTask) {
-	modJar = tasks.named('jar').flatMap { it.archiveFile }
-}
+tasks.register('validateInjectedInterfaces', net.fabricmc.loom.task.ValidateInjectedInterfacesTask)
 
 tasks.named('check') {
 	dependsOn 'validateInjectedInterfaces'

--- a/src/test/resources/projects/interfaceInjectionNoIntermediary/build.gradle
+++ b/src/test/resources/projects/interfaceInjectionNoIntermediary/build.gradle
@@ -27,9 +27,7 @@ base {
 	archivesName = "fabric-example-mod"
 }
 
-tasks.register('validateInjectedInterfaces', net.fabricmc.loom.task.ValidateInjectedInterfacesTask) {
-	modJar = tasks.named('jar').flatMap { it.archiveFile }
-}
+tasks.register('validateInjectedInterfaces', net.fabricmc.loom.task.ValidateInjectedInterfacesTask)
 
 tasks.named('check') {
 	dependsOn 'validateInjectedInterfaces'

--- a/src/test/resources/projects/interfaceInjectionNoIntermediary/build.gradle
+++ b/src/test/resources/projects/interfaceInjectionNoIntermediary/build.gradle
@@ -26,3 +26,11 @@ loom {
 base {
 	archivesName = "fabric-example-mod"
 }
+
+tasks.register('validateInjectedInterfaces', net.fabricmc.loom.task.ValidateInjectedInterfacesTask) {
+	modJar = tasks.named('jar').flatMap { it.archiveFile }
+}
+
+tasks.named('check') {
+	dependsOn 'validateInjectedInterfaces'
+}


### PR DESCRIPTION
Mostly for use within Fabric API, but added here so anyone can benefit from it.

Also includes a new wrapper for Gradle's problem reporting API that
- hopefully wraps any breakages in a way that doesn't need changes in task classes
- lets tasks report multiple problems and throw one exception that lists all the problems at once for better UX
- lets us print GitHub Actions annotations directly from Gradle if requested.

## Example setup
```gradle
tasks.register('validateInjectedInterfaces', ValidateInjectedInterfacesTask) {
    modJar = tasks.named('jar').flatMap { it.archiveFile }

    // Optional, results in better error messages
    sourceRoots.from(sourceSets.main.java.srcDirs)

    // To enable GitHub Actions annotations for errors
    problemReportingOptions.displayGithubActionsAnnotations = true
}
```