### PR TITLE
Fix implementation from #1560 to allow configuration of dep resolution for included jars

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/IncludeConfigurations.java
+++ b/src/main/java/net/fabricmc/loom/configuration/IncludeConfigurations.java
@@ -57,20 +57,22 @@ public final class IncludeConfigurations {
 
 	public static void nestJars(Project project, TaskProvider<? extends Jar> jarTask, Configuration configuration) {
 		String taskName = getUniqueTaskName(project, getProcessIncludeJarsTaskName(jarTask.getName(), configuration.getName()));
-		nestJars(project, jarTask, project.provider(() -> configuration), taskName);
+		String configName = getUniqueConfigName(project, getResolvedIncludeJarsConfigName(jarTask.getName(), configuration.getName()));
+		nestJars(project, jarTask, project.provider(() -> configuration), taskName, configName);
 	}
 
 	public static void nestJars(Project project, TaskProvider<? extends Jar> jarTask, NamedDomainObjectProvider<? extends Configuration> configuration) {
 		String taskName = getUniqueTaskName(project, getProcessIncludeJarsTaskName(jarTask.getName(), configuration.getName()));
-		nestJars(project, jarTask, configuration, taskName);
+		String configName = getUniqueConfigName(project, getResolvedIncludeJarsConfigName(jarTask.getName(), configuration.getName()));
+		nestJars(project, jarTask, configuration, taskName, configName);
 	}
 
-	public static void nestJars(Project project, TaskProvider<? extends Jar> jarTask, Configuration configuration, String taskName) {
-		nestJars(project, jarTask, project.provider(() -> configuration), taskName);
+	public static void nestJars(Project project, TaskProvider<? extends Jar> jarTask, Configuration configuration, String taskName, String configName) {
+		nestJars(project, jarTask, project.provider(() -> configuration), taskName, configName);
 	}
 
-	public static void nestJars(Project project, TaskProvider<? extends Jar> jarTask, Provider<? extends Configuration> configuration, String taskName) {
-		TaskProvider<NestableJarGenerationTask> processTask = createProcessTask(project, configuration, taskName);
+	public static void nestJars(Project project, TaskProvider<? extends Jar> jarTask, Provider<? extends Configuration> configuration, String taskName, String configName) {
+		TaskProvider<NestableJarGenerationTask> processTask = createProcessTask(project, configuration, taskName, configName);
 		FileCollection outputJars = getOutputJars(project, processTask);
 
 		jarTask.configure(task -> {
@@ -85,26 +87,27 @@ public final class IncludeConfigurations {
 		});
 	}
 
-	private static TaskProvider<NestableJarGenerationTask> createProcessTask(Project project, Provider<? extends Configuration> configuration, String taskName) {
-		Configuration internalConfiguration = createInternalConfiguration(project, configuration);
+	private static TaskProvider<NestableJarGenerationTask> createProcessTask(Project project, Provider<? extends Configuration> configuration, String taskName, String configName) {
+		NamedDomainObjectProvider<Configuration> internalConfiguration = createResolvingConfiguration(project, configuration, configName);
 		LoomGradleExtension extension = LoomGradleExtension.get(project);
 
 		return project.getTasks().register(taskName, NestableJarGenerationTask.class, task -> {
-			task.from(internalConfiguration);
+			task.from(internalConfiguration.get());
 			task.getOutputDirectory().set(project.getLayout().getBuildDirectory().dir(task.getName()));
 			task.getUncompressNestedJars().set(extension.getUncompressNestedJars());
 		});
 	}
 
-	private static Configuration createInternalConfiguration(Project project, Provider<? extends Configuration> include) {
-		Configuration internal = project.getConfigurations().detachedConfiguration();
-		LoomConfigurations.Role.RESOLVABLE.apply(internal);
-		addNonTransitiveDependencies(project, internal, include);
-		configureAttributes(project, internal);
-		return internal;
+	private static NamedDomainObjectProvider<Configuration> createResolvingConfiguration(Project project, Provider<? extends Configuration> include, String configName) {
+		return project.getConfigurations().register(configName, config -> {
+			LoomConfigurations.Role.RESOLVABLE.apply(config);
+			addNonTransitiveDependencies(project, config, include);
+			configureAttributes(project, config);
+		});
 	}
 
 	private static void addNonTransitiveDependencies(Project project, Configuration target, Provider<? extends Configuration> source) {
+		target.getDependencyConstraints().addAllLater(project.provider(() -> source.get().getIncoming().getDependencyConstraints()));
 		target.getDependencies().addAllLater(project.provider(() -> {
 			List<Dependency> dependencies = new ArrayList<>();
 
@@ -148,6 +151,10 @@ public final class IncludeConfigurations {
 		return "process" + Strings.capitalize(jarTaskName) + Strings.capitalize(configurationName) + "Jars";
 	}
 
+	private static String getResolvedIncludeJarsConfigName(String jarTaskName, String configurationName) {
+		return "resolved" + Strings.capitalize(jarTaskName) + Strings.capitalize(configurationName) + "Jars";
+	}
+
 	private static String getUniqueTaskName(Project project, String taskName) {
 		if (!project.getTasks().getNames().contains(taskName)) {
 			return taskName;
@@ -160,5 +167,19 @@ public final class IncludeConfigurations {
 		}
 
 		return taskName + suffix;
+	}
+
+	private static String getUniqueConfigName(Project project, String configName) {
+		if (!project.getConfigurations().getNames().contains(configName)) {
+			return configName;
+		}
+
+		int suffix = 2;
+
+		while (project.getConfigurations().getNames().contains(configName + suffix)) {
+			suffix++;
+		}
+
+		return configName + suffix;
 	}
 }

--- a/src/main/java/net/fabricmc/loom/task/NonRemappedJarTaskConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/task/NonRemappedJarTaskConfiguration.java
@@ -75,7 +75,8 @@ public class NonRemappedJarTaskConfiguration {
 				project,
 				project.getTasks().named(JavaPlugin.JAR_TASK_NAME, Jar.class),
 				project.getConfigurations().named(Constants.Configurations.INCLUDE),
-				Constants.Task.PROCESS_INCLUDE_JARS
+				Constants.Task.PROCESS_INCLUDE_JARS,
+				Constants.Configurations.INCLUDE_INTERNAL
 		);
 
 		extension.getUnmappedModCollection().from(project.getTasks().named(JavaPlugin.JAR_TASK_NAME));

--- a/src/main/java/net/fabricmc/loom/task/RemapTaskConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapTaskConfiguration.java
@@ -96,7 +96,8 @@ public abstract class RemapTaskConfiguration implements Runnable {
 				getProject(),
 				getTasks().named(REMAP_JAR_TASK_NAME, RemapJarTask.class),
 				getConfigurations().named(Constants.Configurations.INCLUDE),
-				Constants.Task.PROCESS_INCLUDE_JARS
+				Constants.Task.PROCESS_INCLUDE_JARS,
+				Constants.Configurations.INCLUDE_INTERNAL
 		);
 
 		// Configure the default jar task

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -50,6 +50,7 @@ public class Constants {
 		public static final String MOD_COMPILE_CLASSPATH = "modCompileClasspath";
 		public static final String MOD_COMPILE_CLASSPATH_MAPPED = "modCompileClasspathMapped";
 		public static final String INCLUDE = "include";
+		public static final String INCLUDE_INTERNAL = "includeInternal";
 		public static final String MINECRAFT = "minecraft";
 
 		public static final String MINECRAFT_COMPILE_LIBRARIES = "minecraftLibraries";


### PR DESCRIPTION
Use of a detached configuration as #1560 was implemented introduces a regression: it prevents any configuration of the resolution process by modders, including dependency locking, preventing changing/dynamic versions, adding attributes, or configuring handling of version or capability conflicts.

The ability to configure attributes of this configuration is necessary for, for example, [multiloader template](https://github.com/jaredlll08/MultiLoader-Template/blob/178d1abb85e7d4ef7903bdd8fe9f4f9e0748c80c/fabric/build.gradle#L33-L40), which uses the `io.github.mcgradleconventions.loader` attribute in resolvable configs to handle multiloader dependencies which distinguish loader by attribute.

However, the uses that use of a detached configuration rules out, that worked previously, are _much_ broader, and don't even have to invoke `includeInternal` by name, since the configuration in question is not affected by `configurations.configureEach` and thus any attempt to enforce defaults for resolution across all configs -- in terms of various resolution strategy rules or conflict resolution, preventing dynamic or changing versions, etc. -- will fail