### PR TITLE
Replace fabric-loom-native with Java FFM

### DIFF
--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -142,7 +142,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 21, 25 ]
+        java: [ 25 ]
         os: [ windows-2025, ubuntu-24.04, macos-26 ]
 
     runs-on: ${{ matrix.os }}

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ tasks.withType(JavaCompile).configureEach {
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 	kotlinOptions {
-		jvmTarget = "21"
+		jvmTarget = "25"
 	}
 }
 
@@ -105,8 +105,6 @@ dependencies {
 		transitive = false
 	}
 
-	implementation libs.fabric.loom.nativelib
-
 	// decompilers
 	cfrCompileOnly runtimeLibs.cfr
 	cfrCompileOnly libs.fabric.mapping.io
@@ -176,13 +174,13 @@ base {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 21
+	it.options.release = 25
 }
 
 java {
 	withSourcesJar()
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
+	sourceCompatibility = JavaVersion.VERSION_25
+	targetCompatibility = JavaVersion.VERSION_25
 }
 
 spotless {
@@ -274,6 +272,7 @@ test {
 // Workaround https://github.com/gradle/gradle/issues/25898
 tasks.withType(Test).configureEach {
 	jvmArgs = [
+		'--enable-native-access=ALL-UNNAMED',
 		'--add-opens=java.base/java.lang=ALL-UNNAMED',
 		'--add-opens=java.base/java.util=ALL-UNNAMED',
 		'--add-opens=java.base/java.lang.invoke=ALL-UNNAMED',

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ unpick = "3.0.0-beta.13"
 
 # Plugins
 spotless = "8.6.0"
-test-retry = "1.6.2"
+test-retry = "1.6.5"
 checkstyle = "13.4.1"
 codenarc = "3.7.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,6 @@ mapping-io = "0.8.0"
 lorenz-tiny = "4.0.2"
 mercury = "0.4.3"
 mercury-mixin = "0.2.2"
-loom-native = "0.2.0"
 unpick = "3.0.0-beta.13"
 
 # Plugins
@@ -36,7 +35,6 @@ fabric-mapping-io = { module = "net.fabricmc:mapping-io", version.ref = "mapping
 fabric-lorenz-tiny = { module = "net.fabricmc:lorenz-tiny", version.ref = "lorenz-tiny" }
 fabric-mercury = { module = "net.fabricmc:mercury", version.ref = "mercury" }
 fabric-mercury-mixin = { module = "net.fabricmc:mercurymixin", version.ref = "mercury-mixin" }
-fabric-loom-nativelib = { module = "net.fabricmc:fabric-loom-native", version.ref = "loom-native" }
 fabric-unpick = { module = "net.fabricmc.unpick:unpick", version.ref = "unpick" }
 fabric-unpick-utils = { module = "net.fabricmc.unpick:unpick-format-utils", version.ref = "unpick" }
 

--- a/src/main/java/net/fabricmc/loom/util/ExceptionUtil.java
+++ b/src/main/java/net/fabricmc/loom/util/ExceptionUtil.java
@@ -34,9 +34,9 @@ import java.util.function.BiFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import net.fabricmc.loom.nativeplatform.LoomNativePlatform;
-import net.fabricmc.loom.nativeplatform.LoomNativePlatformException;
 import net.fabricmc.loom.util.gradle.daemon.DaemonUtils;
+import net.fabricmc.loom.util.nativeplatform.LoomNativePlatform;
+import net.fabricmc.loom.util.nativeplatform.LoomNativePlatformException;
 
 public final class ExceptionUtil {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionUtil.class);

--- a/src/main/java/net/fabricmc/loom/util/ProcessUtil.java
+++ b/src/main/java/net/fabricmc/loom/util/ProcessUtil.java
@@ -34,8 +34,8 @@ import org.gradle.api.logging.LogLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import net.fabricmc.loom.nativeplatform.LoomNativePlatform;
-import net.fabricmc.loom.nativeplatform.LoomNativePlatformException;
+import net.fabricmc.loom.util.nativeplatform.LoomNativePlatform;
+import net.fabricmc.loom.util.nativeplatform.LoomNativePlatformException;
 
 public record ProcessUtil(ArgumentVisibility argumentVisibility) {
 	private static final String EXPLORER_COMMAND = "C:\\Windows\\explorer.exe";

--- a/src/main/java/net/fabricmc/loom/util/nativeplatform/LoomNativePlatform.java
+++ b/src/main/java/net/fabricmc/loom/util/nativeplatform/LoomNativePlatform.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util.nativeplatform;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import net.fabricmc.loom.util.Platform;
+
+public final class LoomNativePlatform {
+	private static final NativePlatform PLATFORM = create();
+
+	private LoomNativePlatform() {
+	}
+
+	public static List<ProcessHandle> getProcessesWithLockOn(Path path) throws LoomNativePlatformException {
+		return PLATFORM.getProcessesWithLockOn(path);
+	}
+
+	public static List<String> getWindowTitlesForPid(long pid) throws LoomNativePlatformException {
+		return PLATFORM.getWindowTitlesForPid(pid);
+	}
+
+	public static boolean isSupported() {
+		return PLATFORM != UnsupportedNativePlatform.INSTANCE;
+	}
+
+	private static NativePlatform create() {
+		if (Platform.CURRENT.getOperatingSystem().isWindows()) {
+			return WindowsNativePlatform.create();
+		}
+
+		return UnsupportedNativePlatform.INSTANCE;
+	}
+
+	interface NativePlatform {
+		List<ProcessHandle> getProcessesWithLockOn(Path path) throws LoomNativePlatformException;
+
+		List<String> getWindowTitlesForPid(long pid) throws LoomNativePlatformException;
+	}
+
+	private enum UnsupportedNativePlatform implements NativePlatform {
+		INSTANCE;
+
+		@Override
+		public List<ProcessHandle> getProcessesWithLockOn(Path path) {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public List<String> getWindowTitlesForPid(long pid) {
+			return Collections.emptyList();
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/nativeplatform/LoomNativePlatformException.java
+++ b/src/main/java/net/fabricmc/loom/util/nativeplatform/LoomNativePlatformException.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util.nativeplatform;
+
+import org.jspecify.annotations.Nullable;
+
+public class LoomNativePlatformException extends Exception {
+	public LoomNativePlatformException(String message) {
+		super(message);
+	}
+
+	public LoomNativePlatformException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public static LoomNativePlatformException fromWin32Error(String operation, int errorCode) {
+		return new LoomNativePlatformException(formatWin32Error(operation, errorCode));
+	}
+
+	public static String formatWin32Error(String operation, int errorCode) {
+		final StringBuilder message = new StringBuilder("%s failed: Windows error %d (0x%08X)".formatted(operation, errorCode, errorCode));
+		final String windowsMessage = tryFormatMessage(errorCode);
+
+		if (windowsMessage != null && !windowsMessage.isBlank()) {
+			message.append(": ").append(windowsMessage);
+		}
+
+		return message.toString();
+	}
+
+	private static @Nullable String tryFormatMessage(int errorCode) {
+		try {
+			return Win32.tryFormatMessage(errorCode);
+		} catch (Throwable e) {
+			return null;
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/nativeplatform/Win32.java
+++ b/src/main/java/net/fabricmc/loom/util/nativeplatform/Win32.java
@@ -1,0 +1,303 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util.nativeplatform;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.AddressLayout;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import org.jspecify.annotations.Nullable;
+
+final class Win32 {
+	static final int ERROR_SUCCESS = 0;
+	static final int ERROR_MORE_DATA = 234;
+	static final int PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+	static final int GW_OWNER = 4;
+	static final int FORMAT_MESSAGE_ALLOCATE_BUFFER = 0x00000100;
+	static final int FORMAT_MESSAGE_IGNORE_INSERTS = 0x00000200;
+	static final int FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000;
+	static final int LANG_NEUTRAL = 0x0000;
+	static final int LANG_ENGLISH = 0x0009;
+	static final int SUBLANG_ENGLISH_US = 0x0001;
+	static final int SUBLANG_NEUTRAL = 0x0000;
+	static final int ENGLISH_US = makeLangId(LANG_ENGLISH, SUBLANG_ENGLISH_US);
+	static final int NEUTRAL_LANGUAGE = makeLangId(LANG_NEUTRAL, SUBLANG_NEUTRAL);
+
+	static final ValueLayout.OfInt DWORD = ValueLayout.JAVA_INT;
+	static final ValueLayout.OfInt BOOL = ValueLayout.JAVA_INT;
+	static final ValueLayout.OfLong LONG_PTR = ValueLayout.JAVA_LONG;
+	static final AddressLayout HANDLE = ValueLayout.ADDRESS;
+	static final AddressLayout HWND = ValueLayout.ADDRESS;
+
+	static final MemoryLayout FILETIME = MemoryLayout.structLayout(
+			DWORD.withName("dwLowDateTime"),
+			DWORD.withName("dwHighDateTime")
+	).withName("FILETIME");
+	static final MemoryLayout RM_UNIQUE_PROCESS = MemoryLayout.structLayout(
+			DWORD.withName("dwProcessId"),
+			FILETIME.withName("ProcessStartTime")
+	).withName("RM_UNIQUE_PROCESS");
+	static final MemoryLayout RM_PROCESS_INFO = MemoryLayout.structLayout(
+			RM_UNIQUE_PROCESS.withName("Process"),
+			MemoryLayout.sequenceLayout(256, ValueLayout.JAVA_CHAR).withName("strAppName"),
+			MemoryLayout.sequenceLayout(64, ValueLayout.JAVA_CHAR).withName("strServiceShortName"),
+			DWORD.withName("ApplicationType"),
+			DWORD.withName("AppStatus"),
+			DWORD.withName("TSSessionId"),
+			BOOL.withName("bRestartable")
+	).withName("RM_PROCESS_INFO");
+
+	private static final Linker LINKER = Linker.nativeLinker();
+	private static final SymbolLookup RSTRTMGR = SymbolLookup.libraryLookup("rstrtmgr", Arena.global());
+	private static final SymbolLookup KERNEL32 = SymbolLookup.libraryLookup("kernel32", Arena.global());
+	private static final SymbolLookup USER32 = SymbolLookup.libraryLookup("user32", Arena.global());
+
+	private static final MethodHandle RM_START_SESSION = downcall(RSTRTMGR, "RmStartSession",
+			FunctionDescriptor.of(DWORD, ValueLayout.ADDRESS, DWORD, ValueLayout.ADDRESS));
+	private static final MethodHandle RM_REGISTER_RESOURCES = downcall(RSTRTMGR, "RmRegisterResources",
+			FunctionDescriptor.of(DWORD, DWORD, DWORD, ValueLayout.ADDRESS, DWORD, ValueLayout.ADDRESS, DWORD, ValueLayout.ADDRESS));
+	private static final MethodHandle RM_GET_LIST = downcall(RSTRTMGR, "RmGetList",
+			FunctionDescriptor.of(DWORD, DWORD, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+	private static final MethodHandle RM_END_SESSION = downcall(RSTRTMGR, "RmEndSession",
+			FunctionDescriptor.of(DWORD, DWORD));
+	private static final MethodHandle OPEN_PROCESS = downcall(KERNEL32, "OpenProcess",
+			FunctionDescriptor.of(HANDLE, DWORD, BOOL, DWORD));
+	private static final MethodHandle CLOSE_HANDLE = downcall(KERNEL32, "CloseHandle",
+			FunctionDescriptor.of(BOOL, HANDLE));
+	private static final MethodHandle GET_PROCESS_TIMES = downcall(KERNEL32, "GetProcessTimes",
+			FunctionDescriptor.of(BOOL, HANDLE, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+	private static final MethodHandle COMPARE_FILE_TIME = downcall(KERNEL32, "CompareFileTime",
+			FunctionDescriptor.of(DWORD, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+	private static final MethodHandle GET_LAST_ERROR = downcall(KERNEL32, "GetLastError",
+			FunctionDescriptor.of(DWORD));
+	private static final MethodHandle FORMAT_MESSAGE_W = downcall(KERNEL32, "FormatMessageW",
+			FunctionDescriptor.of(DWORD, DWORD, ValueLayout.ADDRESS, DWORD, DWORD, ValueLayout.ADDRESS, DWORD, ValueLayout.ADDRESS));
+	private static final MethodHandle LOCAL_FREE = downcall(KERNEL32, "LocalFree",
+			FunctionDescriptor.of(HANDLE, HANDLE));
+	private static final MethodHandle ENUM_WINDOWS = downcall(USER32, "EnumWindows",
+			FunctionDescriptor.of(BOOL, ValueLayout.ADDRESS, LONG_PTR));
+	private static final MethodHandle GET_WINDOW_THREAD_PROCESS_ID = downcall(USER32, "GetWindowThreadProcessId",
+			FunctionDescriptor.of(DWORD, HWND, ValueLayout.ADDRESS));
+	private static final MethodHandle GET_WINDOW = downcall(USER32, "GetWindow",
+			FunctionDescriptor.of(HWND, HWND, DWORD));
+	private static final MethodHandle IS_WINDOW_VISIBLE = downcall(USER32, "IsWindowVisible",
+			FunctionDescriptor.of(BOOL, HWND));
+	private static final MethodHandle GET_WINDOW_TEXT_LENGTH_W = downcall(USER32, "GetWindowTextLengthW",
+			FunctionDescriptor.of(DWORD, HWND));
+	private static final MethodHandle GET_WINDOW_TEXT_W = downcall(USER32, "GetWindowTextW",
+			FunctionDescriptor.of(DWORD, HWND, ValueLayout.ADDRESS, DWORD));
+
+	private Win32() {
+	}
+
+	static int rmStartSession(Arena arena, int sessionKeyLength) throws Throwable {
+		MemorySegment session = arena.allocate(DWORD);
+		MemorySegment key = arena.allocate((long) (sessionKeyLength + 1) * Character.BYTES, Character.BYTES);
+		int result = (int) RM_START_SESSION.invokeExact(session, 0, key);
+		checkRestartManager("RmStartSession", result);
+		return session.get(DWORD, 0);
+	}
+
+	static void rmRegisterResources(int session, Arena arena, String path) throws Throwable {
+		MemorySegment pathString = allocateWideString(arena, path);
+		MemorySegment filePathPointer = arena.allocate(ValueLayout.ADDRESS);
+		filePathPointer.set(ValueLayout.ADDRESS, 0, pathString);
+		int result = (int) RM_REGISTER_RESOURCES.invokeExact(session, 1, filePathPointer, 0, MemorySegment.NULL, 0, MemorySegment.NULL);
+		checkRestartManager("RmRegisterResources", result);
+	}
+
+	static int rmGetList(int session, MemorySegment procInfoNeeded, MemorySegment procInfo, MemorySegment processes, MemorySegment rebootReasons) throws Throwable {
+		int result = (int) RM_GET_LIST.invokeExact(session, procInfoNeeded, procInfo, processes, rebootReasons);
+
+		if (result != ERROR_MORE_DATA) {
+			checkRestartManager("RmGetList", result);
+		}
+
+		return result;
+	}
+
+	static void rmEndSession(int session) throws Throwable {
+		int result = (int) RM_END_SESSION.invokeExact(session);
+		checkRestartManager("RmEndSession", result);
+	}
+
+	static MemorySegment openProcess(int access, int inheritHandle, int pid) throws Throwable {
+		return (MemorySegment) OPEN_PROCESS.invokeExact(access, inheritHandle, pid);
+	}
+
+	static int closeHandle(MemorySegment handle) throws Throwable {
+		return (int) CLOSE_HANDLE.invokeExact(handle);
+	}
+
+	static @Nullable ProcessTimes getProcessTimes(Arena arena, MemorySegment process) throws Throwable {
+		MemorySegment createTime = arena.allocate(FILETIME);
+		MemorySegment exitTime = arena.allocate(FILETIME);
+		MemorySegment kernelTime = arena.allocate(FILETIME);
+		MemorySegment userTime = arena.allocate(FILETIME);
+
+		if ((int) GET_PROCESS_TIMES.invokeExact(process, createTime, exitTime, kernelTime, userTime) == 0) {
+			return null;
+		}
+
+		return new ProcessTimes(createTime, exitTime, kernelTime, userTime);
+	}
+
+	static int compareFileTime(MemorySegment first, MemorySegment second) throws Throwable {
+		return (int) COMPARE_FILE_TIME.invokeExact(first, second);
+	}
+
+	static int getLastError() throws Throwable {
+		return (int) GET_LAST_ERROR.invokeExact();
+	}
+
+	static boolean enumWindows(MemorySegment callback, long data) throws Throwable {
+		boolean result = (int) ENUM_WINDOWS.invokeExact(callback, data) != 0;
+
+		if (!result) {
+			throwLastError("EnumWindows");
+		}
+
+		return true;
+	}
+
+	static long getWindowThreadProcessId(MemorySegment hwnd) throws Throwable {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment pid = arena.allocate(DWORD);
+			int ignored = (int) GET_WINDOW_THREAD_PROCESS_ID.invokeExact(hwnd, pid);
+			return Integer.toUnsignedLong(pid.get(DWORD, 0));
+		}
+	}
+
+	static MemorySegment getWindow(MemorySegment hwnd, int command) throws Throwable {
+		return (MemorySegment) GET_WINDOW.invokeExact(hwnd, command);
+	}
+
+	static boolean isWindowVisible(MemorySegment hwnd) throws Throwable {
+		return (int) IS_WINDOW_VISIBLE.invokeExact(hwnd) != 0;
+	}
+
+	static Optional<String> getWindowText(MemorySegment hwnd, Arena arena) throws Throwable {
+		int length = (int) GET_WINDOW_TEXT_LENGTH_W.invokeExact(hwnd);
+
+		if (length == 0) {
+			return Optional.empty();
+		}
+
+		MemorySegment buffer = arena.allocate((long) (length + 1) * Character.BYTES, Character.BYTES);
+		int copied = (int) GET_WINDOW_TEXT_W.invokeExact(hwnd, buffer, length + 1);
+
+		if (copied == 0) {
+			return Optional.empty();
+		}
+
+		return Optional.of(readWideString(buffer, copied));
+	}
+
+	static MemorySegment upcallStub(Object target, String methodName, FunctionDescriptor descriptor, Arena arena) {
+		try {
+			return LINKER.upcallStub(MethodHandles.lookup().findVirtual(target.getClass(), methodName, descriptor.toMethodType()).bindTo(target), descriptor, arena);
+		} catch (ReflectiveOperationException e) {
+			throw new ExceptionInInitializerError(e);
+		}
+	}
+
+	static MemorySegment allocateWideString(Arena arena, String value) {
+		byte[] bytes = (value + "\0").getBytes(StandardCharsets.UTF_16LE);
+		MemorySegment segment = arena.allocate(bytes.length, 2);
+		MemorySegment.copy(bytes, 0, segment, ValueLayout.JAVA_BYTE, 0, bytes.length);
+		return segment;
+	}
+
+	static String readWideString(MemorySegment segment, int length) {
+		byte[] bytes = segment.reinterpret((long) length * Character.BYTES).toArray(ValueLayout.JAVA_BYTE);
+		return new String(bytes, StandardCharsets.UTF_16LE);
+	}
+
+	static @Nullable String tryFormatMessage(int errorCode) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment messagePointer = arena.allocate(ValueLayout.ADDRESS);
+			int chars = formatMessage(errorCode, ENGLISH_US, messagePointer);
+
+			if (chars == 0) {
+				chars = formatMessage(errorCode, NEUTRAL_LANGUAGE, messagePointer);
+			}
+
+			if (chars == 0) {
+				return null;
+			}
+
+			MemorySegment message = messagePointer.get(ValueLayout.ADDRESS, 0).reinterpret((long) chars * Character.BYTES);
+
+			try {
+				return readWideString(message, chars).strip();
+			} finally {
+				MemorySegment ignored = (MemorySegment) LOCAL_FREE.invokeExact(messagePointer.get(ValueLayout.ADDRESS, 0));
+			}
+		} catch (Throwable e) {
+			return null;
+		}
+	}
+
+	private static int formatMessage(int errorCode, int languageId, MemorySegment messagePointer) throws Throwable {
+		final int flags = FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS;
+		return (int) FORMAT_MESSAGE_W.invokeExact(flags, MemorySegment.NULL, errorCode, languageId, messagePointer, 0, MemorySegment.NULL);
+	}
+
+	private static void checkRestartManager(String operation, int error) throws LoomNativePlatformException {
+		if (error != ERROR_SUCCESS) {
+			throw LoomNativePlatformException.fromWin32Error(operation, error);
+		}
+	}
+
+	private static void throwLastError(String operation) throws Throwable {
+		throw LoomNativePlatformException.fromWin32Error(operation, getLastError());
+	}
+
+	private static int makeLangId(int primaryLanguage, int subLanguage) {
+		return (subLanguage << 10) | primaryLanguage;
+	}
+
+	private static MethodHandle downcall(SymbolLookup lookup, String name, FunctionDescriptor descriptor) {
+		Optional<MemorySegment> symbol = lookup.find(name);
+
+		if (symbol.isEmpty()) {
+			throw new ExceptionInInitializerError("Could not find Win32 symbol: " + name);
+		}
+
+		return LINKER.downcallHandle(symbol.get(), descriptor);
+	}
+
+	record ProcessTimes(MemorySegment createTime, MemorySegment exitTime, MemorySegment kernelTime, MemorySegment userTime) {
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/nativeplatform/WindowsNativePlatform.java
+++ b/src/main/java/net/fabricmc/loom/util/nativeplatform/WindowsNativePlatform.java
@@ -1,0 +1,225 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util.nativeplatform;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemorySegment;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class WindowsNativePlatform implements LoomNativePlatform.NativePlatform {
+	private static final Logger LOGGER = LoggerFactory.getLogger(WindowsNativePlatform.class);
+	private static final int CCH_RM_SESSION_KEY = 32;
+
+	private WindowsNativePlatform() {
+	}
+
+	static WindowsNativePlatform create() {
+		return new WindowsNativePlatform();
+	}
+
+	@Override
+	public List<ProcessHandle> getProcessesWithLockOn(Path path) throws LoomNativePlatformException {
+		return getPidsHoldingFileHandles(path).stream()
+				.map(ProcessHandle::of)
+				.filter(Optional::isPresent)
+				.map(Optional::get)
+				.toList();
+	}
+
+	@Override
+	public List<String> getWindowTitlesForPid(long pid) throws LoomNativePlatformException {
+		try (Arena arena = Arena.ofConfined()) {
+			List<String> titles = new ArrayList<>();
+			WindowEnumCallback callback = new WindowEnumCallback(pid, titles);
+			MemorySegment callbackStub = Win32.upcallStub(callback, "accept", FunctionDescriptor.of(Win32.BOOL, Win32.HWND, Win32.LONG_PTR), arena);
+
+			try {
+				Win32.enumWindows(callbackStub, 0);
+			} catch (LoomNativePlatformException e) {
+				callback.throwIfFailed();
+				throw e;
+			}
+
+			callback.throwIfFailed();
+			return titles;
+		} catch (LoomNativePlatformException e) {
+			throw e;
+		} catch (Throwable e) {
+			LOGGER.error("Failed to query window titles for pid {}", pid, e);
+			throw new LoomNativePlatformException("EnumWindows failed", e);
+		}
+	}
+
+	private List<Long> getPidsHoldingFileHandles(Path path) throws LoomNativePlatformException {
+		try (Arena arena = Arena.ofConfined()) {
+			try (RmSession session = RmSession.open(arena)) {
+				return getPidsHoldingFileHandles(arena, session, path);
+			}
+		} catch (LoomNativePlatformException e) {
+			throw e;
+		} catch (Throwable e) {
+			LOGGER.error("Failed to query processes holding a lock on {}", path, e);
+			throw new LoomNativePlatformException("Failed to query Restart Manager", e);
+		}
+	}
+
+	private List<Long> getPidsHoldingFileHandles(Arena arena, RmSession session, Path path) throws Throwable {
+		Win32.rmRegisterResources(session.handle(), arena, path.toString());
+
+		MemorySegment procInfoNeeded = arena.allocate(Win32.DWORD);
+		MemorySegment procInfo = arena.allocate(Win32.DWORD);
+		MemorySegment rebootReasons = arena.allocate(Win32.DWORD);
+		int procInfoCount = 64;
+		MemorySegment processes;
+		int error;
+
+		do {
+			procInfo.set(Win32.DWORD, 0, procInfoCount);
+			procInfoNeeded.set(Win32.DWORD, 0, 0);
+			processes = arena.allocate(Win32.RM_PROCESS_INFO, procInfoCount);
+			error = Win32.rmGetList(session.handle(), procInfoNeeded, procInfo, processes, rebootReasons);
+			procInfoCount = Math.max(procInfoNeeded.get(Win32.DWORD, 0), procInfoCount * 2);
+		} while (error == Win32.ERROR_MORE_DATA);
+
+		int returnedProcesses = procInfo.get(Win32.DWORD, 0);
+		List<Long> pids = new ArrayList<>();
+
+		for (int i = 0; i < returnedProcesses; i++) {
+			MemorySegment processInfo = processes.asSlice(Win32.RM_PROCESS_INFO.byteSize() * i, Win32.RM_PROCESS_INFO.byteSize());
+			int pid = processInfo.get(Win32.DWORD, 0);
+			MemorySegment restartManagerStartTime = processInfo.asSlice(Win32.DWORD.byteSize(), Win32.FILETIME.byteSize());
+
+			if (isSameLiveProcess(arena, pid, restartManagerStartTime)) {
+				pids.add(Integer.toUnsignedLong(pid));
+			}
+		}
+
+		return pids;
+	}
+
+	private boolean isSameLiveProcess(Arena arena, int pid, MemorySegment restartManagerStartTime) throws Throwable {
+		try (Win32Process process = Win32Process.open(pid)) {
+			if (!process.isValid()) {
+				return false;
+			}
+
+			Win32.ProcessTimes processTimes = Win32.getProcessTimes(arena, process.handle());
+			return processTimes != null && Win32.compareFileTime(restartManagerStartTime, processTimes.createTime()) == 0;
+		}
+	}
+
+	private record RmSession(int handle) implements AutoCloseable {
+		static RmSession open(Arena arena) throws Throwable {
+			return new RmSession(Win32.rmStartSession(arena, CCH_RM_SESSION_KEY));
+		}
+
+		@Override
+		public void close() throws LoomNativePlatformException {
+			try {
+				Win32.rmEndSession(handle);
+			} catch (LoomNativePlatformException e) {
+				throw e;
+			} catch (Throwable e) {
+				throw new LoomNativePlatformException("RmEndSession failed", e);
+			}
+		}
+	}
+
+	private record Win32Process(MemorySegment handle) implements AutoCloseable {
+		static Win32Process open(int pid) throws Throwable {
+			return new Win32Process(Win32.openProcess(Win32.PROCESS_QUERY_LIMITED_INFORMATION, 0, pid));
+		}
+
+		boolean isValid() {
+			return !handle.equals(MemorySegment.NULL);
+		}
+
+		@Override
+		public void close() throws LoomNativePlatformException {
+			if (!isValid()) {
+				return;
+			}
+
+			try {
+				Win32.closeHandle(handle);
+			} catch (Throwable e) {
+				throw new LoomNativePlatformException("CloseHandle failed", e);
+			}
+		}
+	}
+
+	private static final class WindowEnumCallback {
+		private final long pid;
+		private final List<String> titles;
+		private Throwable failure;
+
+		WindowEnumCallback(long pid, List<String> titles) {
+			this.pid = pid;
+			this.titles = titles;
+		}
+
+		@SuppressWarnings("unused")
+		public int accept(MemorySegment hwnd, long data) {
+			try {
+				if (isWindowOfPid(hwnd) && isMainWindow(hwnd)) {
+					getWindowTitle(hwnd).ifPresent(titles::add);
+				}
+
+				return 1;
+			} catch (Throwable e) {
+				failure = e;
+				return 0;
+			}
+		}
+
+		private void throwIfFailed() throws LoomNativePlatformException {
+			if (failure != null) {
+				LOGGER.error("Failed to inspect window", failure);
+				throw new LoomNativePlatformException("Failed to inspect window", failure);
+			}
+		}
+
+		private boolean isWindowOfPid(MemorySegment hwnd) throws Throwable {
+			return Win32.getWindowThreadProcessId(hwnd) == pid;
+		}
+
+		private boolean isMainWindow(MemorySegment hwnd) throws Throwable {
+			return Win32.getWindow(hwnd, Win32.GW_OWNER).equals(MemorySegment.NULL) && Win32.isWindowVisible(hwnd);
+		}
+
+		private Optional<String> getWindowTitle(MemorySegment hwnd) throws Throwable {
+			try (Arena arena = Arena.ofConfined()) {
+				return Win32.getWindowText(hwnd, arena);
+			}
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/nativeplatform/package-info.java
+++ b/src/main/java/net/fabricmc/loom/util/nativeplatform/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.util.nativeplatform;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/test/groovy/net/fabricmc/loom/test/unit/nativeplatform/LoomNativePlatformExceptionTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/nativeplatform/LoomNativePlatformExceptionTest.groovy
@@ -1,0 +1,47 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit.nativeplatform
+
+import spock.lang.Requires
+import spock.lang.Specification
+
+import net.fabricmc.loom.util.nativeplatform.LoomNativePlatformException
+
+class LoomNativePlatformExceptionTest extends Specification {
+	@Requires({ os.windows })
+	def "formats known win32 errors with system message"() {
+		when:
+		def message = LoomNativePlatformException.formatWin32Error("RmGetList", 5)
+
+		then:
+		message.startsWith("RmGetList failed: Windows error 5 (0x00000005): ")
+		message.toLowerCase(Locale.ROOT).contains("access")
+	}
+
+	def "formats unknown win32 errors with code fallback"() {
+		expect:
+		LoomNativePlatformException.formatWin32Error("RmRegisterResources", 0x7FFFFFFF) == "RmRegisterResources failed: Windows error 2147483647 (0x7FFFFFFF)"
+	}
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/nativeplatform/LoomNativePlatformTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/nativeplatform/LoomNativePlatformTest.groovy
@@ -1,0 +1,172 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit.nativeplatform
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+import javax.swing.JFrame
+import javax.swing.SwingUtilities
+
+import org.junit.jupiter.api.Assumptions
+import spock.lang.Requires
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import net.fabricmc.loom.util.nativeplatform.LoomNativePlatform
+
+@Requires({ os.windows })
+class LoomNativePlatformTest extends Specification {
+	def "is supported on windows"() {
+		expect:
+		LoomNativePlatform.isSupported()
+	}
+
+	def "finds current process holding file lock"() {
+		given:
+		Path path = Files.createTempFile("loom-native-platform", ".txt")
+
+		when:
+		def processes = []
+		Files.newOutputStream(path).withCloseable {
+			processes = LoomNativePlatform.getProcessesWithLockOn(path)
+		}
+
+		then:
+		processes.size() == 1
+		processes.first().pid() == ProcessHandle.current().pid()
+
+		cleanup:
+		Files.deleteIfExists(path)
+	}
+
+	def "unlocked file has no locking processes"() {
+		given:
+		Path path = Files.createTempFile("loom-native-platform", ".txt")
+
+		expect:
+		LoomNativePlatform.getProcessesWithLockOn(path).empty
+
+		cleanup:
+		Files.deleteIfExists(path)
+	}
+
+	def "missing file has no locking processes"() {
+		given:
+		Path path = Files.createTempDirectory("loom-native-platform").resolve("missing.txt")
+
+		expect:
+		LoomNativePlatform.getProcessesWithLockOn(path).empty
+
+		cleanup:
+		Files.deleteIfExists(path.parent)
+	}
+
+	def "pid zero has no window titles"() {
+		expect:
+		LoomNativePlatform.getWindowTitlesForPid(0).empty
+	}
+
+	def "finds window title for process"() {
+		given:
+		String title = "loom-native-platform-${UUID.randomUUID()}"
+		def process = startWindowTitleProcess(title)
+
+		when:
+		waitForReady(process)
+
+		then:
+		new PollingConditions(timeout: 10).eventually {
+			assert LoomNativePlatform.getWindowTitlesForPid(process.pid()).contains(title)
+		}
+
+		cleanup:
+		process?.destroyForcibly()
+	}
+
+	private static Process startWindowTitleProcess(String title) {
+		def java = Path.of(System.getProperty("java.home"), "bin", "java.exe")
+		return new ProcessBuilder(java.toString(), "-cp", System.getProperty("java.class.path"), WindowTitleProcess.name, title)
+				.redirectErrorStream(true)
+				.start()
+	}
+
+	private static void waitForReady(Process process) {
+		def reader = process.inputReader()
+		def output = new StringBuilder()
+		long timeout = System.nanoTime() + TimeUnit.SECONDS.toNanos(10)
+
+		while (System.nanoTime() < timeout) {
+			if (reader.ready()) {
+				def line = reader.readLine()
+
+				if (line == null) {
+					break
+				}
+
+				output.append(line).append('\n')
+
+				if (line == "READY") {
+					return
+				}
+
+				if (line.startsWith("UNAVAILABLE:")) {
+					Assumptions.assumeTrue(false, line)
+				}
+			} else if (!process.isAlive()) {
+				break
+			} else {
+				Thread.sleep(50)
+			}
+		}
+
+		throw new AssertionError("Window test process did not become ready. Exit: ${process.isAlive() ? 'still running' : process.exitValue()}, output:\n${output}")
+	}
+}
+
+class WindowTitleProcess {
+	static void main(String[] args) {
+		try {
+			SwingUtilities.invokeAndWait {
+				def frame = new JFrame(args[0])
+				frame.setSize(320, 180)
+				frame.setLocationRelativeTo(null)
+				frame.setVisible(true)
+			}
+
+			println("READY")
+			System.out.flush()
+
+			while (System.in.read() != -1) {
+				Thread.sleep(100)
+			}
+		} catch (Throwable e) {
+			println("UNAVAILABLE: ${e.class.name}: ${e.message}")
+			System.out.flush()
+			System.exit(2)
+		}
+	}
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/nativeplatform/LoomNativePlatformTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/nativeplatform/LoomNativePlatformTest.groovy
@@ -38,7 +38,9 @@ import spock.util.concurrent.PollingConditions
 
 import net.fabricmc.loom.util.nativeplatform.LoomNativePlatform
 
-@Requires({ os.windows })
+@Requires({
+	os.windows
+})
 class LoomNativePlatformTest extends Specification {
 	def "is supported on windows"() {
 		expect:


### PR DESCRIPTION
Removes another lib to download, allows us to remove fabric-loom-native from tooling repo, easier to build, easier for people to inspect.

Does require Java 25 though.