### PR TITLE
Configure gradle task from run config

### DIFF
--- a/src/main/java/net/fabricmc/loom/api/RunConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/api/RunConfiguration.java
@@ -24,6 +24,7 @@
 
 package net.fabricmc.loom.api;
 
+import org.gradle.api.Action;
 import org.gradle.api.Named;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.ListProperty;
@@ -31,6 +32,8 @@ import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
 import org.jetbrains.annotations.ApiStatus;
+
+import net.fabricmc.loom.task.RunGameTask;
 
 /**
  * Represents a run configuration for Minecraft, these can presented via an IDE run configuration or a Gradle task.
@@ -161,4 +164,11 @@ public interface RunConfiguration extends Named {
 		getRuntimeEnvironment().set("server");
 		getProgramArguments().add("nogui");
 	}
+
+	/**
+	 * Configures the Gradle task used to run this configuration.
+	 *
+	 * @param action The action used to configure the run task.
+	 */
+	void task(Action<RunGameTask> action);
 }

--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
@@ -33,12 +33,15 @@ import java.util.function.Function;
 
 import javax.inject.Inject;
 
+import org.gradle.api.Action;
 import org.gradle.api.Named;
 import org.gradle.api.Project;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
 
 import net.fabricmc.loom.api.RunConfiguration;
+import net.fabricmc.loom.task.LoomTasks;
+import net.fabricmc.loom.task.RunGameTask;
 import net.fabricmc.loom.util.Platform;
 import net.fabricmc.loom.util.gradle.SourceSetHelper;
 
@@ -57,6 +60,12 @@ public abstract class RunConfigSettings implements Named, RunConfiguration, RunC
 	@Override
 	public String getName() {
 		return name;
+	}
+
+	@Override
+	public void task(Action<RunGameTask> action) {
+		String taskName = LoomTasks.getRunConfigTaskName(this);
+		project.getTasks().named(taskName::equals).withType(RunGameTask.class).configureEach(action);
 	}
 
 	// Backwards compatibility shims:

--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigurationInternal.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigurationInternal.java
@@ -24,13 +24,20 @@
 
 package net.fabricmc.loom.configuration.ide;
 
+import org.gradle.api.Action;
 import org.gradle.api.provider.Property;
 import org.jetbrains.annotations.ApiStatus;
 
 import net.fabricmc.loom.api.RunConfiguration;
+import net.fabricmc.loom.task.RunGameTask;
 
 @ApiStatus.Internal
 public interface RunConfigurationInternal extends RunConfiguration {
 	@ApiStatus.Internal
 	Property<Boolean> getIsFinalised();
+
+	@Override
+	default void task(Action<RunGameTask> action) {
+		throw new UnsupportedOperationException("Cannot configure the task of a serialised run configuration");
+	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/integration/RunConfigTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/RunConfigTest.groovy
@@ -84,6 +84,34 @@ class RunConfigTest extends Specification implements GradleProjectTestTrait {
 		version << STANDARD_TEST_VERSIONS
 	}
 
+	def "Run config can configure run task"() {
+		setup:
+		def gradle = gradleProject(project: "minimalBase")
+		gradle.buildGradle << """
+                dependencies {
+                    minecraft "com.mojang:minecraft:1.18.1"
+                    mappings "net.fabricmc:yarn:1.18.1+build.18:v2"
+                    modImplementation "${LoomTestVersions.FABRIC_LOADER.mavenNotation()}"
+                }
+
+                loom {
+                    runs {
+                        client {
+                            task {
+                                description = "Configured through the run config"
+                            }
+                        }
+                    }
+                }
+            """
+
+		when:
+		def result = gradle.run(task: "help", args: ["--task", "runClient"])
+
+		then:
+		result.output.contains("Configured through the run config")
+	}
+
 	@RestoreSystemProperties
 	@Unroll
 	def "idea auto configuration (gradle #version)"() {


### PR DESCRIPTION
Just makes it a little cleaner/easier to do all in one place. same as doing `runClient {}`