### PR TITLE
Initial annotater support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,7 @@ dependencies {
 	testImplementation testLibs.bcutil
 	testImplementation testLibs.bcpkix
 	testImplementation testLibs.fabric.loader
+	testImplementation runtimeLibs.vineflower
 
 	compileOnly runtimeLibs.jetbrains.annotations
 	testCompileOnly runtimeLibs.jetbrains.annotations

--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,7 @@ dependencies {
 	testImplementation testLibs.bcutil
 	testImplementation testLibs.bcpkix
 	testImplementation testLibs.fabric.loader
+	testImplementation runtimeLibs.cfr
 	testImplementation runtimeLibs.vineflower
 
 	compileOnly runtimeLibs.jetbrains.annotations

--- a/src/decompilers/cfr/net/fabricmc/loom/decompilers/cfr/LoomCFRDecompiler.java
+++ b/src/decompilers/cfr/net/fabricmc/loom/decompilers/cfr/LoomCFRDecompiler.java
@@ -45,6 +45,7 @@ import org.benf.cfr.reader.util.getopt.Options;
 import org.benf.cfr.reader.util.getopt.OptionsImpl;
 import org.benf.cfr.reader.util.output.SinkDumperFactory;
 
+import net.fabricmc.loom.api.decompilers.JavadocStyle;
 import net.fabricmc.loom.decompilers.LoomInternalDecompiler;
 
 public final class LoomCFRDecompiler implements LoomInternalDecompiler {
@@ -56,6 +57,10 @@ public final class LoomCFRDecompiler implements LoomInternalDecompiler {
 
 	@Override
 	public void decompile(LoomInternalDecompiler.Context context) {
+		if (context.javadocStyle() == JavadocStyle.MARKDOWN) {
+			throw new UnsupportedOperationException("CFR does not support Markdown Javadocs");
+		}
+
 		Path compiledJar = context.compiledJar();
 
 		final String path = compiledJar.toAbsolutePath().toString();

--- a/src/decompilers/common/net/fabricmc/loom/api/decompilers/JavadocStyle.java
+++ b/src/decompilers/common/net/fabricmc/loom/api/decompilers/JavadocStyle.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2023-2026 FabricMC
+ * Copyright (c) 2026 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,46 +22,9 @@
  * SOFTWARE.
  */
 
-package net.fabricmc.loom.decompilers;
+package net.fabricmc.loom.api.decompilers;
 
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Map;
-
-import net.fabricmc.loom.api.decompilers.JavadocStyle;
-
-// This is an internal interface to loom, DO NOT USE this in your own plugins.
-public interface LoomInternalDecompiler {
-	void decompile(Context context);
-
-	interface Context {
-		Path compiledJar();
-
-		Path sourcesDestination();
-
-		Path linemapDestination();
-
-		int numberOfThreads();
-
-		Path javaDocs();
-
-		Collection<Path> libraries();
-
-		Logger logger();
-
-		Map<String, String> options();
-
-		byte[] unpackZip(Path zip, String path) throws IOException;
-
-		String runtimeNamespace();
-
-		JavadocStyle javadocStyle();
-	}
-
-	interface Logger {
-		void accept(String data) throws IOException;
-
-		void error(String msg);
-	}
+public enum JavadocStyle {
+	HTML,
+	MARKDOWN
 }

--- a/src/decompilers/vineflower/net/fabricmc/loom/decompilers/vineflower/TinyJavadocProvider.java
+++ b/src/decompilers/vineflower/net/fabricmc/loom/decompilers/vineflower/TinyJavadocProvider.java
@@ -36,6 +36,7 @@ import org.jetbrains.java.decompiler.struct.StructField;
 import org.jetbrains.java.decompiler.struct.StructMethod;
 import org.jetbrains.java.decompiler.struct.StructRecordComponent;
 
+import net.fabricmc.fernflower.api.FabricJavadocStyle;
 import net.fabricmc.fernflower.api.IFabricJavadocProvider;
 import net.fabricmc.mappingio.MappingReader;
 import net.fabricmc.mappingio.adapter.MappingSourceNsSwitch;
@@ -44,12 +45,18 @@ import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
 public class TinyJavadocProvider implements IFabricJavadocProvider {
 	private static final int ACC_STATIC = 0x0008;
-	private static final int ACC_RECORD = 0x10000;
 
 	private final MappingTree mappingTree;
+	private final FabricJavadocStyle javadocStyle;
 
 	public TinyJavadocProvider(File tinyFile, String runtimeNamespace) {
 		mappingTree = readMappings(tinyFile, runtimeNamespace);
+		javadocStyle = mappingTree.getDstNamespaces().isEmpty() ? FabricJavadocStyle.MARKDOWN : FabricJavadocStyle.HTML;
+	}
+
+	@Override
+	public FabricJavadocStyle getClassJavadocStyle(StructClass structClass) {
+		return javadocStyle;
 	}
 
 	@Override
@@ -94,7 +101,7 @@ public class TinyJavadocProvider implements IFabricJavadocProvider {
 					addedParam = true;
 				}
 
-				parts.add(String.format("@param %s %s", fieldMapping.getName("named"), comment));
+				parts.add(String.format("@param %s %s", fieldMapping.getSrcName(), comment));
 			}
 		}
 
@@ -152,7 +159,7 @@ public class TinyJavadocProvider implements IFabricJavadocProvider {
 						addedParam = true;
 					}
 
-					parts.add(String.format("@param %s %s", argMapping.getName("named"), comment));
+					parts.add(String.format("@param %s %s", argMapping.getSrcName(), comment));
 				}
 			}
 
@@ -179,7 +186,7 @@ public class TinyJavadocProvider implements IFabricJavadocProvider {
 	}
 
 	public static boolean isRecord(StructClass structClass) {
-		return (structClass.getAccessFlags() & ACC_RECORD) != 0;
+		return structClass.getRecordComponents() != null;
 	}
 
 	public static boolean isStatic(StructField structField) {

--- a/src/decompilers/vineflower/net/fabricmc/loom/decompilers/vineflower/TinyJavadocProvider.java
+++ b/src/decompilers/vineflower/net/fabricmc/loom/decompilers/vineflower/TinyJavadocProvider.java
@@ -38,6 +38,7 @@ import org.jetbrains.java.decompiler.struct.StructRecordComponent;
 
 import net.fabricmc.fernflower.api.FabricJavadocStyle;
 import net.fabricmc.fernflower.api.IFabricJavadocProvider;
+import net.fabricmc.loom.api.decompilers.JavadocStyle;
 import net.fabricmc.mappingio.MappingReader;
 import net.fabricmc.mappingio.adapter.MappingSourceNsSwitch;
 import net.fabricmc.mappingio.tree.MappingTree;
@@ -49,9 +50,12 @@ public class TinyJavadocProvider implements IFabricJavadocProvider {
 	private final MappingTree mappingTree;
 	private final FabricJavadocStyle javadocStyle;
 
-	public TinyJavadocProvider(File tinyFile, String runtimeNamespace) {
+	public TinyJavadocProvider(File tinyFile, String runtimeNamespace, JavadocStyle javadocStyle) {
 		mappingTree = readMappings(tinyFile, runtimeNamespace);
-		javadocStyle = mappingTree.getDstNamespaces().isEmpty() ? FabricJavadocStyle.MARKDOWN : FabricJavadocStyle.HTML;
+		this.javadocStyle = switch (javadocStyle) {
+		case HTML -> FabricJavadocStyle.HTML;
+		case MARKDOWN -> FabricJavadocStyle.MARKDOWN;
+		};
 	}
 
 	@Override

--- a/src/decompilers/vineflower/net/fabricmc/loom/decompilers/vineflower/VineflowerDecompiler.java
+++ b/src/decompilers/vineflower/net/fabricmc/loom/decompilers/vineflower/VineflowerDecompiler.java
@@ -53,7 +53,7 @@ public final class VineflowerDecompiler implements LoomInternalDecompiler {
 		);
 
 		if (context.javaDocs() != null) {
-			options.put(IFabricJavadocProvider.PROPERTY_NAME, new TinyJavadocProvider(context.javaDocs().toFile(), context.runtimeNamespace()));
+			options.put(IFabricJavadocProvider.PROPERTY_NAME, new TinyJavadocProvider(context.javaDocs().toFile(), context.runtimeNamespace(), context.javadocStyle()));
 		}
 
 		options.putAll(context.options());

--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -34,6 +34,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.api.LoomGradleExtensionAPI;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
@@ -42,6 +43,7 @@ import net.fabricmc.loom.configuration.accesswidener.AccessWidenerFile;
 import net.fabricmc.loom.configuration.mods.ArtifactMetadata;
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsFactory;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
+import net.fabricmc.loom.configuration.providers.mappings.RemapMappingConfiguration;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftMetadataProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.library.LibraryProcessorManager;
@@ -74,7 +76,10 @@ public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 
 	void setMinecraftProvider(MinecraftProvider minecraftProvider);
 
-	MappingConfiguration getMappingConfiguration();
+	RemapMappingConfiguration getMappingConfiguration();
+
+	@Nullable
+	MappingConfiguration getMappingConfigurationOrNull();
 
 	void setMappingConfiguration(MappingConfiguration mappingConfiguration);
 

--- a/src/main/java/net/fabricmc/loom/api/decompilers/DecompilationMetadata.java
+++ b/src/main/java/net/fabricmc/loom/api/decompilers/DecompilationMetadata.java
@@ -31,9 +31,9 @@ import java.util.Map;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.util.IOStringConsumer;
 
-public record DecompilationMetadata(int numberOfThreads, Path javaDocs, Collection<Path> libraries, IOStringConsumer logger, Map<String, String> options, String runtimeNamespace) {
+public record DecompilationMetadata(int numberOfThreads, Path javaDocs, Collection<Path> libraries, IOStringConsumer logger, Map<String, String> options, String runtimeNamespace, JavadocStyle javadocStyle) {
 	@Deprecated
 	public DecompilationMetadata(int numberOfThreads, Path javaDocs, Collection<Path> libraries, IOStringConsumer logger, Map<String, String> options) {
-		this(numberOfThreads, javaDocs, libraries, logger, options, MappingsNamespace.NAMED.toString());
+		this(numberOfThreads, javaDocs, libraries, logger, options, MappingsNamespace.NAMED.toString(), JavadocStyle.HTML);
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -67,6 +67,8 @@ import net.fabricmc.loom.configuration.processors.ModJavadocProcessor;
 import net.fabricmc.loom.configuration.processors.speccontext.DebofConfiguration;
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsFactory;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
+import net.fabricmc.loom.configuration.providers.mappings.NoRemapMappingConfiguration;
+import net.fabricmc.loom.configuration.providers.mappings.RemapMappingConfiguration;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftMetadataProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftSourceSets;
@@ -190,9 +192,18 @@ public abstract class CompileConfiguration implements Runnable {
 
 			// Resolve the mapping files from the configuration
 			final DependencyInfo mappingsDep = DependencyInfo.create(getProject(), Configurations.MAPPINGS);
-			final MappingConfiguration mappingConfiguration = MappingConfiguration.create(getProject(), configContext.serviceFactory(), mappingsDep, minecraftProvider);
+			final MappingConfiguration mappingConfiguration = RemapMappingConfiguration.create(getProject(), configContext.serviceFactory(), mappingsDep, minecraftProvider);
 			extension.setMappingConfiguration(mappingConfiguration);
 			mappingConfiguration.applyToProject(getProject(), mappingsDep);
+		} else {
+			var annotations = project.getConfigurations().getByName(Configurations.ANNOTATIONS);
+
+			if (!annotations.getDependencies().isEmpty()) {
+				final DependencyInfo annotationsDep = DependencyInfo.create(getProject(), annotations);
+				final MappingConfiguration mappingConfiguration = NoRemapMappingConfiguration.create(getProject(), annotationsDep, minecraftProvider);
+				extension.setMappingConfiguration(mappingConfiguration);
+				mappingConfiguration.applyToProject(getProject(), annotationsDep);
+			}
 		}
 
 		// Provide the remapped mc jars

--- a/src/main/java/net/fabricmc/loom/configuration/LoomConfigurations.java
+++ b/src/main/java/net/fabricmc/loom/configuration/LoomConfigurations.java
@@ -83,15 +83,13 @@ public abstract class LoomConfigurations implements Runnable {
 		registerNonTransitive(Constants.Configurations.MINECRAFT, Role.NONE);
 
 		register(Constants.Configurations.INCLUDE, Role.NONE);
+		registerNonTransitive(Constants.Configurations.MAPPING_CONSTANTS, Role.RESOLVABLE);
+		extendsFrom(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME, Constants.Configurations.MAPPING_CONSTANTS);
 
 		if (!extension.disableObfuscation()) {
-			registerNonTransitive(Constants.Configurations.MAPPING_CONSTANTS, Role.RESOLVABLE);
-
 			register(Constants.Configurations.NAMED_ELEMENTS, Role.CONSUMABLE).configure(configuration -> {
 				configuration.extendsFrom(getConfigurations().named(JavaPlugin.API_CONFIGURATION_NAME));
 			});
-
-			extendsFrom(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME, Constants.Configurations.MAPPING_CONSTANTS);
 
 			register(Constants.Configurations.MAPPINGS, Role.RESOLVABLE);
 			register(Constants.Configurations.MAPPINGS_FINAL, Role.RESOLVABLE);
@@ -99,6 +97,8 @@ public abstract class LoomConfigurations implements Runnable {
 			extendsFrom(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME, Constants.Configurations.MAPPINGS_FINAL);
 
 			extension.createRemapConfigurations(SourceSetHelper.getMainSourceSet(getProject()));
+		} else {
+			registerNonTransitive(Constants.Configurations.ANNOTATIONS, Role.RESOLVABLE);
 		}
 
 		register(Constants.Configurations.LOOM_DEVELOPMENT_DEPENDENCIES, Role.RESOLVABLE);

--- a/src/main/java/net/fabricmc/loom/configuration/processors/ProcessorContextImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/ProcessorContextImpl.java
@@ -24,10 +24,13 @@
 
 package net.fabricmc.loom.configuration.processors;
 
+import java.util.Objects;
+
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.api.processor.ProcessorContext;
 import net.fabricmc.loom.configuration.ConfigContext;
+import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftJar;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftJarConfiguration;
 import net.fabricmc.loom.util.LazyCloseable;
@@ -63,7 +66,8 @@ public record ProcessorContextImpl(ConfigContext configContext, MinecraftJar min
 	@Override
 	public MemoryMappingTree getMappings() {
 		LoomGradleExtension extension = LoomGradleExtension.get(configContext().project());
-		return extension.getMappingConfiguration().getMappingsService(configContext().project(), configContext().serviceFactory()).getMappingTree();
+		MappingConfiguration mappingConfiguration = Objects.requireNonNull(extension.getMappingConfigurationOrNull(), "Mappings have not been configured");
+		return mappingConfiguration.getMappingsService(configContext().project(), configContext().serviceFactory()).getMappingTree();
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/IntermediaryMappingsProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/IntermediaryMappingsProvider.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.fabricmc.loom.api.mappings.intermediate.IntermediateMappingsProvider;
+import net.fabricmc.loom.configuration.providers.mappings.tiny.TinyJarInfo;
 import net.fabricmc.loom.extension.LoomGradleExtensionApiImpl;
 import net.fabricmc.loom.util.Checksum;
 
@@ -103,7 +104,7 @@ public abstract class IntermediaryMappingsProvider extends IntermediateMappingsP
 					.downloadPath(intermediaryJarPath);
 		}
 
-		MappingConfiguration.extractMappings(intermediaryJarPath, tinyMappings);
+		TinyJarInfo.extractMappings(intermediaryJarPath, tinyMappings);
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
@@ -47,6 +47,7 @@ import net.fabricmc.loom.configuration.providers.mappings.extras.annotations.Ann
 import net.fabricmc.loom.configuration.providers.mappings.tiny.TinyJarInfo;
 import net.fabricmc.loom.configuration.providers.mappings.unpick.UnpickMetadata;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
+import net.fabricmc.loom.api.decompilers.JavadocStyle;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.FileSystemUtil;
 import net.fabricmc.loom.util.service.ServiceFactory;
@@ -101,6 +102,8 @@ public abstract sealed class MappingConfiguration permits RemapMappingConfigurat
 	public abstract String getMappingsHash();
 
 	public abstract MappingsNamespace getRuntimeNamespace();
+
+	public abstract JavadocStyle getJavadocStyle();
 
 	public TinyMappingsService getMappingsService(Project project, ServiceFactory serviceFactory) {
 		return serviceFactory.get(getMappingsServiceOptions(project));

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
@@ -31,7 +31,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Objects;
 
@@ -53,15 +52,13 @@ import net.fabricmc.loom.util.FileSystemUtil;
 import net.fabricmc.loom.util.service.ServiceFactory;
 
 public abstract sealed class MappingConfiguration permits RemapMappingConfiguration, NoRemapMappingConfiguration {
-	protected static final String MAPPINGS_PATH = "mappings/mappings.tiny";
 	protected static final Logger LOGGER = LoggerFactory.getLogger(MappingConfiguration.class);
 
 	public final String mappingsIdentifier;
 
 	private final Path inputJar;
-	private Path unpickDefinitions;
 	@Nullable
-	private String unpickDefinitionsEntry;
+	private byte[] unpickDefinitions;
 
 	private List<AnnotationsData> annotationsData = List.of();
 	@Nullable
@@ -101,7 +98,7 @@ public abstract sealed class MappingConfiguration permits RemapMappingConfigurat
 
 	public abstract Provider<TinyMappingsService.Options> getMappingsServiceOptions(Project project);
 
-	public abstract Path getMappingsInputFile();
+	public abstract String getMappingsHash();
 
 	public abstract MappingsNamespace getRuntimeNamespace();
 
@@ -156,16 +153,6 @@ public abstract sealed class MappingConfiguration permits RemapMappingConfigurat
 		return mappingsName + "." + minecraftVersion.replace(' ', '_').replace('.', '_').replace('-', '_') + "." + version + classifier;
 	}
 
-	public static void extractMappings(Path jar, Path extractTo) throws IOException {
-		try (FileSystemUtil.Delegate delegate = FileSystemUtil.getJarFileSystem(jar)) {
-			extractMappings(delegate.fs(), extractTo);
-		}
-	}
-
-	public static void extractMappings(FileSystem jar, Path extractTo) throws IOException {
-		Files.copy(jar.getPath(MAPPINGS_PATH), extractTo, StandardCopyOption.REPLACE_EXISTING);
-	}
-
 	private void readExtras(FileSystem jar) throws IOException {
 		readAnnotationsData(jar);
 		readUnpickDefinitions(jar);
@@ -192,14 +179,7 @@ public abstract sealed class MappingConfiguration permits RemapMappingConfigurat
 		}
 
 		unpickMetadata = UnpickMetadata.parse(unpickMetadataPath);
-		configureUnpickDefinitions(jar, unpickPath);
-	}
-
-	protected abstract void configureUnpickDefinitions(FileSystem jar, Path unpickPath) throws IOException;
-
-	protected final void setUnpickDefinitions(Path path, @Nullable String entry) {
-		unpickDefinitions = path;
-		unpickDefinitionsEntry = entry;
+		unpickDefinitions = Files.readAllBytes(unpickPath);
 	}
 
 	protected final Path inputJar() {
@@ -210,13 +190,8 @@ public abstract sealed class MappingConfiguration permits RemapMappingConfigurat
 		return mappingsIdentifier;
 	}
 
-	public Path getUnpickDefinitionsFile() {
+	public byte[] getUnpickDefinitions() {
 		return Objects.requireNonNull(unpickDefinitions, "Unpick definitions are not available");
-	}
-
-	@Nullable
-	public String getUnpickDefinitionsEntry() {
-		return unpickDefinitionsEntry;
 	}
 
 	public boolean hasUnpickDefinitions() {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2016-2023 FabricMC
+ * Copyright (c) 2016-2026 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,148 +25,122 @@
 package net.fabricmc.loom.configuration.providers.mappings;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
-import java.io.Reader;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
-import org.apache.tools.ant.util.StringUtils;
 import org.gradle.api.Project;
 import org.gradle.api.provider.Provider;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import net.fabricmc.loom.LoomGradleExtension;
-import net.fabricmc.loom.LoomGradlePlugin;
 import net.fabricmc.loom.configuration.DependencyInfo;
+import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.configuration.providers.mappings.extras.annotations.AnnotationsData;
 import net.fabricmc.loom.configuration.providers.mappings.extras.annotations.AnnotationsLayer;
-import net.fabricmc.loom.configuration.providers.mappings.tiny.MappingsMerger;
 import net.fabricmc.loom.configuration.providers.mappings.tiny.TinyJarInfo;
 import net.fabricmc.loom.configuration.providers.mappings.unpick.UnpickMetadata;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
 import net.fabricmc.loom.util.Constants;
-import net.fabricmc.loom.util.DeletingFileVisitor;
 import net.fabricmc.loom.util.FileSystemUtil;
-import net.fabricmc.loom.util.ZipUtils;
 import net.fabricmc.loom.util.service.ServiceFactory;
-import net.fabricmc.mappingio.MappingReader;
-import net.fabricmc.mappingio.format.MappingFormat;
-import net.fabricmc.stitch.Command;
-import net.fabricmc.stitch.commands.CommandProposeFieldNames;
 
-public class MappingConfiguration {
-	private static final Logger LOGGER = LoggerFactory.getLogger(MappingConfiguration.class);
+public abstract sealed class MappingConfiguration permits RemapMappingConfiguration, NoRemapMappingConfiguration {
+	protected static final String MAPPINGS_PATH = "mappings/mappings.tiny";
+	protected static final Logger LOGGER = LoggerFactory.getLogger(MappingConfiguration.class);
 
 	public final String mappingsIdentifier;
 
-	private final Path mappingsWorkingDir;
-	// The mappings that gradle gives us
-	private final Path baseTinyMappings;
-	// The mappings we use in practice
-	public final Path tinyMappings;
-	public final Path tinyMappingsJar;
-	private final Path unpickDefinitions;
+	private final Path inputJar;
+	private Path unpickDefinitions;
+	@Nullable
+	private String unpickDefinitionsEntry;
 
 	private List<AnnotationsData> annotationsData = List.of();
 	@Nullable
 	private UnpickMetadata unpickMetadata;
-	private Map<String, String> signatureFixes;
 
-	private MappingConfiguration(String mappingsIdentifier, Path mappingsWorkingDir) {
+	protected MappingConfiguration(String mappingsIdentifier, Path inputJar) {
 		this.mappingsIdentifier = mappingsIdentifier;
-
-		this.mappingsWorkingDir = mappingsWorkingDir;
-		this.baseTinyMappings = mappingsWorkingDir.resolve("mappings-base.tiny");
-		this.tinyMappings = mappingsWorkingDir.resolve("mappings.tiny");
-		this.tinyMappingsJar = mappingsWorkingDir.resolve("mappings.jar");
-		this.unpickDefinitions = mappingsWorkingDir.resolve("mappings.unpick");
+		this.inputJar = inputJar;
 	}
 
-	public static MappingConfiguration create(Project project, ServiceFactory serviceFactory, DependencyInfo dependency, MinecraftProvider minecraftProvider) {
-		final String version = dependency.getResolvedVersion();
-		final Path inputJar = dependency.resolveFile().orElseThrow(() -> new RuntimeException("Could not resolve mappings: " + dependency)).toPath();
-		final String mappingsName = StringUtils.removeSuffix(dependency.getDependency().getGroup() + "." + dependency.getDependency().getName(), "-unmerged");
-
-		final TinyJarInfo jarInfo = TinyJarInfo.get(inputJar);
-		jarInfo.minecraftVersionId().ifPresent(id -> {
-			if (!minecraftProvider.minecraftVersion().equals(id)) {
-				LOGGER.warn("The mappings (%s) were not built for Minecraft version %s, proceed with caution.".formatted(dependency.getDepString(), minecraftProvider.minecraftVersion()));
-			}
-		});
-
-		final String mappingsIdentifier = createMappingsIdentifier(mappingsName, version, getMappingsClassifier(dependency, jarInfo.v2()), minecraftProvider.minecraftVersion());
-		final Path workingDir = minecraftProvider.dir(mappingsIdentifier).toPath();
-
-		var mappingProvider = new MappingConfiguration(mappingsIdentifier, workingDir);
-
+	protected final void setup(Project project, MinecraftProvider minecraftProvider, DependencyInfo dependency, String displayName) {
 		try {
-			mappingProvider.setup(project, serviceFactory, minecraftProvider, inputJar);
+			prepare(minecraftProvider);
+
+			try (FileSystemUtil.Delegate delegate = FileSystemUtil.getJarFileSystem(inputJar)) {
+				readExtras(delegate.fs());
+				setupMappings(project, minecraftProvider, delegate.fs());
+			}
 		} catch (IOException e) {
-			cleanWorkingDirectory(workingDir);
-			throw new UncheckedIOException("Failed to setup mappings: " + dependency.getDepString(), e);
+			try {
+				cleanup();
+			} catch (IOException cleanupException) {
+				e.addSuppressed(cleanupException);
+			}
+
+			throw new UncheckedIOException("Failed to setup %s: %s".formatted(displayName, dependency.getDepString()), e);
 		}
-
-		return mappingProvider;
 	}
 
-	public Provider<TinyMappingsService.Options> getMappingsServiceOptions(Project project) {
-		return TinyMappingsService.createOptions(project, Objects.requireNonNull(tinyMappings));
+	protected void prepare(MinecraftProvider minecraftProvider) throws IOException {
 	}
+
+	protected void cleanup() throws IOException {
+	}
+
+	protected abstract void setupMappings(Project project, MinecraftProvider minecraftProvider, FileSystem inputJar) throws IOException;
+
+	public abstract Provider<TinyMappingsService.Options> getMappingsServiceOptions(Project project);
+
+	public abstract Path getMappingsInputFile();
+
+	public abstract MappingsNamespace getRuntimeNamespace();
 
 	public TinyMappingsService getMappingsService(Project project, ServiceFactory serviceFactory) {
 		return serviceFactory.get(getMappingsServiceOptions(project));
 	}
 
-	private void setup(Project project, ServiceFactory serviceFactory, MinecraftProvider minecraftProvider, Path inputJar) throws IOException {
-		if (minecraftProvider.refreshDeps()) {
-			cleanWorkingDirectory(mappingsWorkingDir);
-		}
-
-		if (Files.notExists(tinyMappings) || minecraftProvider.refreshDeps()) {
-			storeMappings(project, serviceFactory, minecraftProvider, inputJar);
-		} else {
-			try (FileSystem fileSystem = FileSystems.newFileSystem(inputJar, (ClassLoader) null)) {
-				extractExtras(fileSystem);
-			}
-		}
-
-		if (Files.notExists(tinyMappingsJar) || minecraftProvider.refreshDeps()) {
-			Files.deleteIfExists(tinyMappingsJar);
-			ZipUtils.add(tinyMappingsJar, "mappings/mappings.tiny", Files.readAllBytes(tinyMappings));
-		}
-	}
-
 	public void applyToProject(Project project, DependencyInfo dependency) {
-		if (unpickMetadata != null) {
-			if (unpickMetadata.hasConstants()) {
-				String notation = switch (unpickMetadata) {
-				case UnpickMetadata.V1 v1 -> String.format("%s:%s:%s:constants",
-						dependency.getDependency().getGroup(),
-						dependency.getDependency().getName(),
-						dependency.getDependency().getVersion()
-				);
-				case UnpickMetadata.V2 v2 -> Objects.requireNonNull(v2.constants());
-				};
+		if (unpickMetadata != null && unpickMetadata.hasConstants()) {
+			String notation = switch (unpickMetadata) {
+			case UnpickMetadata.V1 v1 -> String.format("%s:%s:%s:constants",
+					dependency.getDependency().getGroup(),
+					dependency.getDependency().getName(),
+					dependency.getDependency().getVersion()
+			);
+			case UnpickMetadata.V2 v2 -> Objects.requireNonNull(v2.constants());
+			};
 
-				project.getDependencies().add(Constants.Configurations.MAPPING_CONSTANTS, notation);
-			}
+			project.getDependencies().add(Constants.Configurations.MAPPING_CONSTANTS, notation);
 		}
-
-		project.getDependencies().add(Constants.Configurations.MAPPINGS_FINAL, project.files(tinyMappingsJar.toFile()));
 	}
 
-	private static String getMappingsClassifier(DependencyInfo dependency, boolean isV2) {
+	protected static Path resolveInputJar(DependencyInfo dependency, String displayName) {
+		return dependency.resolveFile()
+				.orElseThrow(() -> new RuntimeException("Could not resolve %s: %s".formatted(displayName, dependency)))
+				.toPath();
+	}
+
+	protected static TinyJarInfo readJarInfo(Path inputJar, DependencyInfo dependency, MinecraftProvider minecraftProvider, String displayName) {
+		TinyJarInfo jarInfo = TinyJarInfo.get(inputJar);
+		jarInfo.minecraftVersionId().ifPresent(id -> {
+			if (!minecraftProvider.minecraftVersion().equals(id)) {
+				LOGGER.warn("The %s (%s) were not built for Minecraft version %s, proceed with caution.".formatted(displayName, dependency.getDepString(), minecraftProvider.minecraftVersion()));
+			}
+		});
+		return jarInfo;
+	}
+
+	protected static String getMappingsClassifier(DependencyInfo dependency, boolean isV2) {
 		String[] depStringSplit = dependency.getDepString().split(":");
 
 		if (depStringSplit.length >= 4) {
@@ -176,43 +150,10 @@ public class MappingConfiguration {
 		return isV2 ? "-v2" : "";
 	}
 
-	private void storeMappings(Project project, ServiceFactory serviceFactory, MinecraftProvider minecraftProvider, Path inputJar) throws IOException {
-		LOGGER.info(":extracting " + inputJar.getFileName());
-
-		try (FileSystemUtil.Delegate delegate = FileSystemUtil.getJarFileSystem(inputJar)) {
-			extractMappings(delegate.fs(), baseTinyMappings);
-			extractExtras(delegate.fs());
-		}
-
-		if (areMappingsV2(baseTinyMappings)) {
-			final LoomGradleExtension extension = LoomGradleExtension.get(project);
-
-			if (extension.getUseIntermediateMappings().get()) {
-				// These are unmerged v2 mappings
-				IntermediateMappingsService intermediateMappingsService = serviceFactory.get(IntermediateMappingsService.createOptions(project, minecraftProvider));
-
-				MappingsMerger.mergeAndSaveMappings(baseTinyMappings, tinyMappings, minecraftProvider, intermediateMappingsService);
-			} else {
-				Files.copy(baseTinyMappings, tinyMappings, StandardCopyOption.REPLACE_EXISTING);
-			}
-		} else {
-			final List<Path> minecraftJars = minecraftProvider.getMinecraftJars();
-
-			if (minecraftJars.size() != 1) {
-				throw new UnsupportedOperationException("V1 mappings only support single jar minecraft providers");
-			}
-
-			// These are merged v1 mappings
-			Files.deleteIfExists(tinyMappings);
-			LOGGER.info(":populating field names");
-			suggestFieldNames(minecraftJars.get(0), baseTinyMappings, tinyMappings);
-		}
-	}
-
-	private static boolean areMappingsV2(Path path) throws IOException {
-		try (BufferedReader reader = Files.newBufferedReader(path)) {
-			return MappingReader.detectFormat(reader) == MappingFormat.TINY_2_FILE;
-		}
+	protected static String createMappingsIdentifier(String mappingsName, String version, String classifier, String minecraftVersion) {
+		//          mappingsName      . mcVersion . version        classifier
+		// Example: net.fabricmc.yarn . 1_16_5    . 1.16.5+build.5 -v2
+		return mappingsName + "." + minecraftVersion.replace(' ', '_').replace('.', '_').replace('-', '_') + "." + version + classifier;
 	}
 
 	public static void extractMappings(Path jar, Path extractTo) throws IOException {
@@ -222,16 +163,15 @@ public class MappingConfiguration {
 	}
 
 	public static void extractMappings(FileSystem jar, Path extractTo) throws IOException {
-		Files.copy(jar.getPath("mappings/mappings.tiny"), extractTo, StandardCopyOption.REPLACE_EXISTING);
+		Files.copy(jar.getPath(MAPPINGS_PATH), extractTo, StandardCopyOption.REPLACE_EXISTING);
 	}
 
-	private void extractExtras(FileSystem jar) throws IOException {
-		extractAnnotationsData(jar);
-		extractUnpickDefinitions(jar);
-		extractSignatureFixes(jar);
+	private void readExtras(FileSystem jar) throws IOException {
+		readAnnotationsData(jar);
+		readUnpickDefinitions(jar);
 	}
 
-	private void extractAnnotationsData(FileSystem jar) throws IOException {
+	private void readAnnotationsData(FileSystem jar) throws IOException {
 		Path annotationsPath = jar.getPath(AnnotationsLayer.ANNOTATIONS_PATH);
 
 		if (!Files.exists(annotationsPath)) {
@@ -243,7 +183,7 @@ public class MappingConfiguration {
 		}
 	}
 
-	private void extractUnpickDefinitions(FileSystem jar) throws IOException {
+	private void readUnpickDefinitions(FileSystem jar) throws IOException {
 		Path unpickPath = jar.getPath(UnpickMetadata.UNPICK_DEFINITIONS_PATH);
 		Path unpickMetadataPath = jar.getPath(UnpickMetadata.UNPICK_METADATA_PATH);
 
@@ -251,67 +191,32 @@ public class MappingConfiguration {
 			return;
 		}
 
-		Files.copy(unpickPath, unpickDefinitions, StandardCopyOption.REPLACE_EXISTING);
-
 		unpickMetadata = UnpickMetadata.parse(unpickMetadataPath);
+		configureUnpickDefinitions(jar, unpickPath);
 	}
 
-	private void extractSignatureFixes(FileSystem jar) throws IOException {
-		Path recordSignaturesJsonPath = jar.getPath("extras/record_signatures.json");
+	protected abstract void configureUnpickDefinitions(FileSystem jar, Path unpickPath) throws IOException;
 
-		if (!Files.exists(recordSignaturesJsonPath)) {
-			return;
-		}
-
-		try (Reader reader = Files.newBufferedReader(recordSignaturesJsonPath, StandardCharsets.UTF_8)) {
-			//noinspection unchecked
-			signatureFixes = LoomGradlePlugin.GSON.fromJson(reader, Map.class);
-		}
+	protected final void setUnpickDefinitions(Path path, @Nullable String entry) {
+		unpickDefinitions = path;
+		unpickDefinitionsEntry = entry;
 	}
 
-	private void suggestFieldNames(Path inputJar, Path oldMappings, Path newMappings) {
-		Command command = new CommandProposeFieldNames();
-		runCommand(command, inputJar.toFile().getAbsolutePath(),
-						oldMappings.toAbsolutePath().toString(),
-						newMappings.toAbsolutePath().toString());
-	}
-
-	private void runCommand(Command command, String... args) {
-		try {
-			command.run(args);
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	private static void cleanWorkingDirectory(Path mappingsWorkingDir) {
-		try {
-			if (Files.exists(mappingsWorkingDir)) {
-				Files.walkFileTree(mappingsWorkingDir, new DeletingFileVisitor());
-			}
-
-			Files.createDirectories(mappingsWorkingDir);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-	}
-
-	public Path mappingsWorkingDir() {
-		return mappingsWorkingDir;
-	}
-
-	private static String createMappingsIdentifier(String mappingsName, String version, String classifier, String minecraftVersion) {
-		//          mappingsName      . mcVersion . version        classifier
-		// Example: net.fabricmc.yarn . 1_16_5    . 1.16.5+build.5 -v2
-		return mappingsName + "." + minecraftVersion.replace(' ', '_').replace('.', '_').replace('-', '_') + "." + version + classifier;
+	protected final Path inputJar() {
+		return inputJar;
 	}
 
 	public String mappingsIdentifier() {
 		return mappingsIdentifier;
 	}
 
-	public File getUnpickDefinitionsFile() {
-		return unpickDefinitions.toFile();
+	public Path getUnpickDefinitionsFile() {
+		return Objects.requireNonNull(unpickDefinitions, "Unpick definitions are not available");
+	}
+
+	@Nullable
+	public String getUnpickDefinitionsEntry() {
+		return unpickDefinitionsEntry;
 	}
 
 	public boolean hasUnpickDefinitions() {
@@ -324,10 +229,5 @@ public class MappingConfiguration {
 
 	public UnpickMetadata getUnpickMetadata() {
 		return Objects.requireNonNull(unpickMetadata, "Unpick metadata is not available");
-	}
-
-	@Nullable
-	public Map<String, String> getSignatureFixes() {
-		return signatureFixes;
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/NoRemapMappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/NoRemapMappingConfiguration.java
@@ -1,0 +1,121 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.configuration.providers.mappings;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+
+import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
+
+import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
+import net.fabricmc.loom.configuration.DependencyInfo;
+import net.fabricmc.loom.configuration.providers.mappings.tiny.TinyJarInfo;
+import net.fabricmc.loom.configuration.providers.mappings.unpick.UnpickMetadata;
+import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
+import net.fabricmc.loom.util.Checksum;
+import net.fabricmc.loom.util.service.ServiceFactory;
+import net.fabricmc.mappingio.MappingReader;
+import net.fabricmc.mappingio.tree.MemoryMappingTree;
+
+public final class NoRemapMappingConfiguration extends MappingConfiguration {
+	private NoRemapMappingConfiguration(String mappingsIdentifier, Path inputJar) {
+		super(mappingsIdentifier, inputJar);
+	}
+
+	public static NoRemapMappingConfiguration create(Project project, DependencyInfo dependency, MinecraftProvider minecraftProvider) {
+		final String version = dependency.getResolvedVersion();
+		final Path inputJar = resolveInputJar(dependency, "annotations");
+		final String[] dependencyParts = dependency.getDepString().split(":");
+		final String mappingsName = "annotations.%s.%s.%s".formatted(dependencyParts[0], dependencyParts[1], Checksum.of(inputJar).sha256().hex(12));
+		final TinyJarInfo jarInfo = readJarInfo(inputJar, dependency, minecraftProvider, "annotations");
+		final String mappingsIdentifier = createMappingsIdentifier(mappingsName, version, getMappingsClassifier(dependency, jarInfo.v2()), minecraftProvider.minecraftVersion());
+		var mappingConfiguration = new NoRemapMappingConfiguration(mappingsIdentifier, inputJar);
+		mappingConfiguration.setup(project, minecraftProvider, dependency, "annotations");
+		return mappingConfiguration;
+	}
+
+	@Override
+	protected void setupMappings(Project project, MinecraftProvider minecraftProvider, FileSystem inputJar) throws IOException {
+		for (var annotationsData : getAnnotationsData()) {
+			if (!MappingsNamespace.OFFICIAL.toString().equals(annotationsData.namespace())) {
+				throw new IOException("Annotations patches must use the official namespace");
+			}
+		}
+
+		if (hasUnpickDefinitions()
+				&& getUnpickMetadata() instanceof UnpickMetadata.V2 metadata
+				&& !MappingsNamespace.OFFICIAL.toString().equals(metadata.namespace())) {
+			throw new IOException("Annotations unpick definitions must use the official namespace");
+		}
+	}
+
+	@Override
+	protected void configureUnpickDefinitions(FileSystem jar, Path unpickPath) {
+		setUnpickDefinitions(inputJar(), UnpickMetadata.UNPICK_DEFINITIONS_PATH);
+	}
+
+	static void validateMappings(Path mappings) throws IOException {
+		MemoryMappingTree mappingTree = new MemoryMappingTree();
+		MappingReader.read(mappings, mappingTree);
+		validateMappings(mappingTree);
+	}
+
+	private static void validateMappings(MemoryMappingTree mappingTree) throws IOException {
+		if (!MappingsNamespace.OFFICIAL.toString().equals(mappingTree.getSrcNamespace()) || !mappingTree.getDstNamespaces().isEmpty()) {
+			throw new IOException("Annotations mappings must contain only the official namespace");
+		}
+	}
+
+	@Override
+	public TinyMappingsService getMappingsService(Project project, ServiceFactory serviceFactory) {
+		TinyMappingsService mappingsService = super.getMappingsService(project, serviceFactory);
+
+		try {
+			validateMappings(mappingsService.getMappingTree());
+		} catch (IOException e) {
+			throw new UncheckedIOException("Failed to validate annotations mappings", e);
+		}
+
+		return mappingsService;
+	}
+
+	@Override
+	public Provider<TinyMappingsService.Options> getMappingsServiceOptions(Project project) {
+		return TinyMappingsService.createOptions(project, project.provider(inputJar()::toFile), MAPPINGS_PATH);
+	}
+
+	@Override
+	public Path getMappingsInputFile() {
+		return inputJar();
+	}
+
+	@Override
+	public MappingsNamespace getRuntimeNamespace() {
+		return MappingsNamespace.OFFICIAL;
+	}
+}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/NoRemapMappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/NoRemapMappingConfiguration.java
@@ -74,11 +74,6 @@ public final class NoRemapMappingConfiguration extends MappingConfiguration {
 		}
 	}
 
-	@Override
-	protected void configureUnpickDefinitions(FileSystem jar, Path unpickPath) {
-		setUnpickDefinitions(inputJar(), UnpickMetadata.UNPICK_DEFINITIONS_PATH);
-	}
-
 	static void validateMappings(Path mappings) throws IOException {
 		MemoryMappingTree mappingTree = new MemoryMappingTree();
 		MappingReader.read(mappings, mappingTree);
@@ -106,12 +101,12 @@ public final class NoRemapMappingConfiguration extends MappingConfiguration {
 
 	@Override
 	public Provider<TinyMappingsService.Options> getMappingsServiceOptions(Project project) {
-		return TinyMappingsService.createOptions(project, project.provider(inputJar()::toFile), MAPPINGS_PATH);
+		return TinyMappingsService.createOptions(project, project.provider(inputJar()::toFile), TinyJarInfo.MAPPINGS_PATH);
 	}
 
 	@Override
-	public Path getMappingsInputFile() {
-		return inputJar();
+	public String getMappingsHash() {
+		return Checksum.of(inputJar()).sha256().hex();
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/NoRemapMappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/NoRemapMappingConfiguration.java
@@ -37,6 +37,7 @@ import net.fabricmc.loom.configuration.DependencyInfo;
 import net.fabricmc.loom.configuration.providers.mappings.tiny.TinyJarInfo;
 import net.fabricmc.loom.configuration.providers.mappings.unpick.UnpickMetadata;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
+import net.fabricmc.loom.api.decompilers.JavadocStyle;
 import net.fabricmc.loom.util.Checksum;
 import net.fabricmc.loom.util.service.ServiceFactory;
 import net.fabricmc.mappingio.MappingReader;
@@ -112,5 +113,10 @@ public final class NoRemapMappingConfiguration extends MappingConfiguration {
 	@Override
 	public MappingsNamespace getRuntimeNamespace() {
 		return MappingsNamespace.OFFICIAL;
+	}
+
+	@Override
+	public JavadocStyle getJavadocStyle() {
+		return JavadocStyle.MARKDOWN;
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/RemapMappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/RemapMappingConfiguration.java
@@ -1,0 +1,207 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.configuration.providers.mappings;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.tools.ant.util.StringUtils;
+import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
+import org.jspecify.annotations.Nullable;
+
+import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.LoomGradlePlugin;
+import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
+import net.fabricmc.loom.configuration.DependencyInfo;
+import net.fabricmc.loom.configuration.providers.mappings.tiny.MappingsMerger;
+import net.fabricmc.loom.configuration.providers.mappings.tiny.TinyJarInfo;
+import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
+import net.fabricmc.loom.util.Constants;
+import net.fabricmc.loom.util.DeletingFileVisitor;
+import net.fabricmc.loom.util.ZipUtils;
+import net.fabricmc.loom.util.service.ServiceFactory;
+import net.fabricmc.mappingio.MappingReader;
+import net.fabricmc.mappingio.format.MappingFormat;
+import net.fabricmc.stitch.Command;
+import net.fabricmc.stitch.commands.CommandProposeFieldNames;
+
+public final class RemapMappingConfiguration extends MappingConfiguration {
+	private final ServiceFactory serviceFactory;
+	private final Path baseTinyMappings;
+	public final Path tinyMappings;
+	public final Path tinyMappingsJar;
+	@Nullable
+	private Map<String, String> signatureFixes;
+
+	private RemapMappingConfiguration(String mappingsIdentifier, Path mappingsWorkingDir, Path inputJar, ServiceFactory serviceFactory) {
+		super(mappingsIdentifier, inputJar);
+		this.serviceFactory = serviceFactory;
+		this.baseTinyMappings = mappingsWorkingDir.resolve("mappings-base.tiny");
+		this.tinyMappings = mappingsWorkingDir.resolve("mappings.tiny");
+		this.tinyMappingsJar = mappingsWorkingDir.resolve("mappings.jar");
+	}
+
+	public static RemapMappingConfiguration create(Project project, ServiceFactory serviceFactory, DependencyInfo dependency, MinecraftProvider minecraftProvider) {
+		final String version = dependency.getResolvedVersion();
+		final Path inputJar = resolveInputJar(dependency, "mappings");
+		final String mappingsName = StringUtils.removeSuffix(dependency.getDependency().getGroup() + "." + dependency.getDependency().getName(), "-unmerged");
+		final TinyJarInfo jarInfo = readJarInfo(inputJar, dependency, minecraftProvider, "mappings");
+		final String mappingsIdentifier = createMappingsIdentifier(mappingsName, version, getMappingsClassifier(dependency, jarInfo.v2()), minecraftProvider.minecraftVersion());
+		final Path workingDir = minecraftProvider.dir(mappingsIdentifier).toPath();
+		var mappingConfiguration = new RemapMappingConfiguration(mappingsIdentifier, workingDir, inputJar, serviceFactory);
+
+		mappingConfiguration.setup(project, minecraftProvider, dependency, "mappings");
+		return mappingConfiguration;
+	}
+
+	@Override
+	protected void prepare(MinecraftProvider minecraftProvider) throws IOException {
+		if (minecraftProvider.refreshDeps()) {
+			cleanup();
+		}
+
+		Files.createDirectories(tinyMappings.getParent());
+	}
+
+	@Override
+	protected void cleanup() throws IOException {
+		if (Files.exists(tinyMappings.getParent())) {
+			Files.walkFileTree(tinyMappings.getParent(), new DeletingFileVisitor());
+		}
+	}
+
+	@Override
+	protected void configureUnpickDefinitions(FileSystem jar, Path unpickPath) throws IOException {
+		Path definitions = tinyMappings.getParent().resolve("mappings.unpick");
+		Files.copy(unpickPath, definitions, StandardCopyOption.REPLACE_EXISTING);
+		setUnpickDefinitions(definitions, null);
+	}
+
+	@Override
+	protected void setupMappings(Project project, MinecraftProvider minecraftProvider, FileSystem inputJar) throws IOException {
+		extractSignatureFixes(inputJar);
+
+		if (Files.notExists(tinyMappings) || minecraftProvider.refreshDeps()) {
+			extractMappings(inputJar, baseTinyMappings);
+			storeMappings(project, minecraftProvider);
+		}
+
+		if (Files.notExists(tinyMappingsJar) || minecraftProvider.refreshDeps()) {
+			Files.deleteIfExists(tinyMappingsJar);
+			ZipUtils.add(tinyMappingsJar, MAPPINGS_PATH, Files.readAllBytes(tinyMappings));
+		}
+	}
+
+	private void storeMappings(Project project, MinecraftProvider minecraftProvider) throws IOException {
+		if (areMappingsV2(baseTinyMappings)) {
+			final LoomGradleExtension extension = LoomGradleExtension.get(project);
+
+			if (extension.getUseIntermediateMappings().get()) {
+				IntermediateMappingsService intermediateMappingsService = serviceFactory.get(IntermediateMappingsService.createOptions(project, minecraftProvider));
+				MappingsMerger.mergeAndSaveMappings(baseTinyMappings, tinyMappings, minecraftProvider, intermediateMappingsService);
+			} else {
+				Files.copy(baseTinyMappings, tinyMappings, StandardCopyOption.REPLACE_EXISTING);
+			}
+		} else {
+			final List<Path> minecraftJars = minecraftProvider.getMinecraftJars();
+
+			if (minecraftJars.size() != 1) {
+				throw new UnsupportedOperationException("V1 mappings only support single jar minecraft providers");
+			}
+
+			Files.deleteIfExists(tinyMappings);
+			LOGGER.info(":populating field names");
+			suggestFieldNames(minecraftJars.get(0), baseTinyMappings, tinyMappings);
+		}
+	}
+
+	@Override
+	public Provider<TinyMappingsService.Options> getMappingsServiceOptions(Project project) {
+		return TinyMappingsService.createOptions(project, tinyMappings);
+	}
+
+	@Override
+	public Path getMappingsInputFile() {
+		return tinyMappings;
+	}
+
+	@Override
+	public MappingsNamespace getRuntimeNamespace() {
+		return MappingsNamespace.NAMED;
+	}
+
+	@Override
+	public void applyToProject(Project project, DependencyInfo dependency) {
+		super.applyToProject(project, dependency);
+		project.getDependencies().add(Constants.Configurations.MAPPINGS_FINAL, project.files(tinyMappingsJar.toFile()));
+	}
+
+	private void extractSignatureFixes(FileSystem inputJar) throws IOException {
+		Path recordSignaturesJsonPath = inputJar.getPath("extras/record_signatures.json");
+
+		if (!Files.exists(recordSignaturesJsonPath)) {
+			return;
+		}
+
+		try (Reader reader = Files.newBufferedReader(recordSignaturesJsonPath, StandardCharsets.UTF_8)) {
+			//noinspection unchecked
+			signatureFixes = LoomGradlePlugin.GSON.fromJson(reader, Map.class);
+		}
+	}
+
+	@Nullable
+	public Map<String, String> getSignatureFixes() {
+		return signatureFixes;
+	}
+
+	private static boolean areMappingsV2(Path path) throws IOException {
+		try (BufferedReader reader = Files.newBufferedReader(path)) {
+			return MappingReader.detectFormat(reader) == MappingFormat.TINY_2_FILE;
+		}
+	}
+
+	private static void suggestFieldNames(Path inputJar, Path oldMappings, Path newMappings) {
+		Command command = new CommandProposeFieldNames();
+
+		try {
+			command.run(new String[] {
+					inputJar.toFile().getAbsolutePath(),
+					oldMappings.toAbsolutePath().toString(),
+					newMappings.toAbsolutePath().toString()
+			});
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/RemapMappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/RemapMappingConfiguration.java
@@ -47,6 +47,7 @@ import net.fabricmc.loom.configuration.DependencyInfo;
 import net.fabricmc.loom.configuration.providers.mappings.tiny.MappingsMerger;
 import net.fabricmc.loom.configuration.providers.mappings.tiny.TinyJarInfo;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
+import net.fabricmc.loom.api.decompilers.JavadocStyle;
 import net.fabricmc.loom.util.Checksum;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.DeletingFileVisitor;
@@ -153,6 +154,11 @@ public final class RemapMappingConfiguration extends MappingConfiguration {
 	@Override
 	public MappingsNamespace getRuntimeNamespace() {
 		return MappingsNamespace.NAMED;
+	}
+
+	@Override
+	public JavadocStyle getJavadocStyle() {
+		return JavadocStyle.HTML;
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/RemapMappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/RemapMappingConfiguration.java
@@ -47,6 +47,7 @@ import net.fabricmc.loom.configuration.DependencyInfo;
 import net.fabricmc.loom.configuration.providers.mappings.tiny.MappingsMerger;
 import net.fabricmc.loom.configuration.providers.mappings.tiny.TinyJarInfo;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
+import net.fabricmc.loom.util.Checksum;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.DeletingFileVisitor;
 import net.fabricmc.loom.util.ZipUtils;
@@ -102,24 +103,17 @@ public final class RemapMappingConfiguration extends MappingConfiguration {
 	}
 
 	@Override
-	protected void configureUnpickDefinitions(FileSystem jar, Path unpickPath) throws IOException {
-		Path definitions = tinyMappings.getParent().resolve("mappings.unpick");
-		Files.copy(unpickPath, definitions, StandardCopyOption.REPLACE_EXISTING);
-		setUnpickDefinitions(definitions, null);
-	}
-
-	@Override
 	protected void setupMappings(Project project, MinecraftProvider minecraftProvider, FileSystem inputJar) throws IOException {
 		extractSignatureFixes(inputJar);
 
 		if (Files.notExists(tinyMappings) || minecraftProvider.refreshDeps()) {
-			extractMappings(inputJar, baseTinyMappings);
+			TinyJarInfo.extractMappings(inputJar, baseTinyMappings);
 			storeMappings(project, minecraftProvider);
 		}
 
 		if (Files.notExists(tinyMappingsJar) || minecraftProvider.refreshDeps()) {
 			Files.deleteIfExists(tinyMappingsJar);
-			ZipUtils.add(tinyMappingsJar, MAPPINGS_PATH, Files.readAllBytes(tinyMappings));
+			ZipUtils.add(tinyMappingsJar, TinyJarInfo.MAPPINGS_PATH, Files.readAllBytes(tinyMappings));
 		}
 	}
 
@@ -152,8 +146,8 @@ public final class RemapMappingConfiguration extends MappingConfiguration {
 	}
 
 	@Override
-	public Path getMappingsInputFile() {
-		return tinyMappings;
+	public String getMappingsHash() {
+		return Checksum.of(tinyMappings).sha256().hex();
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/tiny/TinyJarInfo.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/tiny/TinyJarInfo.java
@@ -28,8 +28,10 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Optional;
 import java.util.jar.Manifest;
 
@@ -38,6 +40,7 @@ import net.fabricmc.mappingio.MappingReader;
 import net.fabricmc.mappingio.format.MappingFormat;
 
 public record TinyJarInfo(boolean v2, Optional<String> minecraftVersionId) {
+	public static final String MAPPINGS_PATH = "mappings/mappings.tiny";
 	private static final String MANIFEST_PATH = "META-INF/MANIFEST.MF";
 	private static final String MANIFEST_VERSION_ID_ATTRIBUTE = "Minecraft-Version-Id";
 
@@ -47,6 +50,16 @@ public record TinyJarInfo(boolean v2, Optional<String> minecraftVersionId) {
 		} catch (IOException e) {
 			throw new UncheckedIOException("Failed to read tiny jar info", e);
 		}
+	}
+
+	public static void extractMappings(Path jar, Path extractTo) throws IOException {
+		try (FileSystemUtil.Delegate delegate = FileSystemUtil.getJarFileSystem(jar)) {
+			extractMappings(delegate.fs(), extractTo);
+		}
+	}
+
+	public static void extractMappings(FileSystem jar, Path extractTo) throws IOException {
+		Files.copy(jar.getPath(MAPPINGS_PATH), extractTo, StandardCopyOption.REPLACE_EXISTING);
 	}
 
 	private static boolean doesJarContainV2Mappings(FileSystemUtil.Delegate fs) throws IOException {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/SignatureFixerApplyVisitor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/SignatureFixerApplyVisitor.java
@@ -34,7 +34,7 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.commons.Remapper;
 
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
-import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
+import net.fabricmc.loom.configuration.providers.mappings.RemapMappingConfiguration;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.TinyRemapperHelper;
 import net.fabricmc.loom.util.service.ServiceFactory;
@@ -56,7 +56,7 @@ public record SignatureFixerApplyVisitor(Map<String, String> signatureFixes) imp
 		};
 	}
 
-	public static Map<String, String> getRemappedSignatures(boolean toIntermediary, MappingConfiguration mappingConfiguration, Project project, ServiceFactory serviceFactory, String targetNamespace) throws IOException {
+	public static Map<String, String> getRemappedSignatures(boolean toIntermediary, RemapMappingConfiguration mappingConfiguration, Project project, ServiceFactory serviceFactory, String targetNamespace) throws IOException {
 		if (mappingConfiguration.getSignatureFixes() == null) {
 			// No fixes
 			return Collections.emptyMap();

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/AbstractMappedMinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/AbstractMappedMinecraftProvider.java
@@ -30,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -46,6 +47,7 @@ import net.fabricmc.loom.configuration.ConfigContext;
 import net.fabricmc.loom.configuration.mods.dependency.LocalMavenHelper;
 import net.fabricmc.loom.configuration.providers.mappings.IntermediaryMappingsProvider;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
+import net.fabricmc.loom.configuration.providers.mappings.RemapMappingConfiguration;
 import net.fabricmc.loom.configuration.providers.mappings.extras.annotations.AnnotationsData;
 import net.fabricmc.loom.configuration.providers.minecraft.AnnotationsApplyVisitor;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftJar;
@@ -56,6 +58,7 @@ import net.fabricmc.loom.configuration.providers.minecraft.SignatureFixerApplyVi
 import net.fabricmc.loom.extension.LoomFiles;
 import net.fabricmc.loom.util.SidedClassVisitor;
 import net.fabricmc.loom.util.TinyRemapperHelper;
+import net.fabricmc.loom.util.ZipUtils;
 import net.fabricmc.tinyremapper.OutputConsumerPath;
 import net.fabricmc.tinyremapper.TinyRemapper;
 
@@ -205,7 +208,13 @@ public abstract class AbstractMappedMinecraftProvider<M extends MinecraftProvide
 
 	protected String getVersion() {
 		if (extension.disableObfuscation()) {
-			return extension.getMinecraftProvider().minecraftVersion();
+			MappingConfiguration mappingConfiguration = extension.getMappingConfigurationOrNull();
+
+			if (mappingConfiguration == null) {
+				return extension.getMinecraftProvider().minecraftVersion();
+			}
+
+			return "%s-%s".formatted(extension.getMinecraftProvider().minecraftVersion(), mappingConfiguration.mappingsIdentifier());
 		}
 
 		return "%s-%s".formatted(extension.getMinecraftProvider().minecraftVersion(), extension.getMappingConfiguration().mappingsIdentifier());
@@ -257,14 +266,30 @@ public abstract class AbstractMappedMinecraftProvider<M extends MinecraftProvide
 
 	protected void remapJar(RemappedJars remappedJars, ConfigContext configContext) throws IOException {
 		if (extension.disableObfuscation()) {
-			// TODO debof - can we skip this?
 			Files.createDirectories(remappedJars.outputJarPath().getParent());
 			Files.copy(remappedJars.inputJar(), remappedJars.outputJarPath(), StandardCopyOption.REPLACE_EXISTING);
+
+			MappingConfiguration mappingConfiguration = extension.getMappingConfigurationOrNull();
+
+			if (mappingConfiguration != null) {
+				AnnotationsData annotationsData = AnnotationsData.getRemappedAnnotations(
+						MappingsNamespace.OFFICIAL,
+						mappingConfiguration,
+						getProject(),
+						configContext.serviceFactory(),
+						MappingsNamespace.OFFICIAL.toString()
+				);
+
+				if (annotationsData != null) {
+					applyAnnotations(remappedJars.outputJarPath(), annotationsData);
+				}
+			}
+
 			getMavenHelper(remappedJars.type()).savePom();
 			return;
 		}
 
-		final MappingConfiguration mappingConfiguration = extension.getMappingConfiguration();
+		final RemapMappingConfiguration mappingConfiguration = extension.getMappingConfiguration();
 		final String fromM = remappedJars.sourceNamespace().toString();
 		final String toM = getTargetNamespace().toString();
 
@@ -300,6 +325,15 @@ public abstract class AbstractMappedMinecraftProvider<M extends MinecraftProvide
 		}
 
 		getMavenHelper(remappedJars.type()).savePom();
+	}
+
+	private static void applyAnnotations(Path jar, AnnotationsData annotationsData) throws IOException {
+		Map<String, ZipUtils.UnsafeUnaryOperator<byte[]>> transforms = new HashMap<>();
+		annotationsData.classes().forEach((className, classData) -> transforms.put(
+				className + ".class",
+				(ZipUtils.AsmClassOperator) classVisitor -> new AnnotationsApplyVisitor.AnnotationsApplyClassVisitor(classVisitor, classData)
+		));
+		ZipUtils.transform(jar, transforms);
 	}
 
 	protected void configureRemapper(RemappedJars remappedJars, TinyRemapper.Builder tinyRemapperBuilder) {

--- a/src/main/java/net/fabricmc/loom/decompilers/DecompilerConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/decompilers/DecompilerConfiguration.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.decompilers.DecompilationMetadata;
+import net.fabricmc.loom.api.decompilers.JavadocStyle;
 import net.fabricmc.loom.api.decompilers.LoomDecompiler;
 import net.fabricmc.loom.decompilers.cfr.LoomCFRDecompiler;
 import net.fabricmc.loom.decompilers.vineflower.VineflowerDecompiler;
@@ -146,6 +147,11 @@ public abstract class DecompilerConfiguration implements Runnable {
 				@Override
 				public String runtimeNamespace() {
 					return metaData.runtimeNamespace();
+				}
+
+				@Override
+				public JavadocStyle javadocStyle() {
+					return metaData.javadocStyle();
 				}
 			});
 		}

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
@@ -41,6 +41,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.LoomNoRemapGradlePlugin;
@@ -53,6 +54,7 @@ import net.fabricmc.loom.configuration.mods.ArtifactMetadata;
 import net.fabricmc.loom.configuration.providers.mappings.IntermediaryMappingsProvider;
 import net.fabricmc.loom.configuration.providers.mappings.LayeredMappingsFactory;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
+import net.fabricmc.loom.configuration.providers.mappings.RemapMappingConfiguration;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftMetadataProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
 import net.fabricmc.loom.configuration.providers.minecraft.library.LibraryProcessorManager;
@@ -169,21 +171,22 @@ public abstract class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl
 	}
 
 	@Override
-	public MappingConfiguration getMappingConfiguration() {
+	public RemapMappingConfiguration getMappingConfiguration() {
 		if (disableObfuscation()) {
 			project.getLogger().lifecycle("help", new RuntimeException());
 			throw new UnsupportedOperationException("Cannot get mappings configuration in a non-obfuscated environment");
 		}
 
-		return Objects.requireNonNull(mappingConfiguration, "Cannot get MappingsProvider before it has been setup");
+		return (RemapMappingConfiguration) Objects.requireNonNull(mappingConfiguration, "Cannot get MappingsProvider before it has been setup");
+	}
+
+	@Override
+	public @Nullable MappingConfiguration getMappingConfigurationOrNull() {
+		return mappingConfiguration;
 	}
 
 	@Override
 	public void setMappingConfiguration(MappingConfiguration mappingConfiguration) {
-		if (disableObfuscation()) {
-			throw new UnsupportedOperationException("Cannot set mappings configuration in a non-obfuscated environment");
-		}
-
 		this.mappingConfiguration = mappingConfiguration;
 	}
 

--- a/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
@@ -609,7 +609,8 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 						getLibraries(),
 						logger,
 						decompilerOptions.options(),
-						getParameters().getRuntimeNamespace().get()
+						getParameters().getRuntimeNamespace().get(),
+						mappingsService.getJavadocStyle()
 				);
 
 				decompiler.decompile(

--- a/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
@@ -70,7 +70,6 @@ import org.gradle.workers.internal.WorkerDaemonClientsManager;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.Nullable;
 
-import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.decompilers.DecompilationMetadata;
 import net.fabricmc.loom.api.decompilers.DecompilerOptions;
 import net.fabricmc.loom.api.decompilers.LoomDecompiler;
@@ -229,11 +228,12 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 
 		getMappings().set(SourceMappingsService.create(getProject()));
 
-		if (!LoomGradleExtension.get(getProject()).disableObfuscation()) {
-			getUnpickOptions().set(UnpickService.createOptions(this));
-			getRuntimeNamespace().set(MappingsNamespace.NAMED.toString());
-		} else {
+		getUnpickOptions().set(UnpickService.createOptions(this));
+
+		if (getExtension().disableObfuscation()) {
 			getRuntimeNamespace().set(MappingsNamespace.OFFICIAL.toString());
+		} else {
+			getRuntimeNamespace().set(MappingsNamespace.NAMED.toString());
 		}
 
 		getMaxCachedFiles().set(GradleUtils.getIntegerPropertyProvider(getProject(), Constants.Properties.DECOMPILE_CACHE_MAX_FILES).orElse(50_000));

--- a/src/main/java/net/fabricmc/loom/task/service/LorenzMappingService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/LorenzMappingService.java
@@ -35,7 +35,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Nested;
 
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
-import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
+import net.fabricmc.loom.configuration.providers.mappings.RemapMappingConfiguration;
 import net.fabricmc.loom.util.Lazy;
 import net.fabricmc.loom.util.service.Service;
 import net.fabricmc.loom.util.service.ServiceFactory;
@@ -50,7 +50,7 @@ public final class LorenzMappingService extends Service<LorenzMappingService.Opt
 		Property<MappingsService.Options> getMappings();
 	}
 
-	public static Provider<Options> createOptions(Project project, MappingConfiguration mappingConfiguration, MappingsNamespace from, MappingsNamespace to) {
+	public static Provider<Options> createOptions(Project project, RemapMappingConfiguration mappingConfiguration, MappingsNamespace from, MappingsNamespace to) {
 		return TYPE.create(project, options -> options.getMappings().set(
 			MappingsService.createOptions(
 				project,

--- a/src/main/java/net/fabricmc/loom/task/service/MappingsService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/MappingsService.java
@@ -42,7 +42,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.fabricmc.loom.LoomGradleExtension;
-import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
+import net.fabricmc.loom.configuration.providers.mappings.RemapMappingConfiguration;
 import net.fabricmc.loom.task.AbstractRemapJarTask;
 import net.fabricmc.loom.util.TinyRemapperHelper;
 import net.fabricmc.loom.util.service.Service;
@@ -96,7 +96,7 @@ public final class MappingsService extends Service<MappingsService.Options> impl
 	 * Returns options for creating a new mappings service, using the mappings as specified in the project's mapping configuration.
 	 */
 	public static Provider<Options> createOptionsWithProjectMappings(Project project, Provider<String> from, Provider<String> to) {
-		final MappingConfiguration mappingConfiguration = LoomGradleExtension.get(project).getMappingConfiguration();
+		final RemapMappingConfiguration mappingConfiguration = LoomGradleExtension.get(project).getMappingConfiguration();
 		return createOptions(project, mappingConfiguration.tinyMappings, from, to, true);
 	}
 

--- a/src/main/java/net/fabricmc/loom/task/service/SourceMappingsService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/SourceMappingsService.java
@@ -112,15 +112,17 @@ public class SourceMappingsService extends Service<SourceMappingsService.Options
 			}
 		}
 
-		final Path inputMappings = mappingConfiguration != null ? mappingConfiguration.getMappingsInputFile() : emptyMappingsPath;
 		final String processorHash = jarProcessor != null ? jarProcessor.getSourceMappingsHash() : "none";
-		final String hash = Checksum.of(processorHash + ":" + Checksum.of(inputMappings).sha256().hex()).sha1().hex();
+		final String mappingsHash = mappingConfiguration != null
+				? mappingConfiguration.getMappingsHash()
+				: Checksum.of(emptyMappingsPath).sha256().hex();
+		final String hash = Checksum.of(processorHash + ":" + mappingsHash).sha1().hex();
 		hashProperty.set(hash);
 
 		if (jarProcessor == null) {
-			if (mappingConfiguration instanceof RemapMappingConfiguration) {
+			if (mappingConfiguration instanceof RemapMappingConfiguration remapMappingConfiguration) {
 				LOGGER.info("No jar processor found, using configured source mappings");
-				return inputMappings;
+				return remapMappingConfiguration.tinyMappings;
 			} else if (mappingConfiguration == null) {
 				LOGGER.info("No jar processor found, using empty source mappings");
 				return emptyMappingsPath;

--- a/src/main/java/net/fabricmc/loom/task/service/SourceMappingsService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/SourceMappingsService.java
@@ -50,7 +50,10 @@ import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.configuration.ConfigContextImpl;
 import net.fabricmc.loom.configuration.processors.MappingProcessorContextImpl;
 import net.fabricmc.loom.configuration.processors.MinecraftJarProcessorManager;
+import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
+import net.fabricmc.loom.configuration.providers.mappings.RemapMappingConfiguration;
 import net.fabricmc.loom.task.GenerateSourcesTask;
+import net.fabricmc.loom.util.Checksum;
 import net.fabricmc.loom.util.service.ScopedServiceFactory;
 import net.fabricmc.loom.util.service.Service;
 import net.fabricmc.loom.util.service.ServiceFactory;
@@ -93,8 +96,13 @@ public class SourceMappingsService extends Service<SourceMappingsService.Options
 		final Path dir = extension.getFiles().getProjectPersistentCache().toPath().resolve("source_mappings");
 		final Path emptyMappingsPath = dir.resolve("empty.tiny"); // empty base mappings for unobf
 		final boolean disableObf = extension.disableObfuscation();
+		final MappingConfiguration mappingConfiguration = extension.getMappingConfigurationOrNull();
 
-		if (disableObf && (!Files.exists(emptyMappingsPath) || extension.refreshDeps())) {
+		if (!disableObf && mappingConfiguration == null) {
+			throw new IllegalStateException("Mappings have not been configured");
+		}
+
+		if (mappingConfiguration == null && (!Files.exists(emptyMappingsPath) || extension.refreshDeps())) {
 			try {
 				Files.createDirectories(dir);
 				Files.deleteIfExists(emptyMappingsPath);
@@ -104,18 +112,20 @@ public class SourceMappingsService extends Service<SourceMappingsService.Options
 			}
 		}
 
+		final Path inputMappings = mappingConfiguration != null ? mappingConfiguration.getMappingsInputFile() : emptyMappingsPath;
+		final String processorHash = jarProcessor != null ? jarProcessor.getSourceMappingsHash() : "none";
+		final String hash = Checksum.of(processorHash + ":" + Checksum.of(inputMappings).sha256().hex()).sha1().hex();
+		hashProperty.set(hash);
+
 		if (jarProcessor == null) {
-			if (!disableObf) {
-				LOGGER.info("No jar processor found, not creating source mappings, using project mappings");
-				return extension.getMappingConfiguration().tinyMappings;
-			} else {
+			if (mappingConfiguration instanceof RemapMappingConfiguration) {
+				LOGGER.info("No jar processor found, using configured source mappings");
+				return inputMappings;
+			} else if (mappingConfiguration == null) {
 				LOGGER.info("No jar processor found, using empty source mappings");
 				return emptyMappingsPath;
 			}
 		}
-
-		final String hash = jarProcessor.getSourceMappingsHash();
-		hashProperty.set(hash);
 
 		final Path path = dir.resolve(hash + ".tiny");
 
@@ -124,13 +134,12 @@ public class SourceMappingsService extends Service<SourceMappingsService.Options
 			return path;
 		}
 
-		LOGGER.info("Creating source mappings for hash {}", jarProcessor.getSourceMappingsHash());
+		LOGGER.info("Creating source mappings for hash {}", hash);
 
 		try {
 			Files.createDirectories(dir);
 			Files.deleteIfExists(path);
-			final Path inputMappings = disableObf ? emptyMappingsPath : extension.getMappingConfiguration().tinyMappings;
-			createMappings(project, jarProcessor, inputMappings, path);
+			createMappings(project, jarProcessor, mappingConfiguration, emptyMappingsPath, path);
 		} catch (IOException e) {
 			throw new UncheckedIOException("Failed to create source mappings", e);
 		}
@@ -138,27 +147,39 @@ public class SourceMappingsService extends Service<SourceMappingsService.Options
 		return path;
 	}
 
-	private static void createMappings(Project project, MinecraftJarProcessorManager jarProcessor, Path inputMappings, Path outputMappings) throws IOException {
+	private static void createMappings(Project project, @Nullable MinecraftJarProcessorManager jarProcessor, @Nullable MappingConfiguration mappingConfiguration, Path emptyMappings, Path outputMappings) throws IOException {
 		LoomGradleExtension extension = LoomGradleExtension.get(project);
 		MemoryMappingTree mappingTree = new MemoryMappingTree();
+		String sourceNamespace = !extension.disableObfuscation() && extension.getUseIntermediateMappings().get()
+				? MappingsNamespace.INTERMEDIARY.toString()
+				: MappingsNamespace.OFFICIAL.toString();
 
-		try (Reader reader = Files.newBufferedReader(inputMappings, StandardCharsets.UTF_8)) {
-			MappingReader.read(reader, new MappingSourceNsSwitch(mappingTree, extension.getUseIntermediateMappings().get() ? MappingsNamespace.INTERMEDIARY.toString() : MappingsNamespace.OFFICIAL.toString()));
+		if (mappingConfiguration != null) {
+			try (var serviceFactory = new ScopedServiceFactory()) {
+				mappingConfiguration.getMappingsService(project, serviceFactory).getMappingTree()
+						.accept(new MappingSourceNsSwitch(mappingTree, sourceNamespace));
+			}
+		} else {
+			try (Reader reader = Files.newBufferedReader(emptyMappings, StandardCharsets.UTF_8)) {
+				MappingReader.read(reader, new MappingSourceNsSwitch(mappingTree, sourceNamespace));
+			}
 		}
 
-		GenerateSourcesTask.MappingsProcessor mappingsProcessor = mappings -> {
-			try (var serviceFactory = new ScopedServiceFactory()) {
-				final var configContext = new ConfigContextImpl(project, serviceFactory, extension);
-				return jarProcessor.processMappings(mappings, new MappingProcessorContextImpl(configContext));
-			} catch (IOException e) {
-				throw new UncheckedIOException(e);
+		if (jarProcessor != null) {
+			GenerateSourcesTask.MappingsProcessor mappingsProcessor = mappings -> {
+				try (var serviceFactory = new ScopedServiceFactory()) {
+					final var configContext = new ConfigContextImpl(project, serviceFactory, extension);
+					return jarProcessor.processMappings(mappings, new MappingProcessorContextImpl(configContext));
+				} catch (IOException e) {
+					throw new UncheckedIOException(e);
+				}
+			};
+
+			boolean transformed = mappingsProcessor.transform(mappingTree);
+
+			if (!transformed) {
+				LOGGER.info("No mappings processors transformed the mappings");
 			}
-		};
-
-		boolean transformed = mappingsProcessor.transform(mappingTree);
-
-		if (!transformed) {
-			LOGGER.info("No mappings processors transformed the mappings");
 		}
 
 		try (Writer writer = Files.newBufferedWriter(outputMappings, StandardCharsets.UTF_8)) {

--- a/src/main/java/net/fabricmc/loom/task/service/SourceMappingsService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/SourceMappingsService.java
@@ -52,6 +52,7 @@ import net.fabricmc.loom.configuration.processors.MappingProcessorContextImpl;
 import net.fabricmc.loom.configuration.processors.MinecraftJarProcessorManager;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
 import net.fabricmc.loom.configuration.providers.mappings.RemapMappingConfiguration;
+import net.fabricmc.loom.api.decompilers.JavadocStyle;
 import net.fabricmc.loom.task.GenerateSourcesTask;
 import net.fabricmc.loom.util.Checksum;
 import net.fabricmc.loom.util.service.ScopedServiceFactory;
@@ -78,6 +79,9 @@ public class SourceMappingsService extends Service<SourceMappingsService.Options
 		@Input
 		@Optional
 		Property<String> getProcessorHash(); // the hash of the processors applied to the mappings
+
+		@Input
+		Property<JavadocStyle> getJavadocStyle();
 	}
 
 	public static Provider<Options> create(Project project) {
@@ -87,6 +91,8 @@ public class SourceMappingsService extends Service<SourceMappingsService.Options
 		return TYPE.create(project, options -> {
 			options.getMappings().fileValue(project.file(mappings));
 			options.getProcessorHash().set(hash);
+			MappingConfiguration mappingConfiguration = LoomGradleExtension.get(project).getMappingConfigurationOrNull();
+			options.getJavadocStyle().set(mappingConfiguration != null ? mappingConfiguration.getJavadocStyle() : JavadocStyle.HTML);
 		});
 	}
 
@@ -200,5 +206,9 @@ public class SourceMappingsService extends Service<SourceMappingsService.Options
 
 	public @Nullable String getProcessorHash() {
 		return getOptions().getProcessorHash().getOrNull();
+	}
+
+	public JavadocStyle getJavadocStyle() {
+		return getOptions().getJavadocStyle().get();
 	}
 }

--- a/src/main/java/net/fabricmc/loom/task/service/UnpickRemapperService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/UnpickRemapperService.java
@@ -26,11 +26,11 @@ package net.fabricmc.loom.task.service;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
 
@@ -81,6 +81,12 @@ public class UnpickRemapperService extends Service<UnpickRemapperService.Options
 	 * Return the remapped definitions.
 	 */
 	public String remap(File input) throws IOException {
+		try (Reader reader = Files.newBufferedReader(input.toPath())) {
+			return remap(reader);
+		}
+	}
+
+	public String remap(Reader input) throws IOException {
 		TinyRemapperServiceInterface tinyRemapperService = getServiceFactory().get(getOptions().getTinyRemapper());
 		TinyRemapper tinyRemapper = tinyRemapperService.getTinyRemapperForRemapping();
 
@@ -90,9 +96,8 @@ public class UnpickRemapperService extends Service<UnpickRemapperService.Options
 		return doRemap(input, tinyRemapper, packageIndex);
 	}
 
-	private String doRemap(File input, TinyRemapper remapper, JarPackageIndex packageIndex) throws IOException {
-		try (Reader fileReader = new BufferedReader(new FileReader(input));
-				var reader = new UnpickV3Reader(fileReader)) {
+	private String doRemap(Reader input, TinyRemapper remapper, JarPackageIndex packageIndex) throws IOException {
+		try (var reader = new UnpickV3Reader(new BufferedReader(input))) {
 			var writer = new UnpickV3Writer();
 			reader.accept(new UnpickRemapper(writer, remapper, packageIndex));
 			return writer.getOutput().replace(System.lineSeparator(), "\n");

--- a/src/main/java/net/fabricmc/loom/task/service/UnpickService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/UnpickService.java
@@ -51,12 +51,9 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.PathSensitive;
-import org.gradle.api.tasks.PathSensitivity;
 import org.jspecify.annotations.Nullable;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -90,13 +87,8 @@ public class UnpickService extends Service<UnpickService.Options> {
 	public static final ServiceType<Options, UnpickService> TYPE = new ServiceType<>(Options.class, UnpickService.class);
 
 	public interface Options extends Service.Options {
-		@InputFile
-		@PathSensitive(PathSensitivity.NONE)
-		RegularFileProperty getUnpickDefinitions();
-
-		@Optional
 		@Input
-		Property<String> getUnpickDefinitionsEntry();
+		Property<byte[]> getUnpickDefinitions();
 
 		@Optional
 		@Nested
@@ -135,11 +127,7 @@ public class UnpickService extends Service<UnpickService.Options> {
 			}
 
 			ConfigurationContainer configurations = project.getConfigurations();
-			options.getUnpickDefinitions().set(mappingConfiguration.getUnpickDefinitionsFile().toFile());
-
-			if (mappingConfiguration.getUnpickDefinitionsEntry() != null) {
-				options.getUnpickDefinitionsEntry().set(mappingConfiguration.getUnpickDefinitionsEntry());
-			}
+			options.getUnpickDefinitions().set(mappingConfiguration.getUnpickDefinitions());
 
 			options.getUnpickOutputJar().set(task.getInputJarName().map(s -> project.getLayout()
 					.dir(project.provider(() -> extension.getFiles().getProjectPersistentCache().toPath()
@@ -190,19 +178,10 @@ public class UnpickService extends Service<UnpickService.Options> {
 	}
 
 	private InputStream getUnpickDefinitionsInputStream() throws IOException {
-		final Path unpickDefinitionsPath = getOptions().getUnpickDefinitions().getAsFile().get().toPath();
-		final byte[] definitions;
-
-		if (getOptions().getUnpickDefinitionsEntry().isPresent()) {
-			try (FileSystemUtil.Delegate fs = FileSystemUtil.getJarFileSystem(unpickDefinitionsPath, false)) {
-				definitions = Files.readAllBytes(fs.fs().getPath(getOptions().getUnpickDefinitionsEntry().get()));
-			}
-		} else {
-			definitions = Files.readAllBytes(unpickDefinitionsPath);
-		}
+		final byte[] definitions = getOptions().getUnpickDefinitions().get();
 
 		if (getOptions().getUnpickRemapperService().isPresent()) {
-			LOGGER.info("Remapping unpick definitions: {}", unpickDefinitionsPath);
+			LOGGER.info("Remapping unpick definitions");
 
 			UnpickRemapperService unpickRemapperService = getServiceFactory().get(getOptions().getUnpickRemapperService());
 			String remapped = unpickRemapperService.remap(new InputStreamReader(new ByteArrayInputStream(definitions), StandardCharsets.UTF_8));
@@ -210,14 +189,14 @@ public class UnpickService extends Service<UnpickService.Options> {
 			return new ByteArrayInputStream(remapped.getBytes(StandardCharsets.UTF_8));
 		}
 
-		LOGGER.debug("Using unpick definitions: {}", unpickDefinitionsPath);
+		LOGGER.debug("Using unpick definitions");
 
 		return new ByteArrayInputStream(definitions);
 	}
 
 	public String getUnpickCacheKey() {
 		return Checksum.of(List.of(
-				Checksum.of(getOptions().getUnpickDefinitions().getAsFile().get()),
+				Checksum.of(getOptions().getUnpickDefinitions().get()),
 				Checksum.of(getOptions().getUnpickConstantJar()),
 				Checksum.of(getOptions().getUnpickRemapperService()
 						.flatMap(options -> options.getTinyRemapper()

--- a/src/main/java/net/fabricmc/loom/task/service/UnpickService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/UnpickService.java
@@ -29,6 +29,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -94,6 +95,10 @@ public class UnpickService extends Service<UnpickService.Options> {
 		RegularFileProperty getUnpickDefinitions();
 
 		@Optional
+		@Input
+		Property<String> getUnpickDefinitionsEntry();
+
+		@Optional
 		@Nested
 		Property<UnpickRemapperService.Options> getUnpickRemapperService();
 
@@ -114,31 +119,37 @@ public class UnpickService extends Service<UnpickService.Options> {
 		final Project project = task.getProject();
 		return TYPE.maybeCreate(project, options -> {
 			LoomGradleExtension extension = LoomGradleExtension.get(project);
-			MappingConfiguration mappingConfiguration = extension.getMappingConfiguration();
+			MappingConfiguration mappingConfiguration = extension.getMappingConfigurationOrNull();
 
-			if (!mappingConfiguration.hasUnpickDefinitions()) {
+			if (mappingConfiguration == null || !mappingConfiguration.hasUnpickDefinitions()) {
 				return false;
 			}
 
 			UnpickMetadata unpickMetadata = mappingConfiguration.getUnpickMetadata();
+			MappingsNamespace runtimeNamespace = mappingConfiguration.getRuntimeNamespace();
 
 			if (unpickMetadata instanceof UnpickMetadata.V2 v2) {
-				if (!Objects.equals(v2.namespace(), MappingsNamespace.NAMED.toString())) {
+				if (!Objects.equals(v2.namespace(), runtimeNamespace.toString())) {
 					options.getUnpickRemapperService().set(UnpickRemapperService.createOptions(project, v2));
 				}
 			}
 
 			ConfigurationContainer configurations = project.getConfigurations();
-			File mappingsWorkingDir = mappingConfiguration.mappingsWorkingDir().toFile();
+			options.getUnpickDefinitions().set(mappingConfiguration.getUnpickDefinitionsFile().toFile());
 
-			options.getUnpickDefinitions().set(mappingConfiguration.getUnpickDefinitionsFile());
+			if (mappingConfiguration.getUnpickDefinitionsEntry() != null) {
+				options.getUnpickDefinitionsEntry().set(mappingConfiguration.getUnpickDefinitionsEntry());
+			}
+
 			options.getUnpickOutputJar().set(task.getInputJarName().map(s -> project.getLayout()
-					.dir(project.provider(() -> mappingsWorkingDir)).get().file(s + "-unpicked.jar")));
+					.dir(project.provider(() -> extension.getFiles().getProjectPersistentCache().toPath()
+							.resolve("unpick").resolve(mappingConfiguration.mappingsIdentifier()).toFile()))
+					.get().file(s + "-unpicked.jar")));
 			options.getUnpickConstantJar().setFrom(configurations.named(Constants.Configurations.MAPPING_CONSTANTS));
 			options.getUnpickClasspath().setFrom(configurations.named(Constants.Configurations.MINECRAFT_COMPILE_LIBRARIES));
 			options.getUnpickClasspath().from(configurations.named(Constants.Configurations.MOD_COMPILE_CLASSPATH_MAPPED));
 			options.getLenient().set(unpickMetadata instanceof UnpickMetadata.V1);
-			extension.getMinecraftJars(MappingsNamespace.NAMED).forEach(options.getUnpickClasspath()::from);
+			extension.getMinecraftJars(runtimeNamespace).forEach(options.getUnpickClasspath()::from);
 			return true;
 		});
 	}
@@ -155,6 +166,7 @@ public class UnpickService extends Service<UnpickService.Options> {
 				Stream.ofNullable(existingClasses)
 			).flatMap(Function.identity()).toList();
 		final Path outputJar = getOptions().getUnpickOutputJar().get().getAsFile().toPath();
+		Files.createDirectories(outputJar.getParent());
 		Files.deleteIfExists(outputJar);
 
 		try (ZipFsClasspath zipFsClasspath = ZipFsClasspath.create(classpath);
@@ -179,19 +191,28 @@ public class UnpickService extends Service<UnpickService.Options> {
 
 	private InputStream getUnpickDefinitionsInputStream() throws IOException {
 		final Path unpickDefinitionsPath = getOptions().getUnpickDefinitions().getAsFile().get().toPath();
+		final byte[] definitions;
+
+		if (getOptions().getUnpickDefinitionsEntry().isPresent()) {
+			try (FileSystemUtil.Delegate fs = FileSystemUtil.getJarFileSystem(unpickDefinitionsPath, false)) {
+				definitions = Files.readAllBytes(fs.fs().getPath(getOptions().getUnpickDefinitionsEntry().get()));
+			}
+		} else {
+			definitions = Files.readAllBytes(unpickDefinitionsPath);
+		}
 
 		if (getOptions().getUnpickRemapperService().isPresent()) {
 			LOGGER.info("Remapping unpick definitions: {}", unpickDefinitionsPath);
 
 			UnpickRemapperService unpickRemapperService = getServiceFactory().get(getOptions().getUnpickRemapperService());
-			String remapped = unpickRemapperService.remap(unpickDefinitionsPath.toFile());
+			String remapped = unpickRemapperService.remap(new InputStreamReader(new ByteArrayInputStream(definitions), StandardCharsets.UTF_8));
 
 			return new ByteArrayInputStream(remapped.getBytes(StandardCharsets.UTF_8));
 		}
 
 		LOGGER.debug("Using unpick definitions: {}", unpickDefinitionsPath);
 
-		return Files.newInputStream(unpickDefinitionsPath);
+		return new ByteArrayInputStream(definitions);
 	}
 
 	public String getUnpickCacheKey() {

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -73,6 +73,7 @@ public class Constants {
 		 */
 		public static final String MINECRAFT_NATIVES = "minecraftNatives";
 		public static final String MAPPINGS = "mappings";
+		public static final String ANNOTATIONS = "annotations";
 		public static final String MAPPINGS_FINAL = "mappingsFinal";
 		public static final String LOADER_DEPENDENCIES = "loaderLibraries";
 		public static final String LOOM_DEVELOPMENT_DEPENDENCIES = "loomDevelopmentDependencies";

--- a/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
+++ b/src/main/java/net/fabricmc/loom/util/SourceRemapper.java
@@ -45,7 +45,7 @@ import org.slf4j.Logger;
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.RemapConfigurationSettings;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
-import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
+import net.fabricmc.loom.configuration.providers.mappings.RemapMappingConfiguration;
 import net.fabricmc.loom.task.service.LorenzMappingService;
 import net.fabricmc.loom.util.service.ServiceFactory;
 
@@ -164,7 +164,7 @@ public class SourceRemapper {
 		}
 
 		LoomGradleExtension extension = LoomGradleExtension.get(project);
-		MappingConfiguration mappingConfiguration = extension.getMappingConfiguration();
+		RemapMappingConfiguration mappingConfiguration = extension.getMappingConfiguration();
 		MappingsNamespace prodNamespace = extension.getProductionNamespaceEnum().get();
 
 		LorenzMappingService lorenzMappingService = serviceFactory.get(LorenzMappingService.createOptions(

--- a/src/test/groovy/net/fabricmc/loom/test/integration/noRemap/AnnotationsTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/noRemap/AnnotationsTest.groovy
@@ -1,0 +1,235 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.integration.noRemap
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.ClassNode
+import spock.lang.Specification
+
+import net.fabricmc.loom.test.util.GradleProjectTestTrait
+import net.fabricmc.loom.util.Checksum
+import net.fabricmc.loom.util.ZipUtils
+
+import static net.fabricmc.loom.test.LoomTestConstants.PRE_RELEASE_GRADLE
+import static org.gradle.testkit.runner.TaskOutcome.NO_SOURCE
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class AnnotationsTest extends Specification implements GradleProjectTestTrait {
+	private static final String MINECRAFT_VERSION = "25w45a_unobfuscated"
+
+	def "javadoc, unpick, constants and annotation patches"() {
+		setup:
+		def gradle = gradleProject(project: "minimalBaseNoRemap", version: PRE_RELEASE_GRADLE)
+		Path annotationsJar = createFixtureRepository(gradle)
+		String minecraftArtifactVersion = getMinecraftArtifactVersion(annotationsJar)
+		gradle.buildGradle << """
+			repositories {
+				maven {
+					url = uri("repo")
+				}
+			}
+
+			dependencies {
+				minecraft "com.mojang:minecraft:${MINECRAFT_VERSION}"
+				annotations "test:annotations:1.0"
+			}
+		"""
+
+		def sourceFile = new File(gradle.projectDir, "src/main/java/test/Test.java")
+		sourceFile.parentFile.mkdirs()
+		sourceFile.text = """
+			package test;
+
+			public class Test {
+				public static final int EXAMPLE_INT = Constants.EXAMPLE_INT;
+			}
+		"""
+
+		when:
+		def compileResult = gradle.run(task: "compileJava")
+		def annotationsCache = getAnnotationsCache(gradle, annotationsJar)
+
+		then:
+		compileResult.task(":compileJava").outcome == SUCCESS
+		new File(gradle.projectDir, "build/classes/java/main/test/Test.class").isFile()
+		hasClassAnnotation(gradle.getGeneratedMinecraft(minecraftArtifactVersion, "merged-deobf"), "net/minecraft/client/Options.class", "Ltest/AnnotationPatchApplied;")
+		!annotationsCache.exists()
+		!new File(gradle.projectDir, ".gradle/loom-cache/source_mappings").exists()
+
+		when:
+		def sourcesResult = gradle.run(tasks: [
+			"genSourcesWithVineflower",
+			"--no-use-cache"
+		])
+		def optionsSource = getClassSource(gradle, minecraftArtifactVersion, "net/minecraft/client/Options.java")
+
+		then:
+		sourcesResult.task(":genSourcesWithVineflower").outcome == SUCCESS
+		!annotationsCache.exists()
+		optionsSource.contains("/// # Loom test class javadoc")
+		optionsSource.contains("/// **Loom test field javadoc**")
+		optionsSource.contains("/// `Loom test method javadoc`")
+		optionsSource.contains("Constants.EXAMPLE_INT")
+	}
+
+	def "annotation patches in split jars"() {
+		setup:
+		def gradle = gradleProject(project: "minimalBaseNoRemap", version: PRE_RELEASE_GRADLE)
+		Path annotationsJar = createFixtureRepository(gradle)
+		String minecraftArtifactVersion = getMinecraftArtifactVersion(annotationsJar)
+		gradle.buildGradle << """
+			loom {
+				splitEnvironmentSourceSets()
+			}
+
+			repositories {
+				maven {
+					url = uri("repo")
+				}
+			}
+
+			dependencies {
+				minecraft "com.mojang:minecraft:${MINECRAFT_VERSION}"
+				annotations "test:annotations:1.0"
+			}
+		"""
+
+		when:
+		def result = gradle.run(task: "compileJava")
+
+		then:
+		result.task(":compileJava").outcome == NO_SOURCE
+		hasClassAnnotation(gradle.getGeneratedMinecraft(minecraftArtifactVersion, "clientonly-deobf"), "net/minecraft/client/Options.class", "Ltest/AnnotationPatchApplied;")
+		hasClassAnnotation(gradle.getGeneratedMinecraft(minecraftArtifactVersion, "common-deobf"), "net/minecraft/resources/Identifier.class", "Ltest/AnnotationPatchApplied;")
+	}
+
+	private static File getAnnotationsCache(GradleProject gradle, Path annotationsJar) {
+		return new File(gradle.gradleHomeDir, "caches/fabric-loom/${MINECRAFT_VERSION}/${getAnnotationsIdentifier(annotationsJar)}")
+	}
+
+	private static String getMinecraftArtifactVersion(Path annotationsJar) {
+		return "${MINECRAFT_VERSION}-${getAnnotationsIdentifier(annotationsJar)}"
+	}
+
+	private static String getAnnotationsIdentifier(Path annotationsJar) {
+		String hash = Checksum.of(annotationsJar).sha256().hex(12)
+		return "annotations.test.annotations.${hash}.${MINECRAFT_VERSION}.1.0-v2"
+	}
+
+	private static Path createFixtureRepository(GradleProject gradle) {
+		Path annotationsJar = createArtifact(gradle, "annotations")
+		ZipUtils.add(annotationsJar, "mappings/mappings.tiny", MAPPINGS)
+		ZipUtils.add(annotationsJar, "extras/annotations.json", ANNOTATIONS_PATCH)
+		ZipUtils.add(annotationsJar, "extras/definitions.unpick", UNPICK_DEFINITIONS)
+		ZipUtils.add(annotationsJar, "extras/unpick.json", UNPICK_METADATA)
+
+		Path constantsJar = createArtifact(gradle, "constants")
+		ZipUtils.add(constantsJar, "test/Constants.class", createConstantsClass())
+		return annotationsJar
+	}
+
+	private static Path createArtifact(GradleProject gradle, String name) {
+		File artifactDirectory = new File(gradle.projectDir, "repo/test/${name}/1.0")
+		artifactDirectory.mkdirs()
+
+		new File(artifactDirectory, "${name}-1.0.pom").text = """
+			<project xmlns="http://maven.apache.org/POM/4.0.0">
+				<modelVersion>4.0.0</modelVersion>
+				<groupId>test</groupId>
+				<artifactId>${name}</artifactId>
+				<version>1.0</version>
+			</project>
+		"""
+
+		return new File(artifactDirectory, "${name}-1.0.jar").toPath()
+	}
+
+	private static byte[] createConstantsClass() {
+		def writer = new ClassWriter(0)
+		writer.visit(Opcodes.V17, Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL | Opcodes.ACC_SUPER, "test/Constants", null, "java/lang/Object", null)
+		writer.visitField(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL, "EXAMPLE_INT", "I", null, 260).visitEnd()
+		writer.visitEnd()
+		return writer.toByteArray()
+	}
+
+	private static boolean hasClassAnnotation(File jar, String className, String annotationDescriptor) {
+		def classNode = new ClassNode()
+		new ClassReader(ZipUtils.unpack(jar.toPath(), className)).accept(classNode, ClassReader.SKIP_CODE)
+		return classNode.invisibleAnnotations.any { it.desc == annotationDescriptor }
+	}
+
+	private static String getClassSource(GradleProject gradle, String minecraftArtifactVersion, String className) {
+		File sourcesJar = gradle.getGeneratedSources(minecraftArtifactVersion, "merged-deobf")
+		return new String(ZipUtils.unpack(sourcesJar.toPath(), className), StandardCharsets.UTF_8)
+	}
+
+	private static final String MAPPINGS = "tiny\t2\t0\tofficial\n" +
+	"c\tnet/minecraft/client/Options\n" +
+	"\tc\t# Loom test class javadoc\n" +
+	"\tf\tI\tUNLIMITED_FRAMERATE_CUTOFF\n" +
+	"\t\tc\t**Loom test field javadoc**\n" +
+	"\tm\t()Lnet/minecraft/client/OptionInstance;\tframerateLimit\n" +
+	"\t\tc\t`Loom test method javadoc`\n"
+
+	private static final String ANNOTATIONS_PATCH = '''{
+		"version": 1,
+		"namespace": "official",
+		"classes": {
+			"net/minecraft/client/Options": {
+				"add": [
+					{
+						"desc": "Ltest/AnnotationPatchApplied;"
+					}
+				]
+			},
+			"net/minecraft/resources/Identifier": {
+				"add": [
+					{
+						"desc": "Ltest/AnnotationPatchApplied;"
+					}
+				]
+			}
+		}
+	}'''
+
+	private static final String UNPICK_DEFINITIONS = "unpick v4\n\n" +
+	"group int example_int\n" +
+	"\ttest.Constants.EXAMPLE_INT\n\n" +
+	"target_method com.mojang.serialization.Codec intRange (II)Lcom/mojang/serialization/Codec;\n" +
+	"\tparam 1 example_int\n"
+
+	private static final String UNPICK_METADATA = """\
+		{
+			"version": 2,
+			"namespace": "official",
+			"constants": "test:constants:1.0"
+		}
+	""".stripIndent()
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/decompilers/TinyJavadocProviderTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/decompilers/TinyJavadocProviderTest.groovy
@@ -39,6 +39,7 @@ import spock.lang.Specification
 import spock.lang.TempDir
 
 import net.fabricmc.fernflower.api.FabricJavadocStyle
+import net.fabricmc.loom.api.decompilers.JavadocStyle
 import net.fabricmc.loom.configuration.providers.mappings.unpick.UnpickMetadata
 import net.fabricmc.loom.decompilers.vineflower.TinyJavadocProvider
 
@@ -82,7 +83,7 @@ c\t${V2_NAME}
 		StructClass structClass = readStructClass(UnpickMetadata.V2)
 		def field = structClass.getField("namespace", "Ljava/lang/String;")
 		def method = structClass.getMethod("<init>", "(Ljava/lang/String;Ljava/lang/String;)V")
-		def provider = new TinyJavadocProvider(mappings.toFile(), "official")
+		def provider = new TinyJavadocProvider(mappings.toFile(), "official", JavadocStyle.MARKDOWN)
 
 		expect:
 		provider.getClassJavadocStyle(structClass) == FabricJavadocStyle.MARKDOWN
@@ -92,12 +93,12 @@ c\t${V2_NAME}
 		provider.getMethodDoc(structClass, method) == "@param namespace The namespace."
 	}
 
-	def "uses HTML javadoc for multi-namespace mappings"() {
+	def "uses the configured HTML javadoc style"() {
 		given:
 		Path mappings = tempDir.resolve("mappings.tiny")
-		Files.writeString(mappings, "tiny\t2\t0\tofficial\tnamed\n")
+		Files.writeString(mappings, "tiny\t2\t0\tofficial\n")
 		StructClass structClass = readStructClass(UnpickMetadata.V2)
-		def provider = new TinyJavadocProvider(mappings.toFile(), "named")
+		def provider = new TinyJavadocProvider(mappings.toFile(), "official", JavadocStyle.HTML)
 
 		expect:
 		provider.getClassJavadocStyle(structClass) == FabricJavadocStyle.HTML

--- a/src/test/groovy/net/fabricmc/loom/test/unit/decompilers/TinyJavadocProviderTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/decompilers/TinyJavadocProviderTest.groovy
@@ -1,0 +1,113 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit.decompilers
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+import org.jetbrains.java.decompiler.main.ClassesProcessor
+import org.jetbrains.java.decompiler.main.DecompilerContext
+import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger
+import org.jetbrains.java.decompiler.struct.StructClass
+import org.jetbrains.java.decompiler.struct.StructContext
+import org.jetbrains.java.decompiler.struct.attr.StructGeneralAttribute
+import org.jetbrains.java.decompiler.util.DataInputFullStream
+import org.mockito.Mockito
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import net.fabricmc.fernflower.api.FabricJavadocStyle
+import net.fabricmc.loom.configuration.providers.mappings.unpick.UnpickMetadata
+import net.fabricmc.loom.decompilers.vineflower.TinyJavadocProvider
+
+class TinyJavadocProviderTest extends Specification {
+	private static final String V2_NAME = UnpickMetadata.V2.name.replace('.', '/')
+
+	@TempDir
+	Path tempDir
+
+	def setupSpec() {
+		StructGeneralAttribute.init()
+	}
+
+	def setup() {
+		DecompilerContext.currentContext = new DecompilerContext(
+				[:],
+				Mockito.mock(IFernflowerLogger),
+				Mockito.mock(StructContext),
+				Mockito.mock(ClassesProcessor),
+				null
+				)
+	}
+
+	def cleanup() {
+		DecompilerContext.currentContext = null
+	}
+
+	def "reads parameter names from an official-only mapping tree"() {
+		given:
+		Path mappings = tempDir.resolve("mappings.tiny")
+		Files.writeString(mappings, """\
+tiny\t2\t0\tofficial
+c\t${V2_NAME}
+\tf\tLjava/lang/String;\tnamespace
+\t\tc\tThe namespace.
+\tm\t(Ljava/lang/String;Ljava/lang/String;)V\t<init>
+\t\tp\t1\tnamespace
+\t\t\tc\tThe namespace.
+""")
+
+		StructClass structClass = readStructClass(UnpickMetadata.V2)
+		def field = structClass.getField("namespace", "Ljava/lang/String;")
+		def method = structClass.getMethod("<init>", "(Ljava/lang/String;Ljava/lang/String;)V")
+		def provider = new TinyJavadocProvider(mappings.toFile(), "official")
+
+		expect:
+		provider.getClassJavadocStyle(structClass) == FabricJavadocStyle.MARKDOWN
+		provider.getFieldJavadocStyle(structClass, field) == FabricJavadocStyle.MARKDOWN
+		provider.getMethodJavadocStyle(structClass, method) == FabricJavadocStyle.MARKDOWN
+		provider.getClassDoc(structClass) == "@param namespace The namespace."
+		provider.getMethodDoc(structClass, method) == "@param namespace The namespace."
+	}
+
+	def "uses HTML javadoc for multi-namespace mappings"() {
+		given:
+		Path mappings = tempDir.resolve("mappings.tiny")
+		Files.writeString(mappings, "tiny\t2\t0\tofficial\tnamed\n")
+		StructClass structClass = readStructClass(UnpickMetadata.V2)
+		def provider = new TinyJavadocProvider(mappings.toFile(), "named")
+
+		expect:
+		provider.getClassJavadocStyle(structClass) == FabricJavadocStyle.HTML
+	}
+
+	private static StructClass readStructClass(Class<?> clazz) {
+		String classFile = "/${clazz.name.replace('.', '/')}.class"
+
+		clazz.getResourceAsStream(classFile).withCloseable {
+			return StructClass.create(new DataInputFullStream(it.bytes), true)
+		}
+	}
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/providers/mappings/NoRemapMappingConfigurationTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/providers/mappings/NoRemapMappingConfigurationTest.groovy
@@ -1,0 +1,88 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit.providers.mappings
+
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
+import java.nio.file.Files
+import java.nio.file.Path
+
+import spock.lang.Specification
+import spock.lang.TempDir
+import spock.lang.Unroll
+
+import net.fabricmc.loom.configuration.providers.mappings.NoRemapMappingConfiguration
+
+class NoRemapMappingConfigurationTest extends Specification {
+	private static final Method VALIDATE_MAPPINGS = NoRemapMappingConfiguration.getDeclaredMethod("validateMappings", Path)
+
+	static {
+		VALIDATE_MAPPINGS.setAccessible(true)
+	}
+
+	@TempDir
+	Path tempDir
+
+	def "accepts official-only mappings"() {
+		given:
+		Path mappings = writeMappings("tiny\t2\t0\tofficial\n")
+
+		when:
+		validateMappings(mappings)
+
+		then:
+		noExceptionThrown()
+	}
+
+	@Unroll
+	def "rejects mappings with #description"() {
+		given:
+		Path mappings = writeMappings(header)
+
+		when:
+		validateMappings(mappings)
+
+		then:
+		def exception = thrown(IOException)
+		exception.message == "Annotations mappings must contain only the official namespace"
+
+		where:
+		description             | header
+		"a non-official source" | "tiny\t2\t0\tnamed\n"
+		"a destination namespace" | "tiny\t2\t0\tofficial\tnamed\n"
+	}
+
+	private Path writeMappings(String mappings) {
+		return Files.writeString(tempDir.resolve("mappings.tiny"), mappings)
+	}
+
+	private static void validateMappings(Path mappings) {
+		try {
+			VALIDATE_MAPPINGS.invoke(null, mappings)
+		} catch (InvocationTargetException e) {
+			throw e.cause
+		}
+	}
+}


### PR DESCRIPTION
Support the following features provided via a depdency jar in a similar format to yarn:
- Unpick (with or without constants)
- Annotations
- Javadoc 


dependencies {
	annotations "net.fabricmc:annotater:26.2+build.1"
}