### PR TITLE
Microsoft Authentication

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/LoomTasks.java
+++ b/src/main/java/net/fabricmc/loom/task/LoomTasks.java
@@ -45,6 +45,8 @@ import net.fabricmc.loom.configuration.providers.minecraft.MinecraftVersionMeta;
 import net.fabricmc.loom.task.launch.GenerateDLIConfigTask;
 import net.fabricmc.loom.task.launch.GenerateLog4jConfigTask;
 import net.fabricmc.loom.task.launch.GenerateRemapClasspathTask;
+import net.fabricmc.loom.task.launch.auth.MicrosoftLoginTask;
+import net.fabricmc.loom.task.launch.auth.MicrosoftLogoutTask;
 import net.fabricmc.loom.util.Check;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.LoomVersions;
@@ -116,6 +118,7 @@ public abstract class LoomTasks implements Runnable {
 		getTasks().named("check").configure(task -> task.dependsOn(validateAccessWidener));
 
 		registerIDETasks();
+		registerMicrosoftAuthTasks();
 		registerRunTasks();
 
 		// Must be done in afterEvaluate to allow time for the build script to configure the jar config.
@@ -176,6 +179,16 @@ public abstract class LoomTasks implements Runnable {
 		});
 	}
 
+	private void registerMicrosoftAuthTasks() {
+		getTasks().register("microsoftLogin", MicrosoftLoginTask.class, task -> {
+			task.setDescription("Logs in to Minecraft with a Microsoft account.");
+		});
+
+		getTasks().register("microsoftLogout", MicrosoftLogoutTask.class, task -> {
+			task.setDescription("Removes the stored Microsoft account.");
+		});
+	}
+
 	public static String getRunConfigTaskName(RunConfiguration config) {
 		String configName = config.getName();
 		return "run" + configName.substring(0, 1).toUpperCase() + configName.substring(1);
@@ -193,6 +206,7 @@ public abstract class LoomTasks implements Runnable {
 			runTask.configure(t -> {
 				t.setDescription("Starts the '" + config.getName() + "' run configuration");
 				t.dependsOn(config.getRuntimeEnvironment().map(env -> env.equals("client") ? "configureClientLaunch" : "configureLaunch"));
+				t.getMicrosoftAuthenticationEnabled().set(config.getName().equals("client"));
 			});
 
 			if (config.getName().equals("client") && renderDocSupported) {

--- a/src/main/java/net/fabricmc/loom/task/RunGameTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RunGameTask.java
@@ -24,20 +24,65 @@
 
 package net.fabricmc.loom.task;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import javax.inject.Inject;
 
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
 import org.gradle.work.DisableCachingByDefault;
 
+import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.RunConfiguration;
 import net.fabricmc.loom.configuration.ide.DefaultRunConfigurationSettings;
+import net.fabricmc.loom.task.launch.auth.MicrosoftAccountStore;
+import net.fabricmc.loom.task.launch.auth.MicrosoftGameAuthentication;
+import net.fabricmc.loom.task.launch.auth.MinecraftAccessTokenProviderImpl;
+import net.fabricmc.loom.util.nativeplatform.EncryptionKeyStoreFactory;
 
 @DisableCachingByDefault
 public abstract class RunGameTask extends AbstractRunTask {
+	@Input
+	public abstract Property<Boolean> getMicrosoftAuthenticationEnabled();
+	@Internal
+	protected abstract RegularFileProperty getMicrosoftAccountFile();
+
 	@Inject
 	public RunGameTask(RunConfiguration settings) {
 		super(proj -> DefaultRunConfigurationSettings.finialise(settings, proj));
+		getMicrosoftAuthenticationEnabled().convention(false);
+		LoomGradleExtension extension = LoomGradleExtension.get(getProject());
+		getMicrosoftAccountFile().fileValue(MicrosoftAccountStore.defaultPath(extension.getFiles()).toFile());
 
 		// Defaults to empty, forwards stdin to mc.
 		setStandardInput(System.in);
+	}
+
+	@Override
+	public void exec() {
+		if (getMicrosoftAuthenticationEnabled().get()) {
+			addMicrosoftAuthenticationArguments();
+		}
+
+		super.exec();
+	}
+
+	private void addMicrosoftAuthenticationArguments() {
+		Path accountPath = getMicrosoftAccountFile().get().getAsFile().toPath();
+
+		if (!Files.exists(accountPath)) {
+			return;
+		}
+
+		try {
+			MicrosoftAccountStore accountStore = new MicrosoftAccountStore(accountPath, EncryptionKeyStoreFactory.create(accountPath));
+			MicrosoftGameAuthentication authentication = new MicrosoftGameAuthentication(accountStore, new MinecraftAccessTokenProviderImpl(), getLogger());
+			args(authentication.getLaunchArguments());
+		} catch (Exception e) {
+			getLogger().error("Failed to initialize Microsoft authentication; starting Minecraft without Microsoft authentication", e);
+		}
 	}
 }

--- a/src/main/java/net/fabricmc/loom/task/launch/auth/MicrosoftAccountStore.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/auth/MicrosoftAccountStore.java
@@ -1,0 +1,179 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.launch.auth;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import net.fabricmc.loom.extension.LoomFiles;
+import net.fabricmc.loom.util.EncryptedStringStore;
+import net.fabricmc.loom.util.nativeplatform.EncryptionKeyStore;
+import net.fabricmc.loom.util.nativeplatform.LoomNativePlatformException;
+
+/// Stores the durable part of a Microsoft Minecraft login in an encrypted file.
+///
+/// The short-lived Minecraft access token is deliberately not persisted. It is obtained from the
+/// refresh token each time the game starts.
+public final class MicrosoftAccountStore {
+	private static final int VERSION = 1;
+	private static final Gson GSON = new Gson();
+
+	private final Path path;
+	private final EncryptionKeyStore keyStore;
+	private final EncryptedStringStore encryptedStringStore;
+
+	public MicrosoftAccountStore(Path path, EncryptionKeyStore keyStore) {
+		this.path = Objects.requireNonNull(path, "path");
+		this.keyStore = Objects.requireNonNull(keyStore, "keyStore");
+		this.encryptedStringStore = new EncryptedStringStore(keyStore);
+	}
+
+	public static Path defaultPath(LoomFiles files) {
+		Objects.requireNonNull(files, "files");
+		return files.getUserCache().toPath().resolve("microsoft-auth.json");
+	}
+
+	public boolean exists() {
+		return Files.exists(path);
+	}
+
+	public void prepare() throws LoomNativePlatformException {
+		keyStore.prepare();
+	}
+
+	public Account read() throws IOException, LoomNativePlatformException {
+		return parse(encryptedStringStore.read(path));
+	}
+
+	public void write(Account account) throws IOException, LoomNativePlatformException {
+		Objects.requireNonNull(account, "account");
+		Path parent = path.getParent();
+
+		if (parent != null) {
+			Files.createDirectories(parent);
+		}
+
+		StoredAccount storedAccount = new StoredAccount(
+				VERSION,
+				account.clientId(),
+				account.refreshToken(),
+				account.profileId(),
+				account.profileName()
+		);
+		encryptedStringStore.write(path, GSON.toJson(storedAccount));
+	}
+
+	public void delete() throws IOException, LoomNativePlatformException {
+		Files.deleteIfExists(path);
+		keyStore.delete();
+	}
+
+	private static Account parse(String json) throws IOException {
+		JsonObject object;
+
+		try {
+			JsonElement element = JsonParser.parseString(json);
+
+			if (!element.isJsonObject()) {
+				throw new IllegalStateException("Microsoft account must contain a JSON object");
+			}
+
+			object = element.getAsJsonObject();
+		} catch (RuntimeException e) {
+			throw new IOException("Invalid stored Microsoft account", e);
+		}
+
+		int version = parseVersion(object);
+
+		if (version != VERSION) {
+			throw new IOException("Unsupported stored Microsoft account version: " + version);
+		}
+
+		try {
+			StoredAccount storedAccount = GSON.fromJson(object, StoredAccount.class);
+			return new Account(
+					storedAccount.clientId(),
+					storedAccount.refreshToken(),
+					storedAccount.profileId(),
+					storedAccount.profileName()
+			);
+		} catch (RuntimeException e) {
+			throw new IOException("Invalid stored Microsoft account", e);
+		}
+	}
+
+	private static int parseVersion(JsonObject object) throws IOException {
+		JsonElement version = object.get("version");
+
+		if (version == null || !version.isJsonPrimitive() || !version.getAsJsonPrimitive().isNumber()) {
+			throw new IOException("Invalid stored Microsoft account version");
+		}
+
+		try {
+			return Integer.parseInt(version.getAsString());
+		} catch (NumberFormatException e) {
+			throw new IOException("Invalid stored Microsoft account version", e);
+		}
+	}
+
+	public record Account(String clientId, String refreshToken, String profileId, String profileName) {
+		public Account {
+			clientId = requireNonBlank(clientId, "clientId");
+			refreshToken = requireNonBlank(refreshToken, "refreshToken");
+			profileId = requireNonBlank(profileId, "profileId");
+			profileName = requireNonBlank(profileName, "profileName");
+		}
+
+		public Account withRefreshToken(String refreshToken) {
+			return new Account(clientId, refreshToken, profileId, profileName);
+		}
+	}
+
+	private static String requireNonBlank(String value, String name) {
+		Objects.requireNonNull(value, name);
+
+		if (value.isBlank()) {
+			throw new IllegalArgumentException(name + " must not be blank");
+		}
+
+		return value;
+	}
+
+	private record StoredAccount(int version, String clientId, String refreshToken, String profileId, String profileName) {
+		private StoredAccount {
+			Objects.requireNonNull(clientId, "clientId");
+			Objects.requireNonNull(refreshToken, "refreshToken");
+			Objects.requireNonNull(profileId, "profileId");
+			Objects.requireNonNull(profileName, "profileName");
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/launch/auth/MicrosoftAuthService.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/auth/MicrosoftAuthService.java
@@ -26,7 +26,6 @@ package net.fabricmc.loom.task.launch.auth;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -150,32 +149,11 @@ public interface MicrosoftAuthService {
 	record MinecraftEntitlements(boolean canPlayMinecraft, boolean ownsMinecraft) {
 	}
 
-	/// The authenticated player's Java Edition identity and cosmetics.
-	record MinecraftProfile(String id, String name, List<Skin> skins, List<Cape> capes) {
+	/// The authenticated player's Java Edition identity.
+	record MinecraftProfile(String id, String name) {
 		public MinecraftProfile {
 			Objects.requireNonNull(id, "id");
 			Objects.requireNonNull(name, "name");
-			skins = List.copyOf(skins);
-			capes = List.copyOf(capes);
-		}
-	}
-
-	record Skin(String id, String state, URI url, String variant, String alias) {
-		public Skin {
-			Objects.requireNonNull(id, "id");
-			Objects.requireNonNull(state, "state");
-			Objects.requireNonNull(url, "url");
-			Objects.requireNonNull(variant, "variant");
-			Objects.requireNonNull(alias, "alias");
-		}
-	}
-
-	record Cape(String id, String state, URI url, String alias) {
-		public Cape {
-			Objects.requireNonNull(id, "id");
-			Objects.requireNonNull(state, "state");
-			Objects.requireNonNull(url, "url");
-			Objects.requireNonNull(alias, "alias");
 		}
 	}
 }

--- a/src/main/java/net/fabricmc/loom/task/launch/auth/MicrosoftAuthService.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/auth/MicrosoftAuthService.java
@@ -1,0 +1,181 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.launch.auth;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.jspecify.annotations.Nullable;
+
+/// The remote calls required to exchange a Microsoft login for a Minecraft access token.
+///
+/// This interface deliberately does not implement device-code polling. Callers should use the
+/// interval and expiry supplied by [DeviceCode] and handle the transient errors returned by
+/// [#requestMicrosoftToken(String, String)].
+///
+/// @see [Microsoft identity platform device authorization grant](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-device-code)
+/// @see [Xbox services authentication](https://learn.microsoft.com/en-us/gaming/gdk/docs/services/fundamentals/s2s-auth-calls/service-authentication/live-xbox-live-authentication)
+public interface MicrosoftAuthService {
+	/// Starts the OAuth device authorization flow. The returned user code and verification URI
+	/// should be shown to the user before token polling begins.
+	///
+	/// @see [Device authorization request](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-device-code#device-authorization-request)
+	DeviceCode requestDeviceCode(String clientId) throws IOException;
+
+	/// Polls Microsoft for the result of a device authorization request. Pending and slow-down
+	/// responses are returned as [MicrosoftToken] values rather than thrown as errors.
+	///
+	/// @see [Device token polling](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-device-code#authenticating-the-user)
+	MicrosoftToken requestMicrosoftToken(String clientId, String deviceCode) throws IOException;
+
+	/// Exchanges a refresh token for new Microsoft access and refresh tokens. Callers should replace
+	/// the stored refresh token with the one in the returned result.
+	///
+	/// @see [Refresh the access token](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#refresh-the-access-token)
+	MicrosoftToken.Success refreshMicrosoftToken(String clientId, String refreshToken) throws IOException;
+
+	/// Exchanges the Microsoft access token for an Xbox user token (UToken).
+	///
+	/// @see [Xbox authorization process](https://learn.microsoft.com/en-us/gaming/gdk/docs/reference/live/rest/additional/edsauthorization)
+	XboxToken authenticateXboxUser(String microsoftAccessToken) throws IOException;
+
+	/// Exchanges an Xbox user token for an XSTS token scoped to the Minecraft services relying party.
+	///
+	/// @see [Xbox services security tokens](https://learn.microsoft.com/en-us/gaming/gdk/docs/services/fundamentals/s2s-auth-calls/service-authentication/security-tokens/live-security-tokens)
+	XboxToken authorizeMinecraftServices(XboxToken xboxUserToken) throws IOException;
+
+	/// Exchanges the Minecraft-scoped XSTS token for a Minecraft access token.
+	MinecraftToken loginToMinecraft(String userHash, String xstsToken) throws IOException;
+
+	/// Checks whether the authenticated account owns Minecraft or can currently play it through
+	/// another entitlement such as Game Pass.
+	MinecraftEntitlements fetchMinecraftEntitlements(String minecraftAccessToken) throws IOException;
+
+	/// Fetches the Java Edition profile belonging to a Minecraft access token.
+	/// An empty result means that the account does not have a Java Edition profile.
+	Optional<MinecraftProfile> fetchMinecraftProfile(String minecraftAccessToken) throws IOException;
+
+	/// Values used to present and schedule a device authorization attempt.
+	record DeviceCode(String deviceCode, String userCode, URI verificationUri, int expiresIn, int interval, String message) {
+		public DeviceCode {
+			Objects.requireNonNull(deviceCode, "deviceCode");
+			Objects.requireNonNull(userCode, "userCode");
+			Objects.requireNonNull(verificationUri, "verificationUri");
+			Objects.requireNonNull(message, "message");
+
+			if (expiresIn <= 0) {
+				throw new IllegalArgumentException("expiresIn must be positive");
+			}
+
+			if (interval <= 0) {
+				throw new IllegalArgumentException("interval must be positive");
+			}
+		}
+	}
+
+	/// The result of polling Microsoft for a device authorization.
+	sealed interface MicrosoftToken {
+		/// Tokens issued after the user completes authorization.
+		record Success(String accessToken, String refreshToken, String tokenType, int expiresIn) implements MicrosoftToken {
+			public Success {
+				Objects.requireNonNull(accessToken, "accessToken");
+				Objects.requireNonNull(refreshToken, "refreshToken");
+				Objects.requireNonNull(tokenType, "tokenType");
+
+				if (expiresIn <= 0) {
+					throw new IllegalArgumentException("expiresIn must be positive");
+				}
+			}
+		}
+
+		/// A response indicating that the caller should continue polling.
+		record Polling(Status status, @Nullable String description) implements MicrosoftToken {
+			public Polling {
+				Objects.requireNonNull(status, "status");
+			}
+
+			public enum Status {
+				AUTHORIZATION_PENDING,
+				SLOW_DOWN
+			}
+		}
+	}
+
+	/// An Xbox user or XSTS token and its associated user hash.
+	record XboxToken(String token, String userHash) {
+		public XboxToken {
+			Objects.requireNonNull(token, "token");
+			Objects.requireNonNull(userHash, "userHash");
+		}
+	}
+
+	/// A bearer token accepted by Minecraft services.
+	record MinecraftToken(String accessToken, String tokenType, int expiresIn) {
+		public MinecraftToken {
+			Objects.requireNonNull(accessToken, "accessToken");
+			Objects.requireNonNull(tokenType, "tokenType");
+
+			if (expiresIn <= 0) {
+				throw new IllegalArgumentException("expiresIn must be positive");
+			}
+		}
+	}
+
+	/// The account's Minecraft purchase and play entitlements.
+	record MinecraftEntitlements(boolean canPlayMinecraft, boolean ownsMinecraft) {
+	}
+
+	/// The authenticated player's Java Edition identity and cosmetics.
+	record MinecraftProfile(String id, String name, List<Skin> skins, List<Cape> capes) {
+		public MinecraftProfile {
+			Objects.requireNonNull(id, "id");
+			Objects.requireNonNull(name, "name");
+			skins = List.copyOf(skins);
+			capes = List.copyOf(capes);
+		}
+	}
+
+	record Skin(String id, String state, URI url, String variant, String alias) {
+		public Skin {
+			Objects.requireNonNull(id, "id");
+			Objects.requireNonNull(state, "state");
+			Objects.requireNonNull(url, "url");
+			Objects.requireNonNull(variant, "variant");
+			Objects.requireNonNull(alias, "alias");
+		}
+	}
+
+	record Cape(String id, String state, URI url, String alias) {
+		public Cape {
+			Objects.requireNonNull(id, "id");
+			Objects.requireNonNull(state, "state");
+			Objects.requireNonNull(url, "url");
+			Objects.requireNonNull(alias, "alias");
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/launch/auth/MicrosoftAuthServiceImpl.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/auth/MicrosoftAuthServiceImpl.java
@@ -1,0 +1,355 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.launch.auth;
+
+import java.io.IOException;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.jspecify.annotations.Nullable;
+
+public final class MicrosoftAuthServiceImpl implements MicrosoftAuthService {
+	private static final Duration TIMEOUT = Duration.ofSeconds(30);
+	private static final String MICROSOFT_SCOPE = "XboxLive.SignIn XboxLive.offline_access";
+	private static final Endpoints DEFAULT_ENDPOINTS = new Endpoints(
+			URI.create("https://login.microsoftonline.com/consumers/oauth2/v2.0/devicecode"),
+			URI.create("https://login.microsoftonline.com/consumers/oauth2/v2.0/token"),
+			URI.create("https://user.auth.xboxlive.com/user/authenticate"),
+			URI.create("https://xsts.auth.xboxlive.com/xsts/authorize"),
+			URI.create("https://api.minecraftservices.com/launcher/login"),
+			URI.create("https://api.minecraftservices.com/entitlements/license"),
+			URI.create("https://api.minecraftservices.com/minecraft/profile")
+	);
+	private static final Gson GSON = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
+
+	private final HttpClient httpClient;
+	private final Endpoints endpoints;
+
+	public MicrosoftAuthServiceImpl() {
+		this(createHttpClient(), DEFAULT_ENDPOINTS);
+	}
+
+	public MicrosoftAuthServiceImpl(Endpoints endpoints) {
+		this(createHttpClient(), endpoints);
+	}
+
+	public MicrosoftAuthServiceImpl(HttpClient httpClient, Endpoints endpoints) {
+		this.httpClient = Objects.requireNonNull(httpClient, "httpClient");
+		this.endpoints = Objects.requireNonNull(endpoints, "endpoints");
+	}
+
+	private static HttpClient createHttpClient() {
+		return HttpClient.newBuilder()
+				.followRedirects(HttpClient.Redirect.NORMAL)
+				.proxy(ProxySelector.getDefault())
+				.connectTimeout(TIMEOUT)
+				.build();
+	}
+
+	@Override
+	public DeviceCode requestDeviceCode(String clientId) throws IOException {
+		DeviceCodeResponse response = postForm(endpoints.deviceCode(), Map.of("client_id", clientId, "scope", MICROSOFT_SCOPE), DeviceCodeResponse.class, false);
+
+		int interval = response.interval() > 0 ? response.interval() : 5;
+		return new DeviceCode(response.deviceCode(), response.userCode(), URI.create(response.verificationUri()), response.expiresIn(), interval, response.message());
+	}
+
+	@Override
+	public MicrosoftToken requestMicrosoftToken(String clientId, String deviceCode) throws IOException {
+		MicrosoftTokenResponse response = postForm(endpoints.microsoftToken(), Map.of(
+				"client_id", clientId,
+				"grant_type", "urn:ietf:params:oauth:grant-type:device_code",
+				"device_code", deviceCode
+		), MicrosoftTokenResponse.class, true);
+
+		if (response.accessToken != null) {
+			if (response.refreshToken == null || response.tokenType == null || response.expiresIn <= 0) {
+				throw new IOException("Microsoft token response is missing a required field");
+			}
+
+			return new MicrosoftToken.Success(response.accessToken, response.refreshToken, response.tokenType, response.expiresIn);
+		}
+
+		return switch (response.error) {
+		case "authorization_pending" -> new MicrosoftToken.Polling(MicrosoftToken.Polling.Status.AUTHORIZATION_PENDING, response.errorDescription);
+		case "slow_down" -> new MicrosoftToken.Polling(MicrosoftToken.Polling.Status.SLOW_DOWN, response.errorDescription);
+		case null -> throw new IOException("Microsoft token response is missing a required field");
+		default -> throw new IOException("Microsoft device authorization failed: %s".formatted(
+				response.errorDescription != null ? response.errorDescription : response.error));
+		};
+	}
+
+	@Override
+	public MicrosoftToken.Success refreshMicrosoftToken(String clientId, String refreshToken) throws IOException {
+		MicrosoftTokenResponse response = postForm(endpoints.microsoftToken(), Map.of(
+				"client_id", clientId,
+				"grant_type", "refresh_token",
+				"refresh_token", refreshToken,
+				"scope", MICROSOFT_SCOPE
+		), MicrosoftTokenResponse.class, true);
+
+		if (response.error != null) {
+			throw new IOException("Microsoft token refresh failed: %s".formatted(
+					response.errorDescription != null ? response.errorDescription : response.error));
+		}
+
+		if (response.accessToken == null || response.refreshToken == null || response.tokenType == null || response.expiresIn <= 0) {
+			throw new IOException("Microsoft token refresh response is missing a required field");
+		}
+
+		return new MicrosoftToken.Success(response.accessToken, response.refreshToken, response.tokenType, response.expiresIn);
+	}
+
+	@Override
+	public XboxToken authenticateXboxUser(String microsoftAccessToken) throws IOException {
+		JsonObject properties = new JsonObject();
+		properties.addProperty("AuthMethod", "RPS");
+		properties.addProperty("SiteName", "user.auth.xboxlive.com");
+		properties.addProperty("RpsTicket", "d=" + microsoftAccessToken);
+		JsonObject request = xboxRequest(properties, "http://auth.xboxlive.com");
+		return parseXboxToken(postJson(endpoints.xboxUser(), request, JsonObject.class));
+	}
+
+	@Override
+	public XboxToken authorizeMinecraftServices(XboxToken xboxUserToken) throws IOException {
+		JsonObject properties = new JsonObject();
+		properties.addProperty("SandboxId", "RETAIL");
+		JsonArray tokens = new JsonArray();
+		tokens.add(xboxUserToken.token());
+		properties.add("UserTokens", tokens);
+		JsonObject request = xboxRequest(properties, "rp://api.minecraftservices.com/");
+		XboxToken xstsToken = parseXboxToken(postJson(endpoints.xsts(), request, JsonObject.class));
+
+		if (!xboxUserToken.userHash().equals(xstsToken.userHash())) {
+			throw new IOException("Xbox authentication changed the user hash");
+		}
+
+		return xstsToken;
+	}
+
+	@Override
+	public MinecraftToken loginToMinecraft(String userHash, String xstsToken) throws IOException {
+		JsonObject request = new JsonObject();
+		request.addProperty("xtoken", "XBL3.0 x=" + userHash + ";" + xstsToken);
+		request.addProperty("platform", "PC_LAUNCHER");
+		MinecraftTokenResponse response = postJson(endpoints.minecraftLogin(), request, MinecraftTokenResponse.class);
+		return new MinecraftToken(response.accessToken(), response.tokenType(), response.expiresIn());
+	}
+
+	@Override
+	public MinecraftEntitlements fetchMinecraftEntitlements(String minecraftAccessToken) throws IOException {
+		URI uri = URI.create(endpoints.minecraftEntitlements() + "?requestId=" + UUID.randomUUID());
+		HttpRequest request = request(uri)
+				.header("Authorization", "Bearer " + minecraftAccessToken)
+				.GET()
+				.build();
+		MinecraftEntitlementsResponse response = send(request, MinecraftEntitlementsResponse.class, false);
+
+		boolean canPlayMinecraft = false;
+		boolean ownsMinecraft = false;
+
+		for (MinecraftEntitlementItem item : response.items()) {
+			canPlayMinecraft |= "game_minecraft".equals(item.name());
+			ownsMinecraft |= "product_minecraft".equals(item.name());
+		}
+
+		return new MinecraftEntitlements(canPlayMinecraft, ownsMinecraft);
+	}
+
+	@Override
+	public Optional<MinecraftProfile> fetchMinecraftProfile(String minecraftAccessToken) throws IOException {
+		HttpRequest request = request(endpoints.minecraftProfile())
+				.header("Authorization", "Bearer " + minecraftAccessToken)
+				.GET()
+				.build();
+		HttpResponse<String> response = send(request);
+
+		if (response.statusCode() == 404) {
+			return Optional.empty();
+		}
+
+		checkStatus(request, response, false);
+		MinecraftProfile profile = parseResponse(request, response, MinecraftProfile.class);
+		return Optional.of(profile);
+	}
+
+	private static JsonObject xboxRequest(JsonObject properties, String relyingParty) {
+		JsonObject request = new JsonObject();
+		request.add("Properties", properties);
+		request.addProperty("RelyingParty", relyingParty);
+		request.addProperty("TokenType", "JWT");
+		return request;
+	}
+
+	private XboxToken parseXboxToken(JsonObject response) throws IOException {
+		try {
+			String token = response.get("Token").getAsString();
+			String userHash = response.getAsJsonObject("DisplayClaims").getAsJsonArray("xui").get(0).getAsJsonObject().get("uhs").getAsString();
+			return new XboxToken(token, userHash);
+		} catch (RuntimeException e) {
+			throw new IOException("Xbox authentication response is missing a required field", e);
+		}
+	}
+
+	private <T> T postForm(URI uri, Map<String, String> values, Class<T> responseType, boolean allowErrorResponse) throws IOException {
+		String body = values.entrySet().stream()
+				.map(entry -> encode(entry.getKey()) + "=" + encode(entry.getValue()))
+				.collect(Collectors.joining("&"));
+		HttpRequest request = request(uri)
+				.header("Content-Type", "application/x-www-form-urlencoded")
+				.POST(HttpRequest.BodyPublishers.ofString(body))
+				.build();
+		return send(request, responseType, allowErrorResponse);
+	}
+
+	private <T> T postJson(URI uri, JsonObject body, Class<T> responseType) throws IOException {
+		HttpRequest request = request(uri)
+				.header("Content-Type", "application/json")
+				.header("x-xbl-contract-version", "1")
+				.POST(HttpRequest.BodyPublishers.ofString(GSON.toJson(body)))
+				.build();
+		return send(request, responseType, false);
+	}
+
+	private <T> T send(HttpRequest request, Class<T> responseType, boolean allowErrorResponse) throws IOException {
+		HttpResponse<String> response = send(request);
+		checkStatus(request, response, allowErrorResponse);
+		return parseResponse(request, response, responseType);
+	}
+
+	private HttpResponse<String> send(HttpRequest request) throws IOException {
+		try {
+			return httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException("Interrupted while authenticating with Microsoft", e);
+		}
+	}
+
+	private static void checkStatus(HttpRequest request, HttpResponse<String> response, boolean allowErrorResponse) throws IOException {
+		if (!allowErrorResponse && (response.statusCode() < 200 || response.statusCode() >= 300)) {
+			throw new IOException("Authentication request to %s failed with HTTP %d: %s".formatted(request.uri(), response.statusCode(), response.body()));
+		}
+	}
+
+	private static <T> T parseResponse(HttpRequest request, HttpResponse<String> response, Class<T> responseType) throws IOException {
+		try {
+			T result = GSON.fromJson(response.body(), responseType);
+
+			if (result == null) {
+				throw new IOException("Authentication request to %s returned an empty response".formatted(request.uri()));
+			}
+
+			return result;
+		} catch (RuntimeException e) {
+			throw new IOException("Authentication request to %s returned invalid JSON".formatted(request.uri()), e);
+		}
+	}
+
+	private static HttpRequest.Builder request(URI uri) {
+		return HttpRequest.newBuilder(uri)
+				.timeout(TIMEOUT)
+				.header("Accept", "application/json");
+	}
+
+	private static String encode(String value) {
+		return URLEncoder.encode(value, StandardCharsets.UTF_8);
+	}
+
+	private record DeviceCodeResponse(String deviceCode, String userCode, String verificationUri, int expiresIn, int interval, String message) {
+		private DeviceCodeResponse {
+			Objects.requireNonNull(deviceCode, "deviceCode");
+			Objects.requireNonNull(userCode, "userCode");
+			Objects.requireNonNull(verificationUri, "verificationUri");
+			Objects.requireNonNull(message, "message");
+
+			if (expiresIn <= 0) {
+				throw new IllegalArgumentException("expiresIn must be positive");
+			}
+		}
+	}
+
+	private static final class MicrosoftTokenResponse {
+		private @Nullable String accessToken;
+		private @Nullable String refreshToken;
+		private @Nullable String tokenType;
+		private int expiresIn;
+		private @Nullable String error;
+		private @Nullable String errorDescription;
+	}
+
+	public record Endpoints(URI deviceCode, URI microsoftToken, URI xboxUser, URI xsts, URI minecraftLogin,
+			URI minecraftEntitlements, URI minecraftProfile) {
+		public Endpoints {
+			Objects.requireNonNull(deviceCode, "deviceCode");
+			Objects.requireNonNull(microsoftToken, "microsoftToken");
+			Objects.requireNonNull(xboxUser, "xboxUser");
+			Objects.requireNonNull(xsts, "xsts");
+			Objects.requireNonNull(minecraftLogin, "minecraftLogin");
+			Objects.requireNonNull(minecraftEntitlements, "minecraftEntitlements");
+			Objects.requireNonNull(minecraftProfile, "minecraftProfile");
+		}
+	}
+
+	private record MinecraftTokenResponse(String accessToken, String tokenType, int expiresIn) {
+		private MinecraftTokenResponse {
+			Objects.requireNonNull(accessToken, "accessToken");
+			Objects.requireNonNull(tokenType, "tokenType");
+
+			if (expiresIn <= 0) {
+				throw new IllegalArgumentException("expiresIn must be positive");
+			}
+		}
+	}
+
+	private record MinecraftEntitlementsResponse(List<MinecraftEntitlementItem> items) {
+		private MinecraftEntitlementsResponse {
+			items = List.copyOf(items);
+		}
+	}
+
+	private record MinecraftEntitlementItem(String name) {
+		private MinecraftEntitlementItem {
+			Objects.requireNonNull(name, "name");
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/launch/auth/MicrosoftAuthTask.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/auth/MicrosoftAuthTask.java
@@ -24,27 +24,38 @@
 
 package net.fabricmc.loom.task.launch.auth;
 
-import java.io.IOException;
-import java.util.Objects;
-import java.util.function.Consumer;
+import java.nio.file.Path;
 
-public final class MinecraftAccessTokenProviderImpl implements MinecraftAccessTokenProvider {
-	private final MicrosoftAuthService authService;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.services.ServiceReference;
+import org.gradle.api.tasks.Internal;
+import org.gradle.work.DisableCachingByDefault;
 
-	public MinecraftAccessTokenProviderImpl() {
-		this(new MicrosoftAuthServiceImpl());
+import net.fabricmc.loom.extension.LoomFiles;
+import net.fabricmc.loom.task.AbstractLoomTask;
+import net.fabricmc.loom.util.gradle.SyncTaskBuildService;
+import net.fabricmc.loom.util.nativeplatform.EncryptionKeyStoreFactory;
+
+/// Base task for operations on the globally stored Microsoft account.
+@DisableCachingByDefault
+public abstract class MicrosoftAuthTask extends AbstractLoomTask {
+	@ServiceReference(SyncTaskBuildService.NAME)
+	abstract Property<SyncTaskBuildService> getSyncTask();
+
+	@Internal
+	protected abstract RegularFileProperty getAccountFile();
+
+	public MicrosoftAuthTask() {
+		getAccountFile().fileValue(MicrosoftAccountStore.defaultPath(LoomFiles.create(getProject())).toFile());
 	}
 
-	public MinecraftAccessTokenProviderImpl(MicrosoftAuthService authService) {
-		this.authService = Objects.requireNonNull(authService, "authService");
+	@Internal
+	protected Path getAccountPath() {
+		return getAccountFile().get().getAsFile().toPath();
 	}
 
-	@Override
-	public AccessToken getAccessToken(String clientId, String refreshToken, Consumer<String> refreshTokenConsumer) throws IOException {
-		Objects.requireNonNull(refreshTokenConsumer, "refreshTokenConsumer");
-		MicrosoftAuthService.MicrosoftToken.Success microsoftToken = authService.refreshMicrosoftToken(clientId, refreshToken);
-		refreshTokenConsumer.accept(microsoftToken.refreshToken());
-		MinecraftAuthFlow.Result minecraft = MinecraftAuthFlow.authenticate(authService, microsoftToken.accessToken());
-		return new AccessToken(minecraft.token().accessToken(), microsoftToken.refreshToken(), minecraft.token().expiresIn());
+	protected MicrosoftAccountStore createAccountStore(Path accountPath) {
+		return new MicrosoftAccountStore(accountPath, EncryptionKeyStoreFactory.create(accountPath));
 	}
 }

--- a/src/main/java/net/fabricmc/loom/task/launch/auth/MicrosoftGameAuthentication.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/auth/MicrosoftGameAuthentication.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.launch.auth;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+
+/// Refreshes a stored Microsoft account and produces the arguments for the game.
+public final class MicrosoftGameAuthentication {
+	private final MicrosoftAccountStore accountStore;
+	private final MinecraftAccessTokenProvider accessTokenProvider;
+	private final Logger logger;
+
+	public MicrosoftGameAuthentication(MicrosoftAccountStore accountStore, MinecraftAccessTokenProvider accessTokenProvider, Logger logger) {
+		this.accountStore = Objects.requireNonNull(accountStore, "accountStore");
+		this.accessTokenProvider = Objects.requireNonNull(accessTokenProvider, "accessTokenProvider");
+		this.logger = Objects.requireNonNull(logger, "logger");
+	}
+
+	public List<String> getLaunchArguments() {
+		if (!accountStore.exists()) {
+			return List.of();
+		}
+
+		try {
+			MicrosoftAccountStore.Account account = accountStore.read();
+			MinecraftAccessTokenProvider.AccessToken accessToken = accessTokenProvider.getAccessToken(
+					account.clientId(),
+					account.refreshToken(),
+					refreshToken -> storeRefreshToken(account, refreshToken)
+			);
+
+			logger.info("Using Microsoft account {} to launch Minecraft", account.profileName());
+			return List.of(
+					"--username", account.profileName(),
+					"--uuid", account.profileId(),
+					"--accessToken", accessToken.accessToken(),
+					"--userType", "msa"
+			);
+		} catch (Exception e) {
+			logger.error("Failed to authenticate with Microsoft; starting Minecraft without Microsoft authentication", e);
+			return List.of();
+		}
+	}
+
+	private void storeRefreshToken(MicrosoftAccountStore.Account account, String refreshToken) {
+		try {
+			accountStore.write(account.withRefreshToken(refreshToken));
+		} catch (Exception e) {
+			logger.error("Failed to store the rotated Microsoft refresh token; continuing authentication for this Minecraft launch", e);
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/launch/auth/MicrosoftLoginService.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/auth/MicrosoftLoginService.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.launch.auth;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/// Performs the interactive Microsoft login that is required when an account is first added.
+public interface MicrosoftLoginService {
+	/// Starts device authorization, reports the code to the caller, and waits for the user to finish
+	/// authentication. The returned refresh token should be stored securely for subsequent launches.
+	LoginResult login(String clientId, Consumer<MicrosoftAuthService.DeviceCode> deviceCodeConsumer) throws IOException;
+
+	record LoginResult(String refreshToken, MicrosoftAuthService.MinecraftProfile profile,
+			MicrosoftAuthService.MinecraftEntitlements entitlements) {
+		public LoginResult {
+			Objects.requireNonNull(refreshToken, "refreshToken");
+			Objects.requireNonNull(profile, "profile");
+			Objects.requireNonNull(entitlements, "entitlements");
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/launch/auth/MicrosoftLoginServiceImpl.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/auth/MicrosoftLoginServiceImpl.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.launch.auth;
+
+import java.io.IOException;
+import java.net.http.HttpTimeoutException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+public final class MicrosoftLoginServiceImpl implements MicrosoftLoginService {
+	private final MicrosoftAuthService authService;
+	private final Sleeper sleeper;
+
+	public MicrosoftLoginServiceImpl() {
+		this(new MicrosoftAuthServiceImpl());
+	}
+
+	public MicrosoftLoginServiceImpl(MicrosoftAuthService authService) {
+		this(authService, duration -> Thread.sleep(duration));
+	}
+
+	public MicrosoftLoginServiceImpl(MicrosoftAuthService authService, Sleeper sleeper) {
+		this.authService = Objects.requireNonNull(authService, "authService");
+		this.sleeper = Objects.requireNonNull(sleeper, "sleeper");
+	}
+
+	@Override
+	public LoginResult login(String clientId, Consumer<MicrosoftAuthService.DeviceCode> deviceCodeConsumer) throws IOException {
+		MicrosoftAuthService.DeviceCode deviceCode = authService.requestDeviceCode(clientId);
+		Objects.requireNonNull(deviceCodeConsumer, "deviceCodeConsumer").accept(deviceCode);
+		MicrosoftAuthService.MicrosoftToken.Success microsoftToken = pollForToken(clientId, deviceCode);
+		MinecraftAuthFlow.Result minecraft = MinecraftAuthFlow.authenticate(authService, microsoftToken.accessToken());
+		MicrosoftAuthService.MinecraftProfile profile = authService.fetchMinecraftProfile(minecraft.token().accessToken())
+				.orElseThrow(() -> new IOException("The Microsoft account does not have a Minecraft Java Edition profile"));
+		return new LoginResult(microsoftToken.refreshToken(), profile, minecraft.entitlements());
+	}
+
+	private MicrosoftAuthService.MicrosoftToken.Success pollForToken(String clientId, MicrosoftAuthService.DeviceCode deviceCode) throws IOException {
+		Instant expiresAt = Instant.now().plusSeconds(deviceCode.expiresIn());
+		int interval = deviceCode.interval();
+
+		while (Instant.now().isBefore(expiresAt)) {
+			if (!Instant.now().plusSeconds(interval).isBefore(expiresAt)) {
+				break;
+			}
+
+			sleep(Duration.ofSeconds(interval));
+
+			try {
+				MicrosoftAuthService.MicrosoftToken result = authService.requestMicrosoftToken(clientId, deviceCode.deviceCode());
+
+				if (result instanceof MicrosoftAuthService.MicrosoftToken.Success success) {
+					return success;
+				}
+
+				MicrosoftAuthService.MicrosoftToken.Polling polling = (MicrosoftAuthService.MicrosoftToken.Polling) result;
+
+				if (polling.status() == MicrosoftAuthService.MicrosoftToken.Polling.Status.SLOW_DOWN) {
+					interval += 5;
+				}
+			} catch (HttpTimeoutException e) {
+				interval *= 2;
+			}
+		}
+
+		throw new IOException("Microsoft device authorization expired before it completed");
+	}
+
+	private void sleep(Duration duration) {
+		try {
+			sleeper.sleep(duration);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException("Interrupted while waiting for Microsoft authentication", e);
+		}
+	}
+
+	@FunctionalInterface
+	public interface Sleeper {
+		void sleep(Duration duration) throws InterruptedException;
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/launch/auth/MicrosoftLoginTask.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/auth/MicrosoftLoginTask.java
@@ -1,0 +1,133 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.launch.auth;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.UntrackedTask;
+
+import net.fabricmc.loom.util.Constants;
+
+/// Authenticates a Microsoft account and stores its refresh token for future client launches.
+@UntrackedTask(because = "Microsoft login must always check the global account state.")
+public abstract class MicrosoftLoginTask extends MicrosoftAuthTask {
+	public MicrosoftLoginTask() {
+		setDescription("Log in to Minecraft with a Microsoft account");
+	}
+
+	@TaskAction
+	public void login() {
+		try {
+			loginInternal(getAccountPath());
+		} catch (GradleException e) {
+			throw e;
+		} catch (Exception e) {
+			String detail = e.getMessage();
+			String message = detail == null || detail.isBlank()
+					? "Microsoft login failed."
+					: "Microsoft login failed: " + detail;
+			throw new GradleException(message, e);
+		}
+	}
+
+	private void loginInternal(Path accountPath) throws Exception {
+		MicrosoftAccountStore accountStore = null;
+		String clientId = null;
+
+		if (Files.exists(accountPath)) {
+			accountStore = createAccountStore(accountPath);
+
+			try {
+				MicrosoftAccountStore.Account account = accountStore.read();
+				clientId = account.clientId();
+				verifyStoredAccount(accountStore, account);
+				getLogger().lifecycle("Microsoft account {} is already logged in and ready to launch; skipping login.", account.profileName());
+				return;
+			} catch (Exception e) {
+				getLogger().warn("The stored Microsoft account could not be verified; starting Microsoft login again.");
+				getLogger().debug("Stored Microsoft account verification failed", e);
+			}
+		}
+
+		if (clientId == null) {
+			clientId = getClientId();
+		}
+
+		if (clientId.isBlank()) {
+			throw new GradleException("Microsoft login is not configured. Set Constants.MICROSOFT_CLIENT_ID to the Microsoft application client ID.");
+		}
+
+		if (accountStore == null) {
+			accountStore = createAccountStore(accountPath);
+		}
+
+		accountStore.prepare();
+
+		MicrosoftLoginService.LoginResult result = createLoginService().login(clientId, this::displayDeviceCode);
+		MicrosoftAuthService.MinecraftProfile profile = result.profile();
+		accountStore.write(new MicrosoftAccountStore.Account(clientId, result.refreshToken(), profile.id(), profile.name()));
+
+		getLogger().lifecycle("Logged in to Minecraft as {} ({}).", profile.name(), profile.id());
+	}
+
+	private void verifyStoredAccount(MicrosoftAccountStore accountStore, MicrosoftAccountStore.Account account) throws Exception {
+		createAccessTokenProvider().getAccessToken(
+				account.clientId(),
+				account.refreshToken(),
+				refreshToken -> storeRefreshToken(accountStore, account, refreshToken)
+		);
+	}
+
+	private static void storeRefreshToken(MicrosoftAccountStore accountStore, MicrosoftAccountStore.Account account, String refreshToken) {
+		try {
+			accountStore.write(account.withRefreshToken(refreshToken));
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to store the rotated Microsoft refresh token", e);
+		}
+	}
+
+	@Internal
+	protected String getClientId() {
+		return Constants.MICROSOFT_CLIENT_ID;
+	}
+
+	protected MicrosoftLoginService createLoginService() {
+		return new MicrosoftLoginServiceImpl();
+	}
+
+	protected MinecraftAccessTokenProvider createAccessTokenProvider() {
+		return new MinecraftAccessTokenProviderImpl();
+	}
+
+	private void displayDeviceCode(MicrosoftAuthService.DeviceCode deviceCode) {
+		getLogger().lifecycle(deviceCode.message());
+		getLogger().lifecycle("Verification URI: {}", deviceCode.verificationUri());
+		getLogger().lifecycle("User code: {}", deviceCode.userCode());
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/launch/auth/MicrosoftLogoutTask.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/auth/MicrosoftLogoutTask.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.launch.auth;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.UntrackedTask;
+
+/// Deletes the locally stored Microsoft account and its platform-protected encryption key.
+@UntrackedTask(because = "Microsoft logout must always check the global account state.")
+public abstract class MicrosoftLogoutTask extends MicrosoftAuthTask {
+	public MicrosoftLogoutTask() {
+		setDescription("Log out of the stored Microsoft account");
+	}
+
+	@TaskAction
+	public void logout() {
+		Path accountPath = getAccountPath();
+		boolean accountExisted = Files.exists(accountPath);
+		MicrosoftAccountStore accountStore;
+
+		try {
+			accountStore = createAccountStore(accountPath);
+		} catch (UnsupportedOperationException e) {
+			deleteAccountOnUnsupportedPlatform(accountPath, accountExisted);
+			return;
+		}
+
+		try {
+			accountStore.delete();
+
+			if (accountExisted) {
+				getLogger().lifecycle("Deleted the stored Microsoft account.");
+			} else {
+				getLogger().lifecycle("No Microsoft account was stored; removed any remaining secure-storage key.");
+			}
+		} catch (Exception e) {
+			throw new GradleException("Microsoft logout failed.", e);
+		}
+	}
+
+	private void deleteAccountOnUnsupportedPlatform(Path accountPath, boolean accountExisted) {
+		try {
+			Files.deleteIfExists(accountPath);
+		} catch (IOException | SecurityException e) {
+			throw new GradleException("Microsoft logout failed.", e);
+		}
+
+		if (accountExisted) {
+			getLogger().lifecycle("Deleted the stored Microsoft account. Secure platform storage is not supported on this operating system.");
+		} else {
+			getLogger().lifecycle("No Microsoft account is stored; skipping logout.");
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/launch/auth/MinecraftAccessTokenProvider.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/auth/MinecraftAccessTokenProvider.java
@@ -26,12 +26,14 @@ package net.fabricmc.loom.task.launch.auth;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 /// Obtains a fresh Minecraft access token immediately before the game is launched.
 public interface MinecraftAccessTokenProvider {
 	/// Refreshes the stored Microsoft session and exchanges it for a Minecraft access token.
-	/// The returned Microsoft refresh token must replace the previously stored value.
-	AccessToken getAccessToken(String clientId, String refreshToken) throws IOException;
+	/// The consumer is called with the replacement Microsoft refresh token immediately after it is
+	/// issued, before the Xbox and Minecraft exchanges are attempted.
+	AccessToken getAccessToken(String clientId, String refreshToken, Consumer<String> refreshTokenConsumer) throws IOException;
 
 	record AccessToken(String accessToken, String refreshToken, int expiresIn) {
 		public AccessToken {

--- a/src/main/java/net/fabricmc/loom/task/launch/auth/MinecraftAccessTokenProvider.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/auth/MinecraftAccessTokenProvider.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.launch.auth;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/// Obtains a fresh Minecraft access token immediately before the game is launched.
+public interface MinecraftAccessTokenProvider {
+	/// Refreshes the stored Microsoft session and exchanges it for a Minecraft access token.
+	/// The returned Microsoft refresh token must replace the previously stored value.
+	AccessToken getAccessToken(String clientId, String refreshToken) throws IOException;
+
+	record AccessToken(String accessToken, String refreshToken, int expiresIn) {
+		public AccessToken {
+			Objects.requireNonNull(accessToken, "accessToken");
+			Objects.requireNonNull(refreshToken, "refreshToken");
+
+			if (expiresIn <= 0) {
+				throw new IllegalArgumentException("expiresIn must be positive");
+			}
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/launch/auth/MinecraftAccessTokenProviderImpl.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/auth/MinecraftAccessTokenProviderImpl.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.launch.auth;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public final class MinecraftAccessTokenProviderImpl implements MinecraftAccessTokenProvider {
+	private final MicrosoftAuthService authService;
+
+	public MinecraftAccessTokenProviderImpl() {
+		this(new MicrosoftAuthServiceImpl());
+	}
+
+	public MinecraftAccessTokenProviderImpl(MicrosoftAuthService authService) {
+		this.authService = Objects.requireNonNull(authService, "authService");
+	}
+
+	@Override
+	public AccessToken getAccessToken(String clientId, String refreshToken) throws IOException {
+		MicrosoftAuthService.MicrosoftToken.Success microsoftToken = authService.refreshMicrosoftToken(clientId, refreshToken);
+		MinecraftAuthFlow.Result minecraft = MinecraftAuthFlow.authenticate(authService, microsoftToken.accessToken());
+		return new AccessToken(minecraft.token().accessToken(), microsoftToken.refreshToken(), minecraft.token().expiresIn());
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/launch/auth/MinecraftAuthFlow.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/auth/MinecraftAuthFlow.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.task.launch.auth;
+
+import java.io.IOException;
+
+final class MinecraftAuthFlow {
+	private MinecraftAuthFlow() {
+	}
+
+	static Result authenticate(MicrosoftAuthService authService, String microsoftAccessToken) throws IOException {
+		MicrosoftAuthService.XboxToken xboxUserToken = authService.authenticateXboxUser(microsoftAccessToken);
+		MicrosoftAuthService.XboxToken xstsToken = authService.authorizeMinecraftServices(xboxUserToken);
+		MicrosoftAuthService.MinecraftToken minecraftToken = authService.loginToMinecraft(xstsToken.userHash(), xstsToken.token());
+		MicrosoftAuthService.MinecraftEntitlements entitlements = authService.fetchMinecraftEntitlements(minecraftToken.accessToken());
+
+		if (!entitlements.canPlayMinecraft()) {
+			throw new IOException("The Microsoft account is not entitled to play Minecraft");
+		}
+
+		return new Result(minecraftToken, entitlements);
+	}
+
+	record Result(MicrosoftAuthService.MinecraftToken token, MicrosoftAuthService.MinecraftEntitlements entitlements) {
+	}
+}

--- a/src/main/java/net/fabricmc/loom/task/launch/auth/README.md
+++ b/src/main/java/net/fabricmc/loom/task/launch/auth/README.md
@@ -1,6 +1,22 @@
-# Microsoft authentication client ID
+# Microsoft authentication
+
+Set the empty `net.fabricmc.loom.util.Constants.MICROSOFT_CLIENT_ID` placeholder to the application
+ID used for Microsoft authentication.
+
+To create an ID:
 
 1. Open [Microsoft Entra](https://entra.microsoft.com/) and go to **Identity > Applications > App registrations**.
 2. Create a registration that supports personal Microsoft accounts.
 3. Under **Authentication > Advanced settings**, enable **Allow public client flows**.
 4. Copy the **Application (client) ID** from the application's overview page.
+
+Run `microsoftLogin` once to sign in. Loom stores the encrypted account in
+`<GRADLE_USER_HOME>/caches/fabric-loom/microsoft-auth.json`, so it can be reused by every project.
+The `runClient` task refreshes the account and passes a Minecraft access token to the game.
+If authentication fails, the game still starts without an authenticated account.
+
+Run `microsoftLogout` to delete the locally stored account and its platform-protected key.
+Each Gradle user home has a separate platform key, so logging out does not affect credentials
+stored under another Gradle user home. Logout is local-only because this personal-account flow
+has no supported per-token revocation endpoint; see Microsoft's
+[refresh-token documentation](https://learn.microsoft.com/en-us/entra/identity-platform/refresh-tokens).

--- a/src/main/java/net/fabricmc/loom/task/launch/auth/README.md
+++ b/src/main/java/net/fabricmc/loom/task/launch/auth/README.md
@@ -1,0 +1,6 @@
+# Microsoft authentication client ID
+
+1. Open [Microsoft Entra](https://entra.microsoft.com/) and go to **Identity > Applications > App registrations**.
+2. Create a registration that supports personal Microsoft accounts.
+3. Under **Authentication > Advanced settings**, enable **Allow public client flows**.
+4. Copy the **Application (client) ID** from the application's overview page.

--- a/src/main/java/net/fabricmc/loom/task/launch/auth/package-info.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/auth/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@NullMarked
+package net.fabricmc.loom.task.launch.auth;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -34,7 +34,7 @@ public class Constants {
 	public static final String EXPERIMENTAL_VERSIONS = "https://maven.fabricmc.net/net/minecraft/experimental_versions.json";
 	public static final String FABRIC_REPOSITORY = "https://maven.fabricmc.net/";
 	public static final String DLI_ENTRYPOINT = "net.fabricmc.devlaunchinjector.Main";
-	public static final String MICROSOFT_CLIENT_ID = "";
+	public static final String MICROSOFT_CLIENT_ID = "f8ebf47c-dffd-4ee4-b27e-c293f3a887a8";
 
 	public static final int ASM_VERSION = Opcodes.ASM9;
 	public static final String RELEASE_TIME_1_21_11_UNOBFUSCATED_SNAPSHOTS = "2025-11-01T00:00:00+00:00";

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -34,6 +34,7 @@ public class Constants {
 	public static final String EXPERIMENTAL_VERSIONS = "https://maven.fabricmc.net/net/minecraft/experimental_versions.json";
 	public static final String FABRIC_REPOSITORY = "https://maven.fabricmc.net/";
 	public static final String DLI_ENTRYPOINT = "net.fabricmc.devlaunchinjector.Main";
+	public static final String MICROSOFT_CLIENT_ID = "";
 
 	public static final int ASM_VERSION = Opcodes.ASM9;
 	public static final String RELEASE_TIME_1_21_11_UNOBFUSCATED_SNAPSHOTS = "2025-11-01T00:00:00+00:00";

--- a/src/main/java/net/fabricmc/loom/util/EncryptedStringStore.java
+++ b/src/main/java/net/fabricmc/loom/util/EncryptedStringStore.java
@@ -26,12 +26,17 @@ package net.fabricmc.loom.util;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 import java.util.Base64;
+import java.util.EnumSet;
 import java.util.Objects;
+import java.util.Set;
 
 import javax.crypto.AEADBadTagException;
 import javax.crypto.Cipher;
@@ -56,6 +61,7 @@ public final class EncryptedStringStore {
 	private static final int GCM_TAG_BITS = 128;
 	private static final int INITIALIZATION_VECTOR_BYTES = 12;
 	private static final byte[] AAD = "fabric-loom-encrypted-string-v1".getBytes(StandardCharsets.UTF_8);
+	private static final Set<PosixFilePermission> OWNER_ONLY_PERMISSIONS = EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE);
 	private static final Gson GSON = new Gson();
 
 	private final EncryptionKeyStore keyStore;
@@ -96,10 +102,26 @@ public final class EncryptedStringStore {
 					encoder.encodeToString(initializationVector),
 					encoder.encodeToString(ciphertext)
 			);
-			Files.writeString(path, GSON.toJson(encrypted));
+			writeFile(path, GSON.toJson(encrypted));
 		} catch (GeneralSecurityException e) {
 			throw new IOException("Failed to encrypt string", e);
 		}
+	}
+
+	private static void writeFile(Path path, String value) throws IOException {
+		try {
+			try {
+				Files.createFile(path, PosixFilePermissions.asFileAttribute(OWNER_ONLY_PERMISSIONS));
+			} catch (FileAlreadyExistsException ignored) {
+				// Permissions are updated below.
+			}
+
+			Files.setPosixFilePermissions(path, OWNER_ONLY_PERMISSIONS);
+		} catch (UnsupportedOperationException ignored) {
+			// POSIX permissions are not supported on this filesystem.
+		}
+
+		Files.writeString(path, value);
 	}
 
 	public String read(Path path) throws IOException, LoomNativePlatformException {

--- a/src/main/java/net/fabricmc/loom/util/EncryptedStringStore.java
+++ b/src/main/java/net/fabricmc/loom/util/EncryptedStringStore.java
@@ -1,0 +1,202 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Objects;
+
+import javax.crypto.AEADBadTagException;
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import net.fabricmc.loom.util.nativeplatform.EncryptionKeyStore;
+import net.fabricmc.loom.util.nativeplatform.LoomNativePlatformException;
+
+/// Reads and writes a UTF-8 string encrypted with a platform-protected Java encryption key.
+///
+/// Encryption uses the standard Java Cryptography implementation of AES-256-GCM.
+public final class EncryptedStringStore {
+	private static final int VERSION = 1;
+	private static final int AES_KEY_BITS = 256;
+	private static final int GCM_TAG_BITS = 128;
+	private static final int INITIALIZATION_VECTOR_BYTES = 12;
+	private static final byte[] AAD = "fabric-loom-encrypted-string-v1".getBytes(StandardCharsets.UTF_8);
+	private static final Gson GSON = new Gson();
+
+	private final EncryptionKeyStore keyStore;
+	private final SecureRandom secureRandom;
+
+	public EncryptedStringStore(EncryptionKeyStore keyStore) {
+		this(keyStore, new SecureRandom());
+	}
+
+	EncryptedStringStore(EncryptionKeyStore keyStore, SecureRandom secureRandom) {
+		this.keyStore = Objects.requireNonNull(keyStore, "keyStore");
+		this.secureRandom = Objects.requireNonNull(secureRandom, "secureRandom");
+	}
+
+	public void write(Path path, String value) throws IOException, LoomNativePlatformException {
+		Objects.requireNonNull(path, "path");
+		Objects.requireNonNull(value, "value");
+		byte[] plaintext = value.getBytes(StandardCharsets.UTF_8);
+
+		try {
+			KeyGenerator generator = KeyGenerator.getInstance("AES");
+			generator.init(AES_KEY_BITS, secureRandom);
+			SecretKey key = generator.generateKey();
+			EncryptionKeyStore.StoredKey storedKey = keyStore.store(key);
+
+			if (!"AES".equalsIgnoreCase(storedKey.algorithm())) {
+				throw new IOException("Encryption key store returned an unsupported algorithm: " + storedKey.algorithm());
+			}
+
+			byte[] initializationVector = new byte[INITIALIZATION_VECTOR_BYTES];
+			secureRandom.nextBytes(initializationVector);
+			Cipher cipher = createCipher(Cipher.ENCRYPT_MODE, key, initializationVector);
+			byte[] ciphertext = cipher.doFinal(plaintext);
+			Base64.Encoder encoder = Base64.getEncoder();
+			EncryptedValue encrypted = new EncryptedValue(
+					VERSION,
+					encoder.encodeToString(storedKey.data()),
+					encoder.encodeToString(initializationVector),
+					encoder.encodeToString(ciphertext)
+			);
+			Files.writeString(path, GSON.toJson(encrypted));
+		} catch (GeneralSecurityException e) {
+			throw new IOException("Failed to encrypt string", e);
+		}
+	}
+
+	public String read(Path path) throws IOException, LoomNativePlatformException {
+		Objects.requireNonNull(path, "path");
+		EncryptedValue encrypted = parse(readFile(path));
+		Base64.Decoder decoder = Base64.getDecoder();
+		byte[] wrappedKey;
+		byte[] initializationVector;
+		byte[] ciphertext;
+
+		try {
+			wrappedKey = decoder.decode(encrypted.wrappedKey());
+			initializationVector = decoder.decode(encrypted.initializationVector());
+			ciphertext = decoder.decode(encrypted.ciphertext());
+		} catch (IllegalArgumentException e) {
+			throw new IOException("Encrypted string file contains invalid Base64", e);
+		}
+
+		if (wrappedKey.length == 0 || initializationVector.length != INITIALIZATION_VECTOR_BYTES || ciphertext.length < GCM_TAG_BITS / Byte.SIZE) {
+			throw new IOException("Encrypted string file contains invalid values");
+		}
+
+		SecretKey key = keyStore.read(new EncryptionKeyStore.StoredKey("AES", wrappedKey));
+
+		if (!"AES".equalsIgnoreCase(key.getAlgorithm())) {
+			throw new IOException("Encryption key store returned an unsupported algorithm: " + key.getAlgorithm());
+		}
+
+		try {
+			Cipher cipher = createCipher(Cipher.DECRYPT_MODE, key, initializationVector);
+			byte[] plaintext = cipher.doFinal(ciphertext);
+			return new String(plaintext, StandardCharsets.UTF_8);
+		} catch (AEADBadTagException e) {
+			throw new IOException("Encrypted string authentication failed", e);
+		} catch (GeneralSecurityException e) {
+			throw new IOException("Failed to decrypt string", e);
+		}
+	}
+
+	private static Cipher createCipher(int mode, SecretKey key, byte[] initializationVector) throws GeneralSecurityException {
+		Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+		cipher.init(mode, key, new GCMParameterSpec(GCM_TAG_BITS, initializationVector));
+		cipher.updateAAD(AAD);
+		return cipher;
+	}
+
+	private static EncryptedValue parse(byte[] file) throws IOException {
+		JsonObject object;
+
+		try {
+			JsonElement element = JsonParser.parseString(new String(file, StandardCharsets.UTF_8));
+
+			if (!element.isJsonObject()) {
+				throw new IllegalStateException("Encrypted string file must contain a JSON object");
+			}
+
+			object = element.getAsJsonObject();
+		} catch (RuntimeException e) {
+			throw new IOException("Invalid encrypted string file", e);
+		}
+
+		int version = parseVersion(object);
+
+		if (version != VERSION) {
+			throw new IOException("Unsupported encrypted string file version: " + version);
+		}
+
+		try {
+			return GSON.fromJson(object, EncryptedValue.class);
+		} catch (RuntimeException e) {
+			throw new IOException("Invalid encrypted string file", e);
+		}
+	}
+
+	private static int parseVersion(JsonObject object) throws IOException {
+		JsonElement version = object.get("version");
+
+		if (version == null || !version.isJsonPrimitive() || !version.getAsJsonPrimitive().isNumber()) {
+			throw new IOException("Invalid encrypted string file version");
+		}
+
+		try {
+			return Integer.parseInt(version.getAsString());
+		} catch (NumberFormatException e) {
+			throw new IOException("Invalid encrypted string file version", e);
+		}
+	}
+
+	private static byte[] readFile(Path path) throws IOException {
+		return Files.readAllBytes(path);
+	}
+
+	private record EncryptedValue(int version, String wrappedKey, String initializationVector, String ciphertext) {
+		private EncryptedValue {
+			Objects.requireNonNull(wrappedKey, "wrappedKey");
+			Objects.requireNonNull(initializationVector, "initializationVector");
+			Objects.requireNonNull(ciphertext, "ciphertext");
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/nativeplatform/EncryptionKeyStore.java
+++ b/src/main/java/net/fabricmc/loom/util/nativeplatform/EncryptionKeyStore.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util.nativeplatform;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import javax.crypto.SecretKey;
+
+/// Stores a Java encryption key using protection supplied by the host operating system.
+///
+/// The returned [StoredKey] is safe to persist, but can only be read while the corresponding
+/// platform key remains available. Encryption of application data remains independent of the
+/// platform because [#read(StoredKey)] returns a standard [SecretKey].
+public interface EncryptionKeyStore {
+	StoredKey store(SecretKey key) throws LoomNativePlatformException;
+
+	SecretKey read(StoredKey key) throws LoomNativePlatformException;
+
+	/// Deletes the platform key. Any values returned by [#store(SecretKey)] become unreadable.
+	void delete() throws LoomNativePlatformException;
+
+	/// Controls whether the platform is allowed to require interactive user consent.
+	enum UserInteraction {
+		REQUIRED,
+		DISABLED
+	}
+
+	record StoredKey(String algorithm, byte[] data) {
+		public StoredKey {
+			Objects.requireNonNull(algorithm, "algorithm");
+			Objects.requireNonNull(data, "data");
+
+			if (algorithm.isBlank()) {
+				throw new IllegalArgumentException("algorithm must not be blank");
+			}
+
+			if (data.length == 0) {
+				throw new IllegalArgumentException("data must not be empty");
+			}
+
+			data = data.clone();
+		}
+
+		@Override
+		public byte[] data() {
+			return data.clone();
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			return this == obj || obj instanceof StoredKey other
+					&& algorithm.equals(other.algorithm)
+					&& Arrays.equals(data, other.data);
+		}
+
+		@Override
+		public int hashCode() {
+			return 31 * algorithm.hashCode() + Arrays.hashCode(data);
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/nativeplatform/EncryptionKeyStore.java
+++ b/src/main/java/net/fabricmc/loom/util/nativeplatform/EncryptionKeyStore.java
@@ -35,6 +35,9 @@ import javax.crypto.SecretKey;
 /// platform key remains available. Encryption of application data remains independent of the
 /// platform because [#read(StoredKey)] returns a standard [SecretKey].
 public interface EncryptionKeyStore {
+	/// Prepares and verifies the platform key before credentials are acquired.
+	void prepare() throws LoomNativePlatformException;
+
 	StoredKey store(SecretKey key) throws LoomNativePlatformException;
 
 	SecretKey read(StoredKey key) throws LoomNativePlatformException;

--- a/src/main/java/net/fabricmc/loom/util/nativeplatform/EncryptionKeyStore.java
+++ b/src/main/java/net/fabricmc/loom/util/nativeplatform/EncryptionKeyStore.java
@@ -28,13 +28,50 @@ import java.util.Arrays;
 import java.util.Objects;
 
 import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 
-/// Stores a Java encryption key using protection supplied by the host operating system.
+/// Stores a Java encryption key for use by encrypted application data.
 ///
-/// The returned [StoredKey] is safe to persist, but can only be read while the corresponding
-/// platform key remains available. Encryption of application data remains independent of the
-/// platform because [#read(StoredKey)] returns a standard [SecretKey].
+/// Native implementations protect the returned [StoredKey] with facilities supplied by the host
+/// operating system. [#FALLBACK] stores the encoded key directly and relies on the permissions of
+/// the file containing it. It prevents casual plaintext disclosure, but does not protect against an
+/// attacker that can read that file.
+///
+/// Encryption of application data remains independent of the implementation because
+/// [#read(StoredKey)] returns a standard [SecretKey].
 public interface EncryptionKeyStore {
+	/// A portable fallback for platforms without a native secure-storage implementation.
+	///
+	/// The encoded key is stored directly in [StoredKey#data()], so callers must restrict access to
+	/// the file containing the stored key.
+	EncryptionKeyStore FALLBACK = new EncryptionKeyStore() {
+		@Override
+		public void prepare() {
+		}
+
+		@Override
+		public StoredKey store(SecretKey key) {
+			Objects.requireNonNull(key, "key");
+			byte[] encoded = key.getEncoded();
+
+			if (encoded == null || encoded.length == 0) {
+				throw new IllegalArgumentException("key must be encodable");
+			}
+
+			return new StoredKey(key.getAlgorithm(), encoded);
+		}
+
+		@Override
+		public SecretKey read(StoredKey key) {
+			Objects.requireNonNull(key, "key");
+			return new SecretKeySpec(key.data(), key.algorithm());
+		}
+
+		@Override
+		public void delete() {
+		}
+	};
+
 	/// Prepares and verifies the platform key before credentials are acquired.
 	void prepare() throws LoomNativePlatformException;
 

--- a/src/main/java/net/fabricmc/loom/util/nativeplatform/EncryptionKeyStoreFactory.java
+++ b/src/main/java/net/fabricmc/loom/util/nativeplatform/EncryptionKeyStoreFactory.java
@@ -48,7 +48,7 @@ public final class EncryptionKeyStoreFactory {
 		return switch (Platform.CURRENT.getOperatingSystem()) {
 		case WINDOWS -> new WindowsEncryptionKeyStore(keyName, userInteraction);
 		case MAC_OS -> new MacOSEncryptionKeyStore(keyName, userInteraction);
-		case LINUX -> throw unsupportedPlatform();
+		case LINUX -> EncryptionKeyStore.FALLBACK;
 		};
 	}
 
@@ -62,11 +62,5 @@ public final class EncryptionKeyStoreFactory {
 		}
 
 		return KEY_NAME_PREFIX + Checksum.of(normalizedPath).sha256().hex();
-	}
-
-	private static UnsupportedOperationException unsupportedPlatform() {
-		return new UnsupportedOperationException(
-				"Microsoft authentication secure storage is not supported on " + Platform.CURRENT.getOperatingSystem()
-		);
 	}
 }

--- a/src/main/java/net/fabricmc/loom/util/nativeplatform/EncryptionKeyStoreFactory.java
+++ b/src/main/java/net/fabricmc/loom/util/nativeplatform/EncryptionKeyStoreFactory.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util.nativeplatform;
+
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Objects;
+
+import net.fabricmc.loom.util.Checksum;
+import net.fabricmc.loom.util.Platform;
+
+public final class EncryptionKeyStoreFactory {
+	private static final String KEY_NAME_PREFIX = "FabricLoomMicrosoftTokenEncryptionKey-";
+
+	private EncryptionKeyStoreFactory() {
+	}
+
+	public static EncryptionKeyStore create(Path encryptedFile) {
+		return create(keyNameFor(encryptedFile), EncryptionKeyStore.UserInteraction.REQUIRED);
+	}
+
+	public static EncryptionKeyStore create(String keyName, EncryptionKeyStore.UserInteraction userInteraction) {
+		Objects.requireNonNull(keyName, "keyName");
+		Objects.requireNonNull(userInteraction, "userInteraction");
+
+		return switch (Platform.CURRENT.getOperatingSystem()) {
+		case WINDOWS -> new WindowsEncryptionKeyStore(keyName, userInteraction);
+		case MAC_OS -> new MacOSEncryptionKeyStore(keyName, userInteraction);
+		case LINUX -> throw unsupportedPlatform();
+		};
+	}
+
+	/// Ensures that different Gradle home dirs use a different key.
+	public static String keyNameFor(Path encryptedFile) {
+		Objects.requireNonNull(encryptedFile, "encryptedFile");
+		String normalizedPath = encryptedFile.toAbsolutePath().normalize().toString();
+
+		if (Platform.CURRENT.getOperatingSystem().isWindows()) {
+			normalizedPath = normalizedPath.toLowerCase(Locale.ROOT);
+		}
+
+		return KEY_NAME_PREFIX + Checksum.of(normalizedPath).sha256().hex();
+	}
+
+	private static UnsupportedOperationException unsupportedPlatform() {
+		return new UnsupportedOperationException(
+				"Microsoft authentication secure storage is not supported on " + Platform.CURRENT.getOperatingSystem()
+		);
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/nativeplatform/MacOS.java
+++ b/src/main/java/net/fabricmc/loom/util/nativeplatform/MacOS.java
@@ -1,0 +1,354 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util.nativeplatform;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import org.jspecify.annotations.Nullable;
+
+import net.fabricmc.loom.util.nativeplatform.EncryptionKeyStore.UserInteraction;
+
+final class MacOS {
+	private static final int ERR_SEC_SUCCESS = 0;
+	private static final int ERR_SEC_DUPLICATE_ITEM = -25299;
+	private static final int ERR_SEC_ITEM_NOT_FOUND = -25300;
+	private static final int CF_STRING_ENCODING_UTF_8 = 0x08000100;
+	private static final String SERVICE = "net.fabricmc.fabric-loom.encryption-key";
+	private static final String ITEM_DESCRIPTION = "Fabric Loom encryption key";
+
+	private static final Linker LINKER = Linker.nativeLinker();
+	private static final SymbolLookup CORE_FOUNDATION = SymbolLookup.libraryLookup(
+			"/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation", Arena.global());
+	private static final SymbolLookup SECURITY = SymbolLookup.libraryLookup(
+			"/System/Library/Frameworks/Security.framework/Security", Arena.global());
+
+	private static final MethodHandle CF_ARRAY_CREATE = downcall(CORE_FOUNDATION, "CFArrayCreate",
+			FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.ADDRESS));
+	private static final MethodHandle CF_DATA_CREATE = downcall(CORE_FOUNDATION, "CFDataCreate",
+			FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
+	private static final MethodHandle CF_DATA_GET_BYTE_PTR = downcall(CORE_FOUNDATION, "CFDataGetBytePtr",
+			FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+	private static final MethodHandle CF_DATA_GET_LENGTH = downcall(CORE_FOUNDATION, "CFDataGetLength",
+			FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS));
+	private static final MethodHandle CF_DICTIONARY_CREATE_MUTABLE = downcall(CORE_FOUNDATION, "CFDictionaryCreateMutable",
+			FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+	private static final MethodHandle CF_DICTIONARY_SET_VALUE = downcall(CORE_FOUNDATION, "CFDictionarySetValue",
+			FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+	private static final MethodHandle CF_RELEASE = downcall(CORE_FOUNDATION, "CFRelease",
+			FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+	private static final MethodHandle CF_STRING_CREATE_WITH_C_STRING = downcall(CORE_FOUNDATION, "CFStringCreateWithCString",
+			FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_INT));
+	private static final MethodHandle CF_STRING_GET_C_STRING = downcall(CORE_FOUNDATION, "CFStringGetCString",
+			FunctionDescriptor.of(ValueLayout.JAVA_BYTE, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.JAVA_INT));
+	private static final MethodHandle CF_STRING_GET_LENGTH = downcall(CORE_FOUNDATION, "CFStringGetLength",
+			FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS));
+	private static final MethodHandle CF_STRING_GET_MAXIMUM_SIZE_FOR_ENCODING = downcall(CORE_FOUNDATION, "CFStringGetMaximumSizeForEncoding",
+			FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_INT));
+
+	private static final MethodHandle SEC_ACCESS_CREATE = downcall(SECURITY, "SecAccessCreate",
+			FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+	private static final MethodHandle SEC_COPY_ERROR_MESSAGE_STRING = downcall(SECURITY, "SecCopyErrorMessageString",
+			FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.JAVA_INT, ValueLayout.ADDRESS));
+	private static final MethodHandle SEC_ITEM_ADD = downcall(SECURITY, "SecItemAdd",
+			FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+	private static final MethodHandle SEC_ITEM_COPY_MATCHING = downcall(SECURITY, "SecItemCopyMatching",
+			FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+	private static final MethodHandle SEC_ITEM_DELETE = downcall(SECURITY, "SecItemDelete",
+			FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS));
+
+	private static final MemorySegment CF_BOOLEAN_TRUE = globalReference(CORE_FOUNDATION, "kCFBooleanTrue");
+	private static final MemorySegment CF_TYPE_ARRAY_CALLBACKS = symbol(CORE_FOUNDATION, "kCFTypeArrayCallBacks");
+	private static final MemorySegment CF_TYPE_DICTIONARY_KEY_CALLBACKS = symbol(CORE_FOUNDATION, "kCFTypeDictionaryKeyCallBacks");
+	private static final MemorySegment CF_TYPE_DICTIONARY_VALUE_CALLBACKS = symbol(CORE_FOUNDATION, "kCFTypeDictionaryValueCallBacks");
+	private static final MemorySegment SEC_ATTR_ACCESS = globalReference(SECURITY, "kSecAttrAccess");
+	private static final MemorySegment SEC_ATTR_ACCOUNT = globalReference(SECURITY, "kSecAttrAccount");
+	private static final MemorySegment SEC_ATTR_LABEL = globalReference(SECURITY, "kSecAttrLabel");
+	private static final MemorySegment SEC_ATTR_SERVICE = globalReference(SECURITY, "kSecAttrService");
+	private static final MemorySegment SEC_CLASS = globalReference(SECURITY, "kSecClass");
+	private static final MemorySegment SEC_CLASS_GENERIC_PASSWORD = globalReference(SECURITY, "kSecClassGenericPassword");
+	private static final MemorySegment SEC_MATCH_LIMIT = globalReference(SECURITY, "kSecMatchLimit");
+	private static final MemorySegment SEC_MATCH_LIMIT_ONE = globalReference(SECURITY, "kSecMatchLimitOne");
+	private static final MemorySegment SEC_RETURN_DATA = globalReference(SECURITY, "kSecReturnData");
+	private static final MemorySegment SEC_USE_AUTHENTICATION_UI = globalReference(SECURITY, "kSecUseAuthenticationUI");
+	private static final MemorySegment SEC_USE_AUTHENTICATION_UI_ALLOW = globalReference(SECURITY, "kSecUseAuthenticationUIAllow");
+	private static final MemorySegment SEC_USE_AUTHENTICATION_UI_FAIL = globalReference(SECURITY, "kSecUseAuthenticationUIFail");
+	private static final MemorySegment SEC_VALUE_DATA = globalReference(SECURITY, "kSecValueData");
+
+	private MacOS() {
+	}
+
+	static boolean add(String keyName, byte[] value, UserInteraction userInteraction) throws Throwable {
+		try (Arena arena = Arena.ofConfined();
+				CFObject service = createString(arena, SERVICE);
+				CFObject account = createString(arena, keyName);
+				CFObject label = createString(arena, ITEM_DESCRIPTION);
+				CFObject data = createData(arena, value);
+				CFObject access = createAccess(arena, label, userInteraction);
+				CFObject query = createDictionary()) {
+			put(query, SEC_CLASS, SEC_CLASS_GENERIC_PASSWORD);
+			put(query, SEC_ATTR_SERVICE, service.segment());
+			put(query, SEC_ATTR_ACCOUNT, account.segment());
+			put(query, SEC_ATTR_LABEL, label.segment());
+			put(query, SEC_ATTR_ACCESS, access.segment());
+			put(query, SEC_VALUE_DATA, data.segment());
+			putAuthenticationUi(query, userInteraction);
+
+			int status = (int) SEC_ITEM_ADD.invokeExact(query.segment(), MemorySegment.NULL);
+
+			if (status == ERR_SEC_DUPLICATE_ITEM) {
+				return false;
+			}
+
+			checkStatus("SecItemAdd", status);
+			return true;
+		}
+	}
+
+	static @Nullable byte[] read(String keyName, UserInteraction userInteraction) throws Throwable {
+		try (Arena arena = Arena.ofConfined();
+				CFObject service = createString(arena, SERVICE);
+				CFObject account = createString(arena, keyName);
+				CFObject query = createDictionary()) {
+			put(query, SEC_CLASS, SEC_CLASS_GENERIC_PASSWORD);
+			put(query, SEC_ATTR_SERVICE, service.segment());
+			put(query, SEC_ATTR_ACCOUNT, account.segment());
+			put(query, SEC_MATCH_LIMIT, SEC_MATCH_LIMIT_ONE);
+			put(query, SEC_RETURN_DATA, CF_BOOLEAN_TRUE);
+			putAuthenticationUi(query, userInteraction);
+
+			MemorySegment result = arena.allocate(ValueLayout.ADDRESS);
+			int status = (int) SEC_ITEM_COPY_MATCHING.invokeExact(query.segment(), result);
+
+			if (status == ERR_SEC_ITEM_NOT_FOUND) {
+				return null;
+			}
+
+			checkStatus("SecItemCopyMatching", status);
+			MemorySegment data = result.get(ValueLayout.ADDRESS, 0);
+
+			if (data.equals(MemorySegment.NULL)) {
+				throw new LoomNativePlatformException("SecItemCopyMatching returned no Keychain data");
+			}
+
+			try (CFObject dataObject = new CFObject(data)) {
+				return readData(dataObject.segment());
+			}
+		}
+	}
+
+	static void delete(String keyName, UserInteraction userInteraction) throws Throwable {
+		try (Arena arena = Arena.ofConfined();
+				CFObject service = createString(arena, SERVICE);
+				CFObject account = createString(arena, keyName);
+				CFObject query = createDictionary()) {
+			put(query, SEC_CLASS, SEC_CLASS_GENERIC_PASSWORD);
+			put(query, SEC_ATTR_SERVICE, service.segment());
+			put(query, SEC_ATTR_ACCOUNT, account.segment());
+			putAuthenticationUi(query, userInteraction);
+
+			int status = (int) SEC_ITEM_DELETE.invokeExact(query.segment());
+
+			if (status != ERR_SEC_ITEM_NOT_FOUND) {
+				checkStatus("SecItemDelete", status);
+			}
+		}
+	}
+
+	private static CFObject createAccess(Arena arena, CFObject description, UserInteraction userInteraction) throws Throwable {
+		MemorySegment access = arena.allocate(ValueLayout.ADDRESS);
+		MemorySegment trustedApplications = MemorySegment.NULL;
+
+		if (userInteraction == UserInteraction.REQUIRED) {
+			try (CFObject emptyTrustedApplications = createEmptyArray()) {
+				int status = (int) SEC_ACCESS_CREATE.invokeExact(description.segment(), emptyTrustedApplications.segment(), access);
+				checkStatus("SecAccessCreate", status);
+			}
+		} else {
+			int status = (int) SEC_ACCESS_CREATE.invokeExact(description.segment(), trustedApplications, access);
+			checkStatus("SecAccessCreate", status);
+		}
+
+		MemorySegment result = access.get(ValueLayout.ADDRESS, 0);
+
+		if (result.equals(MemorySegment.NULL)) {
+			throw new LoomNativePlatformException("SecAccessCreate returned no Keychain access object");
+		}
+
+		return new CFObject(result);
+	}
+
+	private static CFObject createData(Arena arena, byte[] value) throws Throwable {
+		MemorySegment bytes = arena.allocate(value.length);
+		MemorySegment.copy(value, 0, bytes, ValueLayout.JAVA_BYTE, 0, value.length);
+		MemorySegment data = (MemorySegment) CF_DATA_CREATE.invokeExact(MemorySegment.NULL, bytes, (long) value.length);
+		return requireObject("CFDataCreate", data);
+	}
+
+	private static CFObject createDictionary() throws Throwable {
+		MemorySegment dictionary = (MemorySegment) CF_DICTIONARY_CREATE_MUTABLE.invokeExact(
+				MemorySegment.NULL, 0L, CF_TYPE_DICTIONARY_KEY_CALLBACKS, CF_TYPE_DICTIONARY_VALUE_CALLBACKS);
+		return requireObject("CFDictionaryCreateMutable", dictionary);
+	}
+
+	private static CFObject createEmptyArray() throws Throwable {
+		MemorySegment array = (MemorySegment) CF_ARRAY_CREATE.invokeExact(
+				MemorySegment.NULL, MemorySegment.NULL, 0L, CF_TYPE_ARRAY_CALLBACKS);
+		return requireObject("CFArrayCreate", array);
+	}
+
+	private static CFObject createString(Arena arena, String value) throws Throwable {
+		byte[] bytes = (value + '\0').getBytes(StandardCharsets.UTF_8);
+		MemorySegment cString = arena.allocate(bytes.length);
+		MemorySegment.copy(bytes, 0, cString, ValueLayout.JAVA_BYTE, 0, bytes.length);
+		MemorySegment string = (MemorySegment) CF_STRING_CREATE_WITH_C_STRING.invokeExact(
+				MemorySegment.NULL, cString, CF_STRING_ENCODING_UTF_8);
+		return requireObject("CFStringCreateWithCString", string);
+	}
+
+	private static byte[] readData(MemorySegment data) throws Throwable {
+		long length = (long) CF_DATA_GET_LENGTH.invokeExact(data);
+
+		if (length < 0 || length > Integer.MAX_VALUE) {
+			throw new LoomNativePlatformException("Keychain data has invalid length: " + length);
+		}
+
+		MemorySegment bytes = (MemorySegment) CF_DATA_GET_BYTE_PTR.invokeExact(data);
+
+		if (length != 0 && bytes.equals(MemorySegment.NULL)) {
+			throw new LoomNativePlatformException("CFDataGetBytePtr returned no Keychain data");
+		}
+
+		return bytes.reinterpret(length).toArray(ValueLayout.JAVA_BYTE);
+	}
+
+	private static void put(CFObject dictionary, MemorySegment key, MemorySegment value) throws Throwable {
+		CF_DICTIONARY_SET_VALUE.invokeExact(dictionary.segment(), key, value);
+	}
+
+	private static void putAuthenticationUi(CFObject dictionary, UserInteraction userInteraction) throws Throwable {
+		put(dictionary, SEC_USE_AUTHENTICATION_UI, userInteraction == UserInteraction.REQUIRED
+				? SEC_USE_AUTHENTICATION_UI_ALLOW
+				: SEC_USE_AUTHENTICATION_UI_FAIL);
+	}
+
+	private static void checkStatus(String operation, int status) throws LoomNativePlatformException {
+		if (status != ERR_SEC_SUCCESS) {
+			throw new LoomNativePlatformException(formatStatus(operation, status));
+		}
+	}
+
+	private static String formatStatus(String operation, int status) {
+		String message = tryCopyErrorMessage(status);
+		String result = "%s failed: macOS Security error %d".formatted(operation, status);
+		return message == null || message.isBlank() ? result : result + ": " + message;
+	}
+
+	private static @Nullable String tryCopyErrorMessage(int status) {
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment string = (MemorySegment) SEC_COPY_ERROR_MESSAGE_STRING.invokeExact(status, MemorySegment.NULL);
+
+			if (string.equals(MemorySegment.NULL)) {
+				return null;
+			}
+
+			try (CFObject message = new CFObject(string)) {
+				long length = (long) CF_STRING_GET_LENGTH.invokeExact(message.segment());
+				long maximumSize = (long) CF_STRING_GET_MAXIMUM_SIZE_FOR_ENCODING.invokeExact(length, CF_STRING_ENCODING_UTF_8);
+
+				if (maximumSize < 0 || maximumSize == Long.MAX_VALUE) {
+					return null;
+				}
+
+				MemorySegment buffer = arena.allocate(maximumSize + 1);
+				byte copied = (byte) CF_STRING_GET_C_STRING.invokeExact(
+						message.segment(), buffer, maximumSize + 1, CF_STRING_ENCODING_UTF_8);
+				return copied == 0 ? null : buffer.getString(0);
+			}
+		} catch (Throwable e) {
+			return null;
+		}
+	}
+
+	private static CFObject requireObject(String operation, MemorySegment object) throws LoomNativePlatformException {
+		if (object.equals(MemorySegment.NULL)) {
+			throw new LoomNativePlatformException(operation + " returned null");
+		}
+
+		return new CFObject(object);
+	}
+
+	private static MemorySegment globalReference(SymbolLookup lookup, String name) {
+		return symbol(lookup, name).reinterpret(ValueLayout.ADDRESS.byteSize()).get(ValueLayout.ADDRESS, 0);
+	}
+
+	private static MemorySegment symbol(SymbolLookup lookup, String name) {
+		return lookup.find(name).orElseThrow(() -> new ExceptionInInitializerError("Could not find macOS symbol: " + name));
+	}
+
+	private static MethodHandle downcall(SymbolLookup lookup, String name, FunctionDescriptor descriptor) {
+		Optional<MemorySegment> symbol = lookup.find(name);
+
+		if (symbol.isEmpty()) {
+			throw new ExceptionInInitializerError("Could not find macOS symbol: " + name);
+		}
+
+		return LINKER.downcallHandle(symbol.get(), descriptor);
+	}
+
+	private static final class CFObject implements AutoCloseable {
+		private MemorySegment segment;
+
+		private CFObject(MemorySegment segment) {
+			this.segment = segment;
+		}
+
+		private MemorySegment segment() {
+			return segment;
+		}
+
+		@Override
+		public void close() {
+			if (segment.equals(MemorySegment.NULL)) {
+				return;
+			}
+
+			try {
+				CF_RELEASE.invokeExact(segment);
+			} catch (Throwable e) {
+				throw new AssertionError("CFRelease failed", e);
+			} finally {
+				segment = MemorySegment.NULL;
+			}
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/nativeplatform/MacOS.java
+++ b/src/main/java/net/fabricmc/loom/util/nativeplatform/MacOS.java
@@ -43,8 +43,6 @@ final class MacOS {
 	private static final int ERR_SEC_DUPLICATE_ITEM = -25299;
 	private static final int ERR_SEC_ITEM_NOT_FOUND = -25300;
 	private static final int CF_STRING_ENCODING_UTF_8 = 0x08000100;
-	private static final String SERVICE = "net.fabricmc.fabric-loom.encryption-key";
-	private static final String ITEM_DESCRIPTION = "Fabric Loom encryption key";
 
 	private static final Linker LINKER = Linker.nativeLinker();
 	private static final SymbolLookup CORE_FOUNDATION = SymbolLookup.libraryLookup(
@@ -107,11 +105,11 @@ final class MacOS {
 	private MacOS() {
 	}
 
-	static boolean add(String keyName, byte[] value, UserInteraction userInteraction) throws Throwable {
+	static boolean add(String serviceName, String accountName, String description, byte[] value, UserInteraction userInteraction) throws Throwable {
 		try (Arena arena = Arena.ofConfined();
-				CFObject service = createString(arena, SERVICE);
-				CFObject account = createString(arena, keyName);
-				CFObject label = createString(arena, ITEM_DESCRIPTION);
+				CFObject service = createString(arena, serviceName);
+				CFObject account = createString(arena, accountName);
+				CFObject label = createString(arena, description);
 				CFObject data = createData(arena, value);
 				CFObject access = createAccess(arena, label, userInteraction);
 				CFObject query = createDictionary()) {
@@ -134,10 +132,10 @@ final class MacOS {
 		}
 	}
 
-	static @Nullable byte[] read(String keyName, UserInteraction userInteraction) throws Throwable {
+	static @Nullable byte[] read(String serviceName, String accountName, UserInteraction userInteraction) throws Throwable {
 		try (Arena arena = Arena.ofConfined();
-				CFObject service = createString(arena, SERVICE);
-				CFObject account = createString(arena, keyName);
+				CFObject service = createString(arena, serviceName);
+				CFObject account = createString(arena, accountName);
 				CFObject query = createDictionary()) {
 			put(query, SEC_CLASS, SEC_CLASS_GENERIC_PASSWORD);
 			put(query, SEC_ATTR_SERVICE, service.segment());
@@ -166,10 +164,10 @@ final class MacOS {
 		}
 	}
 
-	static void delete(String keyName, UserInteraction userInteraction) throws Throwable {
+	static void delete(String serviceName, String accountName, UserInteraction userInteraction) throws Throwable {
 		try (Arena arena = Arena.ofConfined();
-				CFObject service = createString(arena, SERVICE);
-				CFObject account = createString(arena, keyName);
+				CFObject service = createString(arena, serviceName);
+				CFObject account = createString(arena, accountName);
 				CFObject query = createDictionary()) {
 			put(query, SEC_CLASS, SEC_CLASS_GENERIC_PASSWORD);
 			put(query, SEC_ATTR_SERVICE, service.segment());

--- a/src/main/java/net/fabricmc/loom/util/nativeplatform/MacOSEncryptionKeyStore.java
+++ b/src/main/java/net/fabricmc/loom/util/nativeplatform/MacOSEncryptionKeyStore.java
@@ -1,0 +1,205 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util.nativeplatform;
+
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Objects;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/// Protects encryption keys with an AES wrapping key stored in the macOS Keychain.
+///
+/// The default mode asks the user to approve Keychain access for the current Java process.
+/// [UserInteraction#DISABLED] exists for automated tests and forbids authentication UI.
+public final class MacOSEncryptionKeyStore implements EncryptionKeyStore {
+	public static final String DEFAULT_KEY_NAME = "FabricLoomMicrosoftTokenEncryptionKey";
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MacOSEncryptionKeyStore.class);
+	private static final int WRAPPING_KEY_BYTES = 32;
+	private static final int INITIALIZATION_VECTOR_BYTES = 12;
+	private static final int GCM_TAG_BITS = 128;
+
+	private final String keyName;
+	private final UserInteraction userInteraction;
+	private final SecureRandom secureRandom = new SecureRandom();
+	private byte @Nullable [] cachedWrappingKey;
+
+	public MacOSEncryptionKeyStore() {
+		this(DEFAULT_KEY_NAME, UserInteraction.REQUIRED);
+	}
+
+	public MacOSEncryptionKeyStore(String keyName, UserInteraction userInteraction) {
+		this.keyName = Objects.requireNonNull(keyName, "keyName");
+		this.userInteraction = Objects.requireNonNull(userInteraction, "userInteraction");
+
+		if (keyName.isBlank()) {
+			throw new IllegalArgumentException("keyName must not be blank");
+		}
+	}
+
+	@Override
+	public void prepare() throws LoomNativePlatformException {
+		try {
+			byte[] wrappingKey = readWrappingKey(true);
+			Arrays.fill(wrappingKey, (byte) 0);
+		} catch (LoomNativePlatformException e) {
+			String message = userInteraction == UserInteraction.REQUIRED
+					? "Could not initialize macOS Keychain secure storage. Approve access when prompted to store Microsoft login tokens."
+					: "Could not initialize macOS Keychain secure storage.";
+			throw new LoomNativePlatformException(message, e);
+		}
+	}
+
+	@Override
+	public StoredKey store(SecretKey key) throws LoomNativePlatformException {
+		Objects.requireNonNull(key, "key");
+		byte[] encoded = key.getEncoded();
+
+		if (encoded == null || encoded.length == 0) {
+			throw new IllegalArgumentException("key must be encodable");
+		}
+
+		byte[] wrappingKey = readWrappingKey(true);
+
+		try {
+			byte[] initializationVector = new byte[INITIALIZATION_VECTOR_BYTES];
+			secureRandom.nextBytes(initializationVector);
+			Cipher cipher = createCipher(Cipher.ENCRYPT_MODE, wrappingKey, initializationVector);
+			byte[] ciphertext = cipher.doFinal(encoded);
+			byte[] wrapped = Arrays.copyOf(initializationVector, initializationVector.length + ciphertext.length);
+			System.arraycopy(ciphertext, 0, wrapped, initializationVector.length, ciphertext.length);
+			return new StoredKey(key.getAlgorithm(), wrapped);
+		} catch (GeneralSecurityException e) {
+			LOGGER.error("Failed to protect an encryption key with the macOS Keychain", e);
+			throw new LoomNativePlatformException("Failed to protect an encryption key with the macOS Keychain", e);
+		} finally {
+			Arrays.fill(wrappingKey, (byte) 0);
+		}
+	}
+
+	@Override
+	public SecretKey read(StoredKey key) throws LoomNativePlatformException {
+		Objects.requireNonNull(key, "key");
+		byte[] wrapped = key.data();
+
+		if (wrapped.length <= INITIALIZATION_VECTOR_BYTES + GCM_TAG_BITS / Byte.SIZE) {
+			throw new LoomNativePlatformException("Invalid wrapped encryption key data");
+		}
+
+		byte[] wrappingKey = readWrappingKey(false);
+
+		try {
+			byte[] initializationVector = Arrays.copyOf(wrapped, INITIALIZATION_VECTOR_BYTES);
+			Cipher cipher = createCipher(Cipher.DECRYPT_MODE, wrappingKey, initializationVector);
+			byte[] encoded = cipher.doFinal(wrapped, INITIALIZATION_VECTOR_BYTES, wrapped.length - INITIALIZATION_VECTOR_BYTES);
+
+			try {
+				return new SecretKeySpec(encoded, key.algorithm());
+			} finally {
+				Arrays.fill(encoded, (byte) 0);
+			}
+		} catch (GeneralSecurityException e) {
+			LOGGER.error("Failed to read an encryption key with the macOS Keychain", e);
+			throw new LoomNativePlatformException("Failed to read an encryption key with the macOS Keychain", e);
+		} finally {
+			Arrays.fill(wrappingKey, (byte) 0);
+		}
+	}
+
+	@Override
+	public void delete() throws LoomNativePlatformException {
+		try {
+			MacOS.delete(keyName, userInteraction);
+		} catch (LoomNativePlatformException e) {
+			throw e;
+		} catch (Throwable e) {
+			LOGGER.error("Failed to delete the macOS Keychain key {}", keyName, e);
+			throw new LoomNativePlatformException("Failed to delete the macOS Keychain key " + keyName, e);
+		} finally {
+			clearCachedWrappingKey();
+		}
+	}
+
+	private synchronized byte[] readWrappingKey(boolean create) throws LoomNativePlatformException {
+		if (cachedWrappingKey != null) {
+			return cachedWrappingKey.clone();
+		}
+
+		try {
+			byte[] wrappingKey = MacOS.read(keyName, userInteraction);
+
+			if (wrappingKey == null && create) {
+				byte[] generated = new byte[WRAPPING_KEY_BYTES];
+				secureRandom.nextBytes(generated);
+
+				try {
+					MacOS.add(keyName, generated, userInteraction);
+				} finally {
+					Arrays.fill(generated, (byte) 0);
+				}
+
+				wrappingKey = MacOS.read(keyName, userInteraction);
+			}
+
+			if (wrappingKey == null) {
+				throw new LoomNativePlatformException("macOS Keychain key does not exist: " + keyName);
+			}
+
+			if (wrappingKey.length != WRAPPING_KEY_BYTES) {
+				Arrays.fill(wrappingKey, (byte) 0);
+				throw new LoomNativePlatformException("macOS Keychain key has an invalid length: " + keyName);
+			}
+
+			cachedWrappingKey = wrappingKey.clone();
+			return wrappingKey;
+		} catch (LoomNativePlatformException e) {
+			throw e;
+		} catch (Throwable e) {
+			throw new LoomNativePlatformException("Failed to access the macOS Keychain key " + keyName, e);
+		}
+	}
+
+	private synchronized void clearCachedWrappingKey() {
+		if (cachedWrappingKey != null) {
+			Arrays.fill(cachedWrappingKey, (byte) 0);
+			cachedWrappingKey = null;
+		}
+	}
+
+	private static Cipher createCipher(int mode, byte[] wrappingKey, byte[] initializationVector) throws GeneralSecurityException {
+		Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+		cipher.init(mode, new SecretKeySpec(wrappingKey, "AES"), new GCMParameterSpec(GCM_TAG_BITS, initializationVector));
+		return cipher;
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/nativeplatform/MacOSEncryptionKeyStore.java
+++ b/src/main/java/net/fabricmc/loom/util/nativeplatform/MacOSEncryptionKeyStore.java
@@ -49,6 +49,8 @@ public final class MacOSEncryptionKeyStore implements EncryptionKeyStore {
 	private static final int WRAPPING_KEY_BYTES = 32;
 	private static final int INITIALIZATION_VECTOR_BYTES = 12;
 	private static final int GCM_TAG_BITS = 128;
+	private static final String SERVICE = "net.fabricmc.fabric-loom.encryption-key";
+	private static final String ITEM_DESCRIPTION = "Fabric Loom encryption key";
 
 	private final String keyName;
 	private final UserInteraction userInteraction;
@@ -140,7 +142,7 @@ public final class MacOSEncryptionKeyStore implements EncryptionKeyStore {
 	@Override
 	public void delete() throws LoomNativePlatformException {
 		try {
-			MacOS.delete(keyName, userInteraction);
+			MacOS.delete(SERVICE, keyName, userInteraction);
 		} catch (LoomNativePlatformException e) {
 			throw e;
 		} catch (Throwable e) {
@@ -157,19 +159,19 @@ public final class MacOSEncryptionKeyStore implements EncryptionKeyStore {
 		}
 
 		try {
-			byte[] wrappingKey = MacOS.read(keyName, userInteraction);
+			byte[] wrappingKey = MacOS.read(SERVICE, keyName, userInteraction);
 
 			if (wrappingKey == null && create) {
 				byte[] generated = new byte[WRAPPING_KEY_BYTES];
 				secureRandom.nextBytes(generated);
 
 				try {
-					MacOS.add(keyName, generated, userInteraction);
+					MacOS.add(SERVICE, keyName, ITEM_DESCRIPTION, generated, userInteraction);
 				} finally {
 					Arrays.fill(generated, (byte) 0);
 				}
 
-				wrappingKey = MacOS.read(keyName, userInteraction);
+				wrappingKey = MacOS.read(SERVICE, keyName, userInteraction);
 			}
 
 			if (wrappingKey == null) {

--- a/src/main/java/net/fabricmc/loom/util/nativeplatform/Win32.java
+++ b/src/main/java/net/fabricmc/loom/util/nativeplatform/Win32.java
@@ -47,12 +47,25 @@ final class Win32 {
 	static final int FORMAT_MESSAGE_ALLOCATE_BUFFER = 0x00000100;
 	static final int FORMAT_MESSAGE_IGNORE_INSERTS = 0x00000200;
 	static final int FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000;
+	static final int NTE_EXISTS = 0x8009000F;
+	static final int NTE_BAD_KEYSET = 0x80090016;
+	static final int NCRYPT_ALLOW_DECRYPT_FLAG = 0x00000001;
+	static final int NCRYPT_UI_PROTECT_KEY_FLAG = 0x00000001;
+	static final int NCRYPT_PAD_OAEP_FLAG = 0x00000004;
+	static final int NCRYPT_SILENT_FLAG = 0x00000040;
 	static final int LANG_NEUTRAL = 0x0000;
 	static final int LANG_ENGLISH = 0x0009;
 	static final int SUBLANG_ENGLISH_US = 0x0001;
 	static final int SUBLANG_NEUTRAL = 0x0000;
 	static final int ENGLISH_US = makeLangId(LANG_ENGLISH, SUBLANG_ENGLISH_US);
 	static final int NEUTRAL_LANGUAGE = makeLangId(LANG_NEUTRAL, SUBLANG_NEUTRAL);
+	static final String MS_PLATFORM_CRYPTO_PROVIDER = "Microsoft Platform Crypto Provider";
+	static final String MS_KEY_STORAGE_PROVIDER = "Microsoft Software Key Storage Provider";
+	static final String NCRYPT_RSA_ALGORITHM = "RSA";
+	static final String BCRYPT_SHA256_ALGORITHM = "SHA256";
+	static final String NCRYPT_LENGTH_PROPERTY = "Length";
+	static final String NCRYPT_KEY_USAGE_PROPERTY = "Key Usage";
+	static final String NCRYPT_UI_POLICY_PROPERTY = "UI Policy";
 
 	static final ValueLayout.OfInt DWORD = ValueLayout.JAVA_INT;
 	static final ValueLayout.OfInt BOOL = ValueLayout.JAVA_INT;
@@ -77,11 +90,20 @@ final class Win32 {
 			DWORD.withName("TSSessionId"),
 			BOOL.withName("bRestartable")
 	).withName("RM_PROCESS_INFO");
+	static final MemoryLayout NCRYPT_UI_POLICY = MemoryLayout.structLayout(
+			DWORD.withName("dwVersion"),
+			DWORD.withName("dwFlags"),
+			ValueLayout.ADDRESS.withName("pszCreationTitle"),
+			ValueLayout.ADDRESS.withName("pszFriendlyName"),
+			ValueLayout.ADDRESS.withName("pszDescription")
+	).withName("NCRYPT_UI_POLICY");
+	static final MemoryLayout BCRYPT_OAEP_PADDING_INFO = createOaepPaddingInfoLayout();
 
 	private static final Linker LINKER = Linker.nativeLinker();
 	private static final SymbolLookup RSTRTMGR = SymbolLookup.libraryLookup("rstrtmgr", Arena.global());
 	private static final SymbolLookup KERNEL32 = SymbolLookup.libraryLookup("kernel32", Arena.global());
 	private static final SymbolLookup USER32 = SymbolLookup.libraryLookup("user32", Arena.global());
+	private static final SymbolLookup NCRYPT = SymbolLookup.libraryLookup("ncrypt", Arena.global());
 
 	private static final MethodHandle RM_START_SESSION = downcall(RSTRTMGR, "RmStartSession",
 			FunctionDescriptor.of(DWORD, ValueLayout.ADDRESS, DWORD, ValueLayout.ADDRESS));
@@ -117,6 +139,24 @@ final class Win32 {
 			FunctionDescriptor.of(DWORD, HWND));
 	private static final MethodHandle GET_WINDOW_TEXT_W = downcall(USER32, "GetWindowTextW",
 			FunctionDescriptor.of(DWORD, HWND, ValueLayout.ADDRESS, DWORD));
+	private static final MethodHandle NCRYPT_OPEN_STORAGE_PROVIDER = downcall(NCRYPT, "NCryptOpenStorageProvider",
+			FunctionDescriptor.of(DWORD, ValueLayout.ADDRESS, ValueLayout.ADDRESS, DWORD));
+	private static final MethodHandle NCRYPT_OPEN_KEY = downcall(NCRYPT, "NCryptOpenKey",
+			FunctionDescriptor.of(DWORD, HANDLE, ValueLayout.ADDRESS, ValueLayout.ADDRESS, DWORD, DWORD));
+	private static final MethodHandle NCRYPT_CREATE_PERSISTED_KEY = downcall(NCRYPT, "NCryptCreatePersistedKey",
+			FunctionDescriptor.of(DWORD, HANDLE, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS, DWORD, DWORD));
+	private static final MethodHandle NCRYPT_SET_PROPERTY = downcall(NCRYPT, "NCryptSetProperty",
+			FunctionDescriptor.of(DWORD, HANDLE, ValueLayout.ADDRESS, ValueLayout.ADDRESS, DWORD, DWORD));
+	private static final MethodHandle NCRYPT_FINALIZE_KEY = downcall(NCRYPT, "NCryptFinalizeKey",
+			FunctionDescriptor.of(DWORD, HANDLE, DWORD));
+	private static final MethodHandle NCRYPT_ENCRYPT = downcall(NCRYPT, "NCryptEncrypt",
+			FunctionDescriptor.of(DWORD, HANDLE, ValueLayout.ADDRESS, DWORD, ValueLayout.ADDRESS, ValueLayout.ADDRESS, DWORD, ValueLayout.ADDRESS, DWORD));
+	private static final MethodHandle NCRYPT_DECRYPT = downcall(NCRYPT, "NCryptDecrypt",
+			FunctionDescriptor.of(DWORD, HANDLE, ValueLayout.ADDRESS, DWORD, ValueLayout.ADDRESS, ValueLayout.ADDRESS, DWORD, ValueLayout.ADDRESS, DWORD));
+	private static final MethodHandle NCRYPT_FREE_OBJECT = downcall(NCRYPT, "NCryptFreeObject",
+			FunctionDescriptor.of(DWORD, HANDLE));
+	private static final MethodHandle NCRYPT_DELETE_KEY = downcall(NCRYPT, "NCryptDeleteKey",
+			FunctionDescriptor.of(DWORD, HANDLE, DWORD));
 
 	private Win32() {
 	}
@@ -224,6 +264,86 @@ final class Win32 {
 		return Optional.of(readWideString(buffer, copied));
 	}
 
+	static MemorySegment ncryptOpenStorageProvider(Arena arena, String providerName, int flags) throws Throwable {
+		MemorySegment providerPointer = arena.allocate(ValueLayout.ADDRESS);
+		MemorySegment providerNameString = allocateWideString(arena, providerName);
+		int result = (int) NCRYPT_OPEN_STORAGE_PROVIDER.invokeExact(providerPointer, providerNameString, flags);
+		checkNCrypt("NCryptOpenStorageProvider", result);
+		return providerPointer.get(ValueLayout.ADDRESS, 0);
+	}
+
+	static MemorySegment ncryptOpenKey(Arena arena, MemorySegment provider, String keyName, int flags) throws Throwable {
+		MemorySegment keyPointer = arena.allocate(ValueLayout.ADDRESS);
+		MemorySegment keyNameString = allocateWideString(arena, keyName);
+		int result = (int) NCRYPT_OPEN_KEY.invokeExact(provider, keyPointer, keyNameString, 0, flags);
+
+		if (result == NTE_BAD_KEYSET) {
+			return MemorySegment.NULL;
+		}
+
+		checkNCrypt("NCryptOpenKey", result);
+		return keyPointer.get(ValueLayout.ADDRESS, 0);
+	}
+
+	static MemorySegment ncryptCreatePersistedKey(Arena arena, MemorySegment provider, String keyName, int flags) throws Throwable {
+		MemorySegment keyPointer = arena.allocate(ValueLayout.ADDRESS);
+		MemorySegment algorithmString = allocateWideString(arena, NCRYPT_RSA_ALGORITHM);
+		MemorySegment keyNameString = allocateWideString(arena, keyName);
+		int result = (int) NCRYPT_CREATE_PERSISTED_KEY.invokeExact(provider, keyPointer, algorithmString, keyNameString, 0, flags);
+
+		if (result == NTE_EXISTS) {
+			return MemorySegment.NULL;
+		}
+
+		checkNCrypt("NCryptCreatePersistedKey", result);
+		return keyPointer.get(ValueLayout.ADDRESS, 0);
+	}
+
+	static void ncryptSetDwordProperty(Arena arena, MemorySegment key, String propertyName, int value) throws Throwable {
+		MemorySegment valueSegment = arena.allocate(DWORD);
+		valueSegment.set(DWORD, 0, value);
+		ncryptSetProperty(arena, key, propertyName, valueSegment);
+	}
+
+	static void ncryptSetUiPolicy(Arena arena, MemorySegment key, String creationTitle, String friendlyName, String description) throws Throwable {
+		MemorySegment policy = arena.allocate(NCRYPT_UI_POLICY);
+		policy.set(DWORD, NCRYPT_UI_POLICY.byteOffset(MemoryLayout.PathElement.groupElement("dwVersion")), 1);
+		policy.set(DWORD, NCRYPT_UI_POLICY.byteOffset(MemoryLayout.PathElement.groupElement("dwFlags")), NCRYPT_UI_PROTECT_KEY_FLAG);
+		policy.set(ValueLayout.ADDRESS, NCRYPT_UI_POLICY.byteOffset(MemoryLayout.PathElement.groupElement("pszCreationTitle")), allocateWideString(arena, creationTitle));
+		policy.set(ValueLayout.ADDRESS, NCRYPT_UI_POLICY.byteOffset(MemoryLayout.PathElement.groupElement("pszFriendlyName")), allocateWideString(arena, friendlyName));
+		policy.set(ValueLayout.ADDRESS, NCRYPT_UI_POLICY.byteOffset(MemoryLayout.PathElement.groupElement("pszDescription")), allocateWideString(arena, description));
+		ncryptSetProperty(arena, key, NCRYPT_UI_POLICY_PROPERTY, policy);
+	}
+
+	static void ncryptFinalizeKey(MemorySegment key, int flags) throws Throwable {
+		int result = (int) NCRYPT_FINALIZE_KEY.invokeExact(key, flags);
+		checkNCrypt("NCryptFinalizeKey", result);
+	}
+
+	static byte[] ncryptEncrypt(Arena arena, MemorySegment key, byte[] input) throws Throwable {
+		return ncryptCrypt(arena, NCRYPT_ENCRYPT, "NCryptEncrypt", key, input, 0);
+	}
+
+	static byte[] ncryptDecrypt(Arena arena, MemorySegment key, byte[] input, int flags) throws Throwable {
+		MemorySegment inputSegment = arena.allocate(input.length);
+		MemorySegment.copy(input, 0, inputSegment, ValueLayout.JAVA_BYTE, 0, input.length);
+		MemorySegment output = arena.allocate(input.length);
+		MemorySegment outputSize = arena.allocate(DWORD);
+		int result = (int) NCRYPT_DECRYPT.invokeExact(key, inputSegment, input.length, createOaepPaddingInfo(arena), output, input.length, outputSize, flags | NCRYPT_PAD_OAEP_FLAG);
+		checkNCrypt("NCryptDecrypt", result);
+		return output.asSlice(0, Integer.toUnsignedLong(outputSize.get(DWORD, 0))).toArray(ValueLayout.JAVA_BYTE);
+	}
+
+	static void ncryptFreeObject(MemorySegment object) throws Throwable {
+		int result = (int) NCRYPT_FREE_OBJECT.invokeExact(object);
+		checkNCrypt("NCryptFreeObject", result);
+	}
+
+	static void ncryptDeleteKey(MemorySegment key, int flags) throws Throwable {
+		int result = (int) NCRYPT_DELETE_KEY.invokeExact(key, flags);
+		checkNCrypt("NCryptDeleteKey", result);
+	}
+
 	static MemorySegment upcallStub(Object target, String methodName, FunctionDescriptor descriptor, Arena arena) {
 		try {
 			return LINKER.upcallStub(MethodHandles.lookup().findVirtual(target.getClass(), methodName, descriptor.toMethodType()).bindTo(target), descriptor, arena);
@@ -274,7 +394,43 @@ final class Win32 {
 		return (int) FORMAT_MESSAGE_W.invokeExact(flags, MemorySegment.NULL, errorCode, languageId, messagePointer, 0, MemorySegment.NULL);
 	}
 
+	private static void ncryptSetProperty(Arena arena, MemorySegment key, String propertyName, MemorySegment value) throws Throwable {
+		MemorySegment propertyNameString = allocateWideString(arena, propertyName);
+		int result = (int) NCRYPT_SET_PROPERTY.invokeExact(key, propertyNameString, value, Math.toIntExact(value.byteSize()), 0);
+		checkNCrypt("NCryptSetProperty(" + propertyName + ")", result);
+	}
+
+	private static byte[] ncryptCrypt(Arena arena, MethodHandle operation, String operationName, MemorySegment key, byte[] input, int flags) throws Throwable {
+		MemorySegment inputSegment = arena.allocate(input.length);
+		MemorySegment.copy(input, 0, inputSegment, ValueLayout.JAVA_BYTE, 0, input.length);
+		MemorySegment paddingInfo = createOaepPaddingInfo(arena);
+		MemorySegment outputSize = arena.allocate(DWORD);
+		int paddedFlags = flags | NCRYPT_PAD_OAEP_FLAG;
+		int result = (int) operation.invokeExact(key, inputSegment, input.length, paddingInfo, MemorySegment.NULL, 0, outputSize, paddedFlags);
+		checkNCrypt(operationName + "(size)", result);
+
+		int size = outputSize.get(DWORD, 0);
+		MemorySegment output = arena.allocate(size);
+		result = (int) operation.invokeExact(key, inputSegment, input.length, paddingInfo, output, size, outputSize, paddedFlags);
+		checkNCrypt(operationName, result);
+		return output.asSlice(0, Integer.toUnsignedLong(outputSize.get(DWORD, 0))).toArray(ValueLayout.JAVA_BYTE);
+	}
+
+	private static MemorySegment createOaepPaddingInfo(Arena arena) {
+		MemorySegment paddingInfo = arena.allocate(BCRYPT_OAEP_PADDING_INFO);
+		paddingInfo.set(ValueLayout.ADDRESS, BCRYPT_OAEP_PADDING_INFO.byteOffset(MemoryLayout.PathElement.groupElement("pszAlgId")), allocateWideString(arena, BCRYPT_SHA256_ALGORITHM));
+		paddingInfo.set(ValueLayout.ADDRESS, BCRYPT_OAEP_PADDING_INFO.byteOffset(MemoryLayout.PathElement.groupElement("pbLabel")), MemorySegment.NULL);
+		paddingInfo.set(DWORD, BCRYPT_OAEP_PADDING_INFO.byteOffset(MemoryLayout.PathElement.groupElement("cbLabel")), 0);
+		return paddingInfo;
+	}
+
 	private static void checkRestartManager(String operation, int error) throws LoomNativePlatformException {
+		if (error != ERROR_SUCCESS) {
+			throw LoomNativePlatformException.fromWin32Error(operation, error);
+		}
+	}
+
+	private static void checkNCrypt(String operation, int error) throws LoomNativePlatformException {
 		if (error != ERROR_SUCCESS) {
 			throw LoomNativePlatformException.fromWin32Error(operation, error);
 		}
@@ -286,6 +442,23 @@ final class Win32 {
 
 	private static int makeLangId(int primaryLanguage, int subLanguage) {
 		return (subLanguage << 10) | primaryLanguage;
+	}
+
+	private static MemoryLayout createOaepPaddingInfoLayout() {
+		if (ValueLayout.ADDRESS.byteSize() == Long.BYTES) {
+			return MemoryLayout.structLayout(
+					ValueLayout.ADDRESS.withName("pszAlgId"),
+					ValueLayout.ADDRESS.withName("pbLabel"),
+					DWORD.withName("cbLabel"),
+					MemoryLayout.paddingLayout(Integer.BYTES)
+			).withName("BCRYPT_OAEP_PADDING_INFO");
+		}
+
+		return MemoryLayout.structLayout(
+				ValueLayout.ADDRESS.withName("pszAlgId"),
+				ValueLayout.ADDRESS.withName("pbLabel"),
+				DWORD.withName("cbLabel")
+		).withName("BCRYPT_OAEP_PADDING_INFO");
 	}
 
 	private static MethodHandle downcall(SymbolLookup lookup, String name, FunctionDescriptor descriptor) {

--- a/src/main/java/net/fabricmc/loom/util/nativeplatform/WindowsEncryptionKeyStore.java
+++ b/src/main/java/net/fabricmc/loom/util/nativeplatform/WindowsEncryptionKeyStore.java
@@ -62,6 +62,18 @@ public final class WindowsEncryptionKeyStore implements EncryptionKeyStore {
 	}
 
 	@Override
+	public void prepare() throws LoomNativePlatformException {
+		try (Arena arena = Arena.ofConfined(); NativeHandle provider = openProvider(arena); NativeHandle wrappingKey = openOrCreateKey(arena, provider)) {
+			Win32.ncryptEncrypt(arena, wrappingKey.segment(), new byte[] {0});
+		} catch (Throwable e) {
+			String message = userInteraction == UserInteraction.REQUIRED
+					? "Could not initialize TPM-backed secure storage. Microsoft login requires an enabled and provisioned TPM on Windows, and setup must be approved when prompted."
+					: "Could not initialize Windows CNG secure storage.";
+			throw new LoomNativePlatformException(message, e);
+		}
+	}
+
+	@Override
 	public StoredKey store(SecretKey key) throws LoomNativePlatformException {
 		Objects.requireNonNull(key, "key");
 		byte[] encoded = key.getEncoded();

--- a/src/main/java/net/fabricmc/loom/util/nativeplatform/WindowsEncryptionKeyStore.java
+++ b/src/main/java/net/fabricmc/loom/util/nativeplatform/WindowsEncryptionKeyStore.java
@@ -1,0 +1,220 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.util.nativeplatform;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.Objects;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/// Protects encryption keys with a persisted Windows CNG RSA key.
+///
+/// The default mode stores the RSA key in the Microsoft Platform Crypto Provider and configures
+/// Windows to request user consent for private-key operations. [UserInteraction#DISABLED] exists
+/// for automated tests: it uses the Microsoft Software Key Storage Provider and forbids UI.
+public final class WindowsEncryptionKeyStore implements EncryptionKeyStore {
+	public static final String DEFAULT_KEY_NAME = "FabricLoomMicrosoftTokenEncryptionKey";
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(WindowsEncryptionKeyStore.class);
+	private static final int RSA_KEY_BITS = 2048;
+
+	private final String keyName;
+	private final UserInteraction userInteraction;
+
+	public WindowsEncryptionKeyStore() {
+		this(DEFAULT_KEY_NAME, UserInteraction.REQUIRED);
+	}
+
+	public WindowsEncryptionKeyStore(String keyName, UserInteraction userInteraction) {
+		this.keyName = Objects.requireNonNull(keyName, "keyName");
+		this.userInteraction = Objects.requireNonNull(userInteraction, "userInteraction");
+
+		if (keyName.isBlank()) {
+			throw new IllegalArgumentException("keyName must not be blank");
+		}
+	}
+
+	@Override
+	public StoredKey store(SecretKey key) throws LoomNativePlatformException {
+		Objects.requireNonNull(key, "key");
+		byte[] encoded = key.getEncoded();
+
+		if (encoded == null || encoded.length == 0) {
+			throw new IllegalArgumentException("key must be encodable");
+		}
+
+		try (Arena arena = Arena.ofConfined(); NativeHandle provider = openProvider(arena); NativeHandle wrappingKey = openOrCreateKey(arena, provider)) {
+			return new StoredKey(key.getAlgorithm(), Win32.ncryptEncrypt(arena, wrappingKey.segment(), encoded));
+		} catch (LoomNativePlatformException e) {
+			throw e;
+		} catch (Throwable e) {
+			LOGGER.error("Failed to protect an encryption key with Windows CNG", e);
+			throw new LoomNativePlatformException("Failed to protect an encryption key with Windows CNG", e);
+		}
+	}
+
+	@Override
+	public SecretKey read(StoredKey key) throws LoomNativePlatformException {
+		Objects.requireNonNull(key, "key");
+		byte[] encrypted = key.data();
+
+		try (Arena arena = Arena.ofConfined(); NativeHandle provider = openProvider(arena); NativeHandle wrappingKey = openExistingKey(arena, provider)) {
+			byte[] encoded = Win32.ncryptDecrypt(arena, wrappingKey.segment(), encrypted, nativeFlags());
+			return new SecretKeySpec(encoded, key.algorithm());
+		} catch (LoomNativePlatformException e) {
+			throw e;
+		} catch (Throwable e) {
+			LOGGER.error("Failed to read an encryption key with Windows CNG", e);
+			throw new LoomNativePlatformException("Failed to read an encryption key with Windows CNG", e);
+		}
+	}
+
+	@Override
+	public void delete() throws LoomNativePlatformException {
+		try (Arena arena = Arena.ofConfined(); NativeHandle provider = openProvider(arena)) {
+			MemorySegment key = Win32.ncryptOpenKey(arena, provider.segment(), keyName, nativeFlags());
+
+			if (key.equals(MemorySegment.NULL)) {
+				return;
+			}
+
+			try (NativeHandle keyHandle = new NativeHandle(key)) {
+				Win32.ncryptDeleteKey(keyHandle.segment(), nativeFlags());
+				keyHandle.release();
+			}
+		} catch (LoomNativePlatformException e) {
+			throw e;
+		} catch (Throwable e) {
+			LOGGER.error("Failed to delete the Windows CNG key {}", keyName, e);
+			throw new LoomNativePlatformException("Failed to delete the Windows CNG key " + keyName, e);
+		}
+	}
+
+	private NativeHandle openProvider(Arena arena) throws Throwable {
+		String provider = userInteraction == UserInteraction.REQUIRED
+				? Win32.MS_PLATFORM_CRYPTO_PROVIDER
+				: Win32.MS_KEY_STORAGE_PROVIDER;
+		return new NativeHandle(Win32.ncryptOpenStorageProvider(arena, provider, 0));
+	}
+
+	private NativeHandle openExistingKey(Arena arena, NativeHandle provider) throws Throwable {
+		MemorySegment key = Win32.ncryptOpenKey(arena, provider.segment(), keyName, nativeFlags());
+
+		if (key.equals(MemorySegment.NULL)) {
+			throw new LoomNativePlatformException("Windows CNG key does not exist: " + keyName);
+		}
+
+		return new NativeHandle(key);
+	}
+
+	private NativeHandle openOrCreateKey(Arena arena, NativeHandle provider) throws Throwable {
+		MemorySegment existing = Win32.ncryptOpenKey(arena, provider.segment(), keyName, nativeFlags());
+
+		if (!existing.equals(MemorySegment.NULL)) {
+			return new NativeHandle(existing);
+		}
+
+		MemorySegment created = Win32.ncryptCreatePersistedKey(arena, provider.segment(), keyName, 0);
+
+		if (created.equals(MemorySegment.NULL)) {
+			return openExistingKey(arena, provider);
+		}
+
+		NativeHandle key = new NativeHandle(created);
+
+		try {
+			Win32.ncryptSetDwordProperty(arena, key.segment(), Win32.NCRYPT_LENGTH_PROPERTY, RSA_KEY_BITS);
+			Win32.ncryptSetDwordProperty(arena, key.segment(), Win32.NCRYPT_KEY_USAGE_PROPERTY, Win32.NCRYPT_ALLOW_DECRYPT_FLAG);
+
+			if (userInteraction == UserInteraction.REQUIRED) {
+				Win32.ncryptSetUiPolicy(arena, key.segment(),
+						"Set up Fabric Loom secure token storage",
+						"Fabric Loom Microsoft login token key",
+						"Fabric Loom uses this key to securely store and access your Microsoft login tokens.");
+			}
+
+			Win32.ncryptFinalizeKey(key.segment(), nativeFlags());
+			return key;
+		} catch (Throwable e) {
+			discardCreatedKey(key, e);
+			throw e;
+		}
+	}
+
+	private void discardCreatedKey(NativeHandle key, Throwable originalException) {
+		try {
+			Win32.ncryptDeleteKey(key.segment(), nativeFlags());
+			key.release();
+		} catch (Throwable deleteException) {
+			originalException.addSuppressed(deleteException);
+
+			try {
+				key.close();
+			} catch (Throwable closeException) {
+				originalException.addSuppressed(closeException);
+			}
+		}
+	}
+
+	private int nativeFlags() {
+		return userInteraction == UserInteraction.DISABLED ? Win32.NCRYPT_SILENT_FLAG : 0;
+	}
+
+	private static final class NativeHandle implements AutoCloseable {
+		private MemorySegment segment;
+
+		private NativeHandle(MemorySegment segment) {
+			this.segment = segment;
+		}
+
+		private MemorySegment segment() {
+			return segment;
+		}
+
+		private void release() {
+			segment = MemorySegment.NULL;
+		}
+
+		@Override
+		public void close() throws LoomNativePlatformException {
+			if (!segment.equals(MemorySegment.NULL)) {
+				try {
+					Win32.ncryptFreeObject(segment);
+				} catch (LoomNativePlatformException e) {
+					throw e;
+				} catch (Throwable e) {
+					throw new LoomNativePlatformException("NCryptFreeObject failed", e);
+				} finally {
+					segment = MemorySegment.NULL;
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/nativeplatform/WindowsEncryptionKeyStore.java
+++ b/src/main/java/net/fabricmc/loom/util/nativeplatform/WindowsEncryptionKeyStore.java
@@ -26,6 +26,7 @@ package net.fabricmc.loom.util.nativeplatform;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.util.Arrays;
 import java.util.Objects;
 
 import javax.crypto.SecretKey;
@@ -64,7 +65,13 @@ public final class WindowsEncryptionKeyStore implements EncryptionKeyStore {
 	@Override
 	public void prepare() throws LoomNativePlatformException {
 		try (Arena arena = Arena.ofConfined(); NativeHandle provider = openProvider(arena); NativeHandle wrappingKey = openOrCreateKey(arena, provider)) {
-			Win32.ncryptEncrypt(arena, wrappingKey.segment(), new byte[] {0});
+			byte[] plaintext = new byte[] {0};
+			byte[] encrypted = Win32.ncryptEncrypt(arena, wrappingKey.segment(), plaintext);
+			byte[] decrypted = Win32.ncryptDecrypt(arena, wrappingKey.segment(), encrypted, nativeFlags());
+
+			if (!Arrays.equals(plaintext, decrypted)) {
+				throw new LoomNativePlatformException("Windows CNG key validation failed");
+			}
 		} catch (Throwable e) {
 			String message = userInteraction == UserInteraction.REQUIRED
 					? "Could not initialize TPM-backed secure storage. Microsoft login requires an enabled and provisioned TPM on Windows, and setup must be approved when prompted."

--- a/src/test/groovy/net/fabricmc/loom/test/unit/EncryptedStringStoreTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/EncryptedStringStoreTest.groovy
@@ -136,6 +136,10 @@ class EncryptedStringStoreTest extends Specification {
 
 	private static final class ReversibleTestKeyStore implements EncryptionKeyStore {
 		@Override
+		void prepare() {
+		}
+
+		@Override
 		StoredKey store(SecretKey key) {
 			return new StoredKey(key.algorithm, transform(key.encoded))
 		}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/EncryptedStringStoreTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/EncryptedStringStoreTest.groovy
@@ -1,0 +1,156 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+
+import javax.crypto.SecretKey
+import javax.crypto.spec.SecretKeySpec
+
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import net.fabricmc.loom.util.EncryptedStringStore
+import net.fabricmc.loom.util.nativeplatform.EncryptionKeyStore
+
+class EncryptedStringStoreTest extends Specification {
+	@TempDir
+	Path directory
+
+	EncryptedStringStore store = new EncryptedStringStore(new ReversibleTestKeyStore())
+
+	def "writes and reads an encrypted string"() {
+		given:
+		Path file = directory.resolve("secret.bin")
+
+		when:
+		store.write(file, "refresh-token-value")
+
+		then:
+		store.read(file) == "refresh-token-value"
+		!new String(Files.readAllBytes(file), StandardCharsets.UTF_8).contains("refresh-token-value")
+	}
+
+	def "overwrites an existing encrypted string"() {
+		given:
+		Path file = directory.resolve("secret.bin")
+		store.write(file, "old-token")
+
+		when:
+		store.write(file, "new-token")
+
+		then:
+		store.read(file) == "new-token"
+	}
+
+	def "rejects modified ciphertext"() {
+		given:
+		Path file = directory.resolve("secret.bin")
+		store.write(file, "refresh-token-value")
+		def envelope = new JsonSlurper().parse(file.toFile())
+		byte[] ciphertext = Base64.decoder.decode(envelope.ciphertext)
+		ciphertext[ciphertext.length - 1] ^= 1
+		envelope.ciphertext = Base64.encoder.encodeToString(ciphertext)
+		Files.writeString(file, JsonOutput.toJson(envelope))
+
+		when:
+		store.read(file)
+
+		then:
+		def exception = thrown IOException
+		exception.message == "Encrypted string authentication failed"
+	}
+
+	def "rejects an invalid file"() {
+		given:
+		Path file = directory.resolve("secret.bin")
+		Files.write(file, [1, 2, 3] as byte[])
+
+		when:
+		store.read(file)
+
+		then:
+		thrown IOException
+	}
+
+	def "rejects an envelope with missing fields"() {
+		given:
+		Path file = directory.resolve("secret.bin")
+		Files.writeString(file, '{"version":1}')
+
+		when:
+		store.read(file)
+
+		then:
+		thrown IOException
+	}
+
+	def "checks the version before parsing the version-specific format"() {
+		given:
+		Path file = directory.resolve("secret.bin")
+		Files.writeString(file, '{"version":2,"differentFormat":true}')
+
+		when:
+		store.read(file)
+
+		then:
+		def exception = thrown IOException
+		exception.message == "Unsupported encrypted string file version: 2"
+	}
+
+	def "stored keys use value equality"() {
+		given:
+		def first = new EncryptionKeyStore.StoredKey("AES", [1, 2, 3] as byte[])
+		def second = new EncryptionKeyStore.StoredKey("AES", [1, 2, 3] as byte[])
+
+		expect:
+		first == second
+		first.hashCode() == second.hashCode()
+	}
+
+	private static final class ReversibleTestKeyStore implements EncryptionKeyStore {
+		@Override
+		StoredKey store(SecretKey key) {
+			return new StoredKey(key.algorithm, transform(key.encoded))
+		}
+
+		@Override
+		SecretKey read(StoredKey key) {
+			return new SecretKeySpec(transform(key.data()), key.algorithm())
+		}
+
+		@Override
+		void delete() {
+		}
+
+		private static byte[] transform(byte[] input) {
+			return input.collect { (byte) (it ^ 0x5A) } as byte[]
+		}
+	}
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/EncryptedStringStoreTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/EncryptedStringStoreTest.groovy
@@ -27,12 +27,14 @@ package net.fabricmc.loom.test.unit
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermissions
 
 import javax.crypto.SecretKey
 import javax.crypto.spec.SecretKeySpec
 
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
+import spock.lang.Requires
 import spock.lang.Specification
 import spock.lang.TempDir
 
@@ -67,6 +69,18 @@ class EncryptedStringStoreTest extends Specification {
 
 		then:
 		store.read(file) == "new-token"
+	}
+
+	@Requires({ os.linux || os.macOs })
+	def "restricts encrypted files to the owner"() {
+		given:
+		Path file = directory.resolve("secret.bin")
+
+		when:
+		store.write(file, "refresh-token-value")
+
+		then:
+		Files.getPosixFilePermissions(file) == PosixFilePermissions.fromString("rw-------")
 	}
 
 	def "rejects modified ciphertext"() {

--- a/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftAccountStoreTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftAccountStoreTest.groovy
@@ -1,0 +1,182 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit.auth
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+import javax.crypto.SecretKey
+import javax.crypto.spec.SecretKeySpec
+
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import net.fabricmc.loom.extension.LoomFiles
+import net.fabricmc.loom.task.launch.auth.MicrosoftAccountStore
+import net.fabricmc.loom.util.EncryptedStringStore
+import net.fabricmc.loom.util.nativeplatform.EncryptionKeyStore
+
+class MicrosoftAccountStoreTest extends Specification {
+	@TempDir
+	Path directory
+
+	TestKeyStore keyStore = new TestKeyStore()
+
+	def "uses a shared path beneath the Loom user cache"() {
+		given:
+		def files = Stub(LoomFiles) {
+			getUserCache() >> directory.toFile()
+		}
+
+		expect:
+		MicrosoftAccountStore.defaultPath(files) == directory.resolve("microsoft-auth.json")
+	}
+
+	def "writes and reads a validated encrypted account"() {
+		given:
+		Path file = directory.resolve("nested/microsoft-auth.json")
+		def store = new MicrosoftAccountStore(file, keyStore)
+		def account = new MicrosoftAccountStore.Account("client-id", "refresh-token", "profile-id", "Player")
+
+		when:
+		store.write(account)
+
+		then:
+		store.exists()
+		store.read() == account
+		!Files.readString(file).contains("refresh-token")
+	}
+
+	def "delegates storage preparation"() {
+		given:
+		def store = new MicrosoftAccountStore(directory.resolve("microsoft-auth.json"), keyStore)
+
+		when:
+		store.prepare()
+
+		then:
+		keyStore.prepareCount == 1
+	}
+
+	def "checks the account version before parsing version-specific fields"() {
+		given:
+		Path file = directory.resolve("microsoft-auth.json")
+		new EncryptedStringStore(keyStore).write(file, '{"version":2,"differentFormat":true}')
+		def store = new MicrosoftAccountStore(file, keyStore)
+
+		when:
+		store.read()
+
+		then:
+		def exception = thrown IOException
+		exception.message == "Unsupported stored Microsoft account version: 2"
+	}
+
+	def "rejects missing account fields"() {
+		given:
+		Path file = directory.resolve("microsoft-auth.json")
+		new EncryptedStringStore(keyStore).write(file, '{"version":1}')
+		def store = new MicrosoftAccountStore(file, keyStore)
+
+		when:
+		store.read()
+
+		then:
+		def exception = thrown IOException
+		exception.message == "Invalid stored Microsoft account"
+	}
+
+	def "deletes the account file before its platform key"() {
+		given:
+		Path file = directory.resolve("microsoft-auth.json")
+		keyStore.fileThatMustBeDeleted = file
+		def store = new MicrosoftAccountStore(file, keyStore)
+		store.write(new MicrosoftAccountStore.Account("client-id", "refresh-token", "profile-id", "Player"))
+
+		when:
+		store.delete()
+
+		then:
+		!store.exists()
+		keyStore.deleted
+	}
+
+	def "replaces only the refresh token"() {
+		given:
+		def account = new MicrosoftAccountStore.Account("client-id", "old-token", "profile-id", "Player")
+
+		expect:
+		account.withRefreshToken("new-token") == new MicrosoftAccountStore.Account("client-id", "new-token", "profile-id", "Player")
+	}
+
+	def "rejects a blank #field"() {
+		when:
+		new MicrosoftAccountStore.Account(clientId, refreshToken, profileId, profileName)
+
+		then:
+		thrown IllegalArgumentException
+
+		where:
+		field          | clientId   | refreshToken    | profileId    | profileName
+		"client ID"    | ""         | "refresh-token" | "profile-id" | "Player"
+		"refresh token" | "client-id" | ""              | "profile-id" | "Player"
+		"profile ID"   | "client-id" | "refresh-token" | ""           | "Player"
+		"profile name" | "client-id" | "refresh-token" | "profile-id" | ""
+	}
+
+	private static final class TestKeyStore implements EncryptionKeyStore {
+		int prepareCount
+		boolean deleted
+		Path fileThatMustBeDeleted
+
+		@Override
+		void prepare() {
+			prepareCount++
+		}
+
+		@Override
+		StoredKey store(SecretKey key) {
+			return new StoredKey(key.algorithm, transform(key.encoded))
+		}
+
+		@Override
+		SecretKey read(StoredKey key) {
+			return new SecretKeySpec(transform(key.data()), key.algorithm())
+		}
+
+		@Override
+		void delete() {
+			if (fileThatMustBeDeleted != null && Files.exists(fileThatMustBeDeleted)) {
+				throw new AssertionError("The encrypted account must be deleted first")
+			}
+
+			deleted = true
+		}
+
+		private static byte[] transform(byte[] input) {
+			return input.collect { (byte) (it ^ 0x5A) } as byte[]
+		}
+	}
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftAuthManualTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftAuthManualTest.groovy
@@ -1,0 +1,66 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit.auth
+
+import net.fabricmc.loom.task.launch.auth.MicrosoftLoginService
+import net.fabricmc.loom.task.launch.auth.MicrosoftLoginServiceImpl
+import net.fabricmc.loom.task.launch.auth.MinecraftAccessTokenProvider
+import net.fabricmc.loom.task.launch.auth.MinecraftAccessTokenProviderImpl
+
+/**
+ * Manual authentication smoke test. This intentionally prints credentials and must not be used in
+ * CI or with logs that will be retained or shared.
+ */
+final class MicrosoftAuthManualTest {
+	private MicrosoftAuthManualTest() {
+	}
+
+	static void main(String[] args) {
+		String clientId = args.length > 0 ? args[0] : System.getenv("LOOM_MICROSOFT_CLIENT_ID")
+
+		if (!clientId) {
+			throw new IllegalArgumentException("Pass the Microsoft client ID as the first argument or set LOOM_MICROSOFT_CLIENT_ID")
+		}
+
+		MicrosoftLoginService loginService = new MicrosoftLoginServiceImpl()
+		MicrosoftLoginService.LoginResult login = loginService.login(clientId) { deviceCode ->
+			println deviceCode.message()
+			println "Verification URI: ${deviceCode.verificationUri()}"
+			println "User code: ${deviceCode.userCode()}"
+		}
+
+		println "Profile: ${login.profile().name()} (${login.profile().id()})"
+		println "Can play Minecraft: ${login.entitlements().canPlayMinecraft()}"
+		println "Owns Minecraft: ${login.entitlements().ownsMinecraft()}"
+		println "Microsoft refresh token: ${login.refreshToken()}"
+
+		MinecraftAccessTokenProvider tokenProvider = new MinecraftAccessTokenProviderImpl()
+		MinecraftAccessTokenProvider.AccessToken accessToken = tokenProvider.getAccessToken(clientId, login.refreshToken())
+
+		println "Rotated Microsoft refresh token: ${accessToken.refreshToken()}"
+		println "Minecraft access token: ${accessToken.accessToken()}"
+		println "Minecraft access token expires in: ${accessToken.expiresIn()} seconds"
+	}
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftAuthManualTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftAuthManualTest.groovy
@@ -24,26 +24,68 @@
 
 package net.fabricmc.loom.test.unit.auth
 
+import java.nio.file.Files
+import java.nio.file.Path
+
+import com.google.gson.Gson
+
 import net.fabricmc.loom.task.launch.auth.MicrosoftLoginService
 import net.fabricmc.loom.task.launch.auth.MicrosoftLoginServiceImpl
 import net.fabricmc.loom.task.launch.auth.MinecraftAccessTokenProvider
 import net.fabricmc.loom.task.launch.auth.MinecraftAccessTokenProviderImpl
+import net.fabricmc.loom.util.EncryptedStringStore
+import net.fabricmc.loom.util.nativeplatform.WindowsEncryptionKeyStore
 
 /**
  * Manual authentication smoke test. This intentionally prints credentials and must not be used in
  * CI or with logs that will be retained or shared.
  */
 final class MicrosoftAuthManualTest {
+	private static final int STORED_LOGIN_VERSION = 1
+	private static final Path STORED_LOGIN_FILE = Path.of("microsoft-auth-test.json")
+	private static final Gson GSON = new Gson()
+
 	private MicrosoftAuthManualTest() {
 	}
 
 	static void main(String[] args) {
-		String clientId = args.length > 0 ? args[0] : System.getenv("LOOM_MICROSOFT_CLIENT_ID")
+		String requestedClientId = args.length > 0 ? args[0] : System.getenv("LOOM_MICROSOFT_CLIENT_ID")
+		EncryptedStringStore storedLoginStore = new EncryptedStringStore(new WindowsEncryptionKeyStore())
+		StoredLogin storedLogin
 
-		if (!clientId) {
-			throw new IllegalArgumentException("Pass the Microsoft client ID as the first argument or set LOOM_MICROSOFT_CLIENT_ID")
+		if (Files.exists(STORED_LOGIN_FILE)) {
+			storedLogin = readStoredLogin(storedLoginStore)
+
+			if (requestedClientId && requestedClientId != storedLogin.clientId) {
+				throw new IllegalArgumentException("The stored login uses a different Microsoft client ID; delete ${STORED_LOGIN_FILE} to authenticate again")
+			}
+
+			println "Loaded encrypted login from ${STORED_LOGIN_FILE.toAbsolutePath()}"
+		} else {
+			if (!requestedClientId) {
+				throw new IllegalArgumentException("Pass the Microsoft client ID as the first argument or set LOOM_MICROSOFT_CLIENT_ID")
+			}
+
+			storedLogin = login(storedLoginStore, requestedClientId)
 		}
 
+		String clientId = storedLogin.clientId
+		println "Profile: ${storedLogin.profileName} (${storedLogin.profileId})"
+		println "Can play Minecraft: ${storedLogin.canPlayMinecraft}"
+		println "Owns Minecraft: ${storedLogin.ownsMinecraft}"
+
+		MinecraftAccessTokenProvider tokenProvider = new MinecraftAccessTokenProviderImpl()
+		MinecraftAccessTokenProvider.AccessToken accessToken = tokenProvider.getAccessToken(clientId, storedLogin.refreshToken)
+		storedLogin = storedLogin.withRefreshToken(accessToken.refreshToken())
+		storedLoginStore.write(STORED_LOGIN_FILE, GSON.toJson(storedLogin))
+
+		println "Rotated Microsoft refresh token: ${accessToken.refreshToken()}"
+		println "Minecraft access token: ${accessToken.accessToken()}"
+		println "Minecraft access token expires in: ${accessToken.expiresIn()} seconds"
+		println "Updated encrypted login in ${STORED_LOGIN_FILE.toAbsolutePath()}"
+	}
+
+	private static StoredLogin login(EncryptedStringStore storedLoginStore, String clientId) {
 		MicrosoftLoginService loginService = new MicrosoftLoginServiceImpl()
 		MicrosoftLoginService.LoginResult login = loginService.login(clientId) { deviceCode ->
 			println deviceCode.message()
@@ -56,11 +98,59 @@ final class MicrosoftAuthManualTest {
 		println "Owns Minecraft: ${login.entitlements().ownsMinecraft()}"
 		println "Microsoft refresh token: ${login.refreshToken()}"
 
-		MinecraftAccessTokenProvider tokenProvider = new MinecraftAccessTokenProviderImpl()
-		MinecraftAccessTokenProvider.AccessToken accessToken = tokenProvider.getAccessToken(clientId, login.refreshToken())
+		StoredLogin storedLogin = new StoredLogin(
+				STORED_LOGIN_VERSION,
+				clientId,
+				login.refreshToken(),
+				login.profile().id(),
+				login.profile().name(),
+				login.entitlements().canPlayMinecraft(),
+				login.entitlements().ownsMinecraft()
+				)
+		storedLoginStore.write(STORED_LOGIN_FILE, GSON.toJson(storedLogin))
+		println "Stored encrypted login in ${STORED_LOGIN_FILE.toAbsolutePath()}"
+		return storedLogin
+	}
 
-		println "Rotated Microsoft refresh token: ${accessToken.refreshToken()}"
-		println "Minecraft access token: ${accessToken.accessToken()}"
-		println "Minecraft access token expires in: ${accessToken.expiresIn()} seconds"
+	private static StoredLogin readStoredLogin(EncryptedStringStore storedLoginStore) {
+		StoredLogin storedLogin = GSON.fromJson(storedLoginStore.read(STORED_LOGIN_FILE), StoredLogin)
+
+		if (storedLogin == null || storedLogin.version != STORED_LOGIN_VERSION) {
+			throw new IllegalStateException("Unsupported stored login in ${STORED_LOGIN_FILE}")
+		}
+
+		if (!storedLogin.clientId || !storedLogin.refreshToken || !storedLogin.profileId || !storedLogin.profileName) {
+			throw new IllegalStateException("Stored login in ${STORED_LOGIN_FILE} is missing required fields")
+		}
+
+		return storedLogin
+	}
+
+	private static final class StoredLogin {
+		int version
+		String clientId
+		String refreshToken
+		String profileId
+		String profileName
+		boolean canPlayMinecraft
+		boolean ownsMinecraft
+
+		private StoredLogin() {
+		}
+
+		private StoredLogin(int version, String clientId, String refreshToken, String profileId, String profileName,
+		boolean canPlayMinecraft, boolean ownsMinecraft) {
+			this.version = version
+			this.clientId = clientId
+			this.refreshToken = refreshToken
+			this.profileId = profileId
+			this.profileName = profileName
+			this.canPlayMinecraft = canPlayMinecraft
+			this.ownsMinecraft = ownsMinecraft
+		}
+
+		private StoredLogin withRefreshToken(String refreshToken) {
+			return new StoredLogin(version, clientId, refreshToken, profileId, profileName, canPlayMinecraft, ownsMinecraft)
+		}
 	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftAuthManualTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftAuthManualTest.groovy
@@ -50,10 +50,18 @@ final class MicrosoftAuthManualTest {
 
 	static void main(String[] args) {
 		String requestedClientId = args.length > 0 ? args[0] : System.getenv("LOOM_MICROSOFT_CLIENT_ID")
-		EncryptedStringStore storedLoginStore = new EncryptedStringStore(new WindowsEncryptionKeyStore())
+		boolean hasStoredLogin = Files.exists(STORED_LOGIN_FILE)
+
+		if (!hasStoredLogin && !requestedClientId) {
+			throw new IllegalArgumentException("Pass the Microsoft client ID as the first argument or set LOOM_MICROSOFT_CLIENT_ID")
+		}
+
+		WindowsEncryptionKeyStore keyStore = new WindowsEncryptionKeyStore()
+		keyStore.prepare()
+		EncryptedStringStore storedLoginStore = new EncryptedStringStore(keyStore)
 		StoredLogin storedLogin
 
-		if (Files.exists(STORED_LOGIN_FILE)) {
+		if (hasStoredLogin) {
 			storedLogin = readStoredLogin(storedLoginStore)
 
 			if (requestedClientId && requestedClientId != storedLogin.clientId) {
@@ -62,10 +70,6 @@ final class MicrosoftAuthManualTest {
 
 			println "Loaded encrypted login from ${STORED_LOGIN_FILE.toAbsolutePath()}"
 		} else {
-			if (!requestedClientId) {
-				throw new IllegalArgumentException("Pass the Microsoft client ID as the first argument or set LOOM_MICROSOFT_CLIENT_ID")
-			}
-
 			storedLogin = login(storedLoginStore, requestedClientId)
 		}
 

--- a/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftAuthManualTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftAuthManualTest.groovy
@@ -24,94 +24,71 @@
 
 package net.fabricmc.loom.test.unit.auth
 
-import java.nio.file.Files
 import java.nio.file.Path
 
-import com.google.gson.Gson
-
+import net.fabricmc.loom.task.launch.auth.MicrosoftAccountStore
 import net.fabricmc.loom.task.launch.auth.MicrosoftLoginService
 import net.fabricmc.loom.task.launch.auth.MicrosoftLoginServiceImpl
 import net.fabricmc.loom.task.launch.auth.MinecraftAccessTokenProvider
 import net.fabricmc.loom.task.launch.auth.MinecraftAccessTokenProviderImpl
-import net.fabricmc.loom.util.EncryptedStringStore
-import net.fabricmc.loom.util.Platform
 import net.fabricmc.loom.util.nativeplatform.EncryptionKeyStore
-import net.fabricmc.loom.util.nativeplatform.MacOSEncryptionKeyStore
-import net.fabricmc.loom.util.nativeplatform.WindowsEncryptionKeyStore
+import net.fabricmc.loom.util.nativeplatform.EncryptionKeyStoreFactory
 
 /**
  * Manual authentication smoke test. This intentionally prints credentials and must not be used in
  * CI or with logs that will be retained or shared.
  */
 final class MicrosoftAuthManualTest {
-	private static final int STORED_LOGIN_VERSION = 1
 	private static final Path STORED_LOGIN_FILE = Path.of("microsoft-auth-test.json")
-	private static final Gson GSON = new Gson()
+	private static final String KEY_NAME = "FabricLoomMicrosoftAuthManualTestEncryptionKey"
 
 	private MicrosoftAuthManualTest() {
 	}
 
 	static void main(String[] args) {
 		String requestedClientId = args.length > 0 ? args[0] : System.getenv("LOOM_MICROSOFT_CLIENT_ID")
-		boolean hasStoredLogin = Files.exists(STORED_LOGIN_FILE)
+		EncryptionKeyStore keyStore = EncryptionKeyStoreFactory.create(KEY_NAME, EncryptionKeyStore.UserInteraction.REQUIRED)
+		MicrosoftAccountStore accountStore = new MicrosoftAccountStore(STORED_LOGIN_FILE, keyStore)
+		boolean hasStoredLogin = accountStore.exists()
 
 		if (!hasStoredLogin && !requestedClientId) {
 			throw new IllegalArgumentException("Pass the Microsoft client ID as the first argument or set LOOM_MICROSOFT_CLIENT_ID")
 		}
 
-		EncryptionKeyStore keyStore = createEncryptionKeyStore()
-
 		if (!hasStoredLogin) {
-			keyStore.delete()
+			accountStore.delete()
 		}
 
-		keyStore.prepare()
-		EncryptedStringStore storedLoginStore = new EncryptedStringStore(keyStore)
-		StoredLogin storedLogin
+		accountStore.prepare()
+		MicrosoftAccountStore.Account account
 
 		if (hasStoredLogin) {
-			storedLogin = readStoredLogin(storedLoginStore)
+			account = accountStore.read()
 
-			if (requestedClientId && requestedClientId != storedLogin.clientId) {
+			if (requestedClientId && requestedClientId != account.clientId()) {
 				throw new IllegalArgumentException("The stored login uses a different Microsoft client ID; delete ${STORED_LOGIN_FILE} to authenticate again")
 			}
 
 			println "Loaded encrypted login from ${STORED_LOGIN_FILE.toAbsolutePath()}"
 		} else {
-			storedLogin = login(storedLoginStore, requestedClientId)
+			account = login(accountStore, requestedClientId)
 		}
 
-		String clientId = storedLogin.clientId
-		println "Profile: ${storedLogin.profileName} (${storedLogin.profileId})"
-		println "Can play Minecraft: ${storedLogin.canPlayMinecraft}"
-		println "Owns Minecraft: ${storedLogin.ownsMinecraft}"
+		String clientId = account.clientId()
+		println "Profile: ${account.profileName()} (${account.profileId()})"
 
 		MinecraftAccessTokenProvider tokenProvider = new MinecraftAccessTokenProviderImpl()
-		MinecraftAccessTokenProvider.AccessToken accessToken = tokenProvider.getAccessToken(clientId, storedLogin.refreshToken)
-		storedLogin = storedLogin.withRefreshToken(accessToken.refreshToken())
-		storedLoginStore.write(STORED_LOGIN_FILE, GSON.toJson(storedLogin))
+		MinecraftAccessTokenProvider.AccessToken accessToken = tokenProvider.getAccessToken(clientId, account.refreshToken()) { refreshToken ->
+			accountStore.write(account.withRefreshToken(refreshToken))
+			println "Rotated Microsoft refresh token: ${refreshToken}"
+			println "Updated encrypted login in ${STORED_LOGIN_FILE.toAbsolutePath()}"
+		}
 
-		println "Rotated Microsoft refresh token: ${accessToken.refreshToken()}"
 		println "Minecraft access token: ${accessToken.accessToken()}"
 		println "Minecraft access token expires in: ${accessToken.expiresIn()} seconds"
-		println "Updated encrypted login in ${STORED_LOGIN_FILE.toAbsolutePath()}"
 	}
 
-	private static EncryptionKeyStore createEncryptionKeyStore() {
-		def operatingSystem = Platform.CURRENT.getOperatingSystem()
-
-		if (operatingSystem.isWindows()) {
-			return new WindowsEncryptionKeyStore()
-		}
-
-		if (operatingSystem.isMacOS()) {
-			return new MacOSEncryptionKeyStore()
-		}
-
-		throw new UnsupportedOperationException("Microsoft authentication secure storage is not supported on ${operatingSystem}")
-	}
-
-	private static StoredLogin login(EncryptedStringStore storedLoginStore, String clientId) {
+	private static MicrosoftAccountStore.Account login(MicrosoftAccountStore accountStore, String clientId) {
 		MicrosoftLoginService loginService = new MicrosoftLoginServiceImpl()
 		MicrosoftLoginService.LoginResult login = loginService.login(clientId) { deviceCode ->
 			println deviceCode.message()
@@ -124,59 +101,14 @@ final class MicrosoftAuthManualTest {
 		println "Owns Minecraft: ${login.entitlements().ownsMinecraft()}"
 		println "Microsoft refresh token: ${login.refreshToken()}"
 
-		StoredLogin storedLogin = new StoredLogin(
-				STORED_LOGIN_VERSION,
+		MicrosoftAccountStore.Account account = new MicrosoftAccountStore.Account(
 				clientId,
 				login.refreshToken(),
 				login.profile().id(),
-				login.profile().name(),
-				login.entitlements().canPlayMinecraft(),
-				login.entitlements().ownsMinecraft()
+				login.profile().name()
 				)
-		storedLoginStore.write(STORED_LOGIN_FILE, GSON.toJson(storedLogin))
+		accountStore.write(account)
 		println "Stored encrypted login in ${STORED_LOGIN_FILE.toAbsolutePath()}"
-		return storedLogin
-	}
-
-	private static StoredLogin readStoredLogin(EncryptedStringStore storedLoginStore) {
-		StoredLogin storedLogin = GSON.fromJson(storedLoginStore.read(STORED_LOGIN_FILE), StoredLogin)
-
-		if (storedLogin == null || storedLogin.version != STORED_LOGIN_VERSION) {
-			throw new IllegalStateException("Unsupported stored login in ${STORED_LOGIN_FILE}")
-		}
-
-		if (!storedLogin.clientId || !storedLogin.refreshToken || !storedLogin.profileId || !storedLogin.profileName) {
-			throw new IllegalStateException("Stored login in ${STORED_LOGIN_FILE} is missing required fields")
-		}
-
-		return storedLogin
-	}
-
-	private static final class StoredLogin {
-		int version
-		String clientId
-		String refreshToken
-		String profileId
-		String profileName
-		boolean canPlayMinecraft
-		boolean ownsMinecraft
-
-		private StoredLogin() {
-		}
-
-		private StoredLogin(int version, String clientId, String refreshToken, String profileId, String profileName,
-		boolean canPlayMinecraft, boolean ownsMinecraft) {
-			this.version = version
-			this.clientId = clientId
-			this.refreshToken = refreshToken
-			this.profileId = profileId
-			this.profileName = profileName
-			this.canPlayMinecraft = canPlayMinecraft
-			this.ownsMinecraft = ownsMinecraft
-		}
-
-		private StoredLogin withRefreshToken(String refreshToken) {
-			return new StoredLogin(version, clientId, refreshToken, profileId, profileName, canPlayMinecraft, ownsMinecraft)
-		}
+		return account
 	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftAuthManualTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftAuthManualTest.groovy
@@ -34,6 +34,9 @@ import net.fabricmc.loom.task.launch.auth.MicrosoftLoginServiceImpl
 import net.fabricmc.loom.task.launch.auth.MinecraftAccessTokenProvider
 import net.fabricmc.loom.task.launch.auth.MinecraftAccessTokenProviderImpl
 import net.fabricmc.loom.util.EncryptedStringStore
+import net.fabricmc.loom.util.Platform
+import net.fabricmc.loom.util.nativeplatform.EncryptionKeyStore
+import net.fabricmc.loom.util.nativeplatform.MacOSEncryptionKeyStore
 import net.fabricmc.loom.util.nativeplatform.WindowsEncryptionKeyStore
 
 /**
@@ -56,7 +59,12 @@ final class MicrosoftAuthManualTest {
 			throw new IllegalArgumentException("Pass the Microsoft client ID as the first argument or set LOOM_MICROSOFT_CLIENT_ID")
 		}
 
-		WindowsEncryptionKeyStore keyStore = new WindowsEncryptionKeyStore()
+		EncryptionKeyStore keyStore = createEncryptionKeyStore()
+
+		if (!hasStoredLogin) {
+			keyStore.delete()
+		}
+
 		keyStore.prepare()
 		EncryptedStringStore storedLoginStore = new EncryptedStringStore(keyStore)
 		StoredLogin storedLogin
@@ -87,6 +95,20 @@ final class MicrosoftAuthManualTest {
 		println "Minecraft access token: ${accessToken.accessToken()}"
 		println "Minecraft access token expires in: ${accessToken.expiresIn()} seconds"
 		println "Updated encrypted login in ${STORED_LOGIN_FILE.toAbsolutePath()}"
+	}
+
+	private static EncryptionKeyStore createEncryptionKeyStore() {
+		def operatingSystem = Platform.CURRENT.getOperatingSystem()
+
+		if (operatingSystem.isWindows()) {
+			return new WindowsEncryptionKeyStore()
+		}
+
+		if (operatingSystem.isMacOS()) {
+			return new MacOSEncryptionKeyStore()
+		}
+
+		throw new UnsupportedOperationException("Microsoft authentication secure storage is not supported on ${operatingSystem}")
 	}
 
 	private static StoredLogin login(EncryptedStringStore storedLoginStore, String clientId) {

--- a/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftAuthManualTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftAuthManualTest.groovy
@@ -31,6 +31,7 @@ import net.fabricmc.loom.task.launch.auth.MicrosoftLoginService
 import net.fabricmc.loom.task.launch.auth.MicrosoftLoginServiceImpl
 import net.fabricmc.loom.task.launch.auth.MinecraftAccessTokenProvider
 import net.fabricmc.loom.task.launch.auth.MinecraftAccessTokenProviderImpl
+import net.fabricmc.loom.util.Constants
 import net.fabricmc.loom.util.nativeplatform.EncryptionKeyStore
 import net.fabricmc.loom.util.nativeplatform.EncryptionKeyStoreFactory
 
@@ -46,14 +47,10 @@ final class MicrosoftAuthManualTest {
 	}
 
 	static void main(String[] args) {
-		String requestedClientId = args.length > 0 ? args[0] : System.getenv("LOOM_MICROSOFT_CLIENT_ID")
+		String clientId = Constants.MICROSOFT_CLIENT_ID
 		EncryptionKeyStore keyStore = EncryptionKeyStoreFactory.create(KEY_NAME, EncryptionKeyStore.UserInteraction.REQUIRED)
 		MicrosoftAccountStore accountStore = new MicrosoftAccountStore(STORED_LOGIN_FILE, keyStore)
 		boolean hasStoredLogin = accountStore.exists()
-
-		if (!hasStoredLogin && !requestedClientId) {
-			throw new IllegalArgumentException("Pass the Microsoft client ID as the first argument or set LOOM_MICROSOFT_CLIENT_ID")
-		}
 
 		if (!hasStoredLogin) {
 			accountStore.delete()
@@ -65,16 +62,15 @@ final class MicrosoftAuthManualTest {
 		if (hasStoredLogin) {
 			account = accountStore.read()
 
-			if (requestedClientId && requestedClientId != account.clientId()) {
+			if (clientId != account.clientId()) {
 				throw new IllegalArgumentException("The stored login uses a different Microsoft client ID; delete ${STORED_LOGIN_FILE} to authenticate again")
 			}
 
 			println "Loaded encrypted login from ${STORED_LOGIN_FILE.toAbsolutePath()}"
 		} else {
-			account = login(accountStore, requestedClientId)
+			account = login(accountStore, clientId)
 		}
 
-		String clientId = account.clientId()
 		println "Profile: ${account.profileName()} (${account.profileId()})"
 
 		MinecraftAccessTokenProvider tokenProvider = new MinecraftAccessTokenProviderImpl()

--- a/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftAuthServiceTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftAuthServiceTest.groovy
@@ -170,7 +170,7 @@ class MicrosoftAuthServiceTest extends Specification {
 				id: "0123456789abcdef0123456789abcdef",
 				name: "Player",
 				skins: [
-					[id: "skin-id", state: "ACTIVE", url: "https://textures.minecraft.net/skin", variant: "CLASSIC", alias: "Steve"]
+					[id: "skin-id", state: "ACTIVE", url: "https://textures.minecraft.net/skin", variant: "CLASSIC"]
 				],
 				capes: []
 			])
@@ -183,7 +183,7 @@ class MicrosoftAuthServiceTest extends Specification {
 		then:
 		token.expiresIn() == 86400
 		profile.name() == "Player"
-		profile.skins()*.id() == ["skin-id"]
+		profile.id() == "0123456789abcdef0123456789abcdef"
 	}
 
 	def "rejects a successful response with missing required fields"() {

--- a/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftAuthServiceTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftAuthServiceTest.groovy
@@ -1,0 +1,228 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit.auth
+
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import io.javalin.Javalin
+import io.javalin.http.Context
+import io.javalin.http.HttpStatus
+import spock.lang.Specification
+
+import net.fabricmc.loom.task.launch.auth.MicrosoftAuthService
+import net.fabricmc.loom.task.launch.auth.MicrosoftAuthServiceImpl
+
+class MicrosoftAuthServiceTest extends Specification {
+	Javalin server = Javalin.create().start(0)
+	MicrosoftAuthService service = new MicrosoftAuthServiceImpl(endpoints())
+
+	def cleanup() {
+		server.stop()
+	}
+
+	def "requests a device code with the Xbox scopes"() {
+		given:
+		server.post("/device-code") { ctx ->
+			assert ctx.formParam("client_id") == "client-id"
+			assert ctx.formParam("scope") == "XboxLive.SignIn XboxLive.offline_access"
+			json(ctx, [
+				device_code: "device-code",
+				user_code: "ABCD-EFGH",
+				verification_uri: "https://microsoft.com/devicelogin",
+				expires_in: 900,
+				message: "Sign in"
+			])
+		}
+
+		when:
+		def result = service.requestDeviceCode("client-id")
+
+		then:
+		result.deviceCode() == "device-code"
+		result.userCode() == "ABCD-EFGH"
+		result.interval() == 5
+	}
+
+	def "returns structured device polling responses"() {
+		given:
+		server.post("/token") { ctx ->
+			assert ctx.formParam("grant_type") == "urn:ietf:params:oauth:grant-type:device_code"
+			ctx.status(HttpStatus.BAD_REQUEST)
+			json(ctx, [
+				error: "slow_down",
+				error_description: "Poll less frequently"
+			])
+		}
+
+		when:
+		def result = service.requestMicrosoftToken("client-id", "device-code")
+
+		then:
+		result instanceof MicrosoftAuthService.MicrosoftToken.Polling
+		result.status() == MicrosoftAuthService.MicrosoftToken.Polling.Status.SLOW_DOWN
+	}
+
+	def "refreshes and rotates the Microsoft refresh token"() {
+		given:
+		server.post("/token") { ctx ->
+			assert ctx.formParam("client_id") == "client-id"
+			assert ctx.formParam("grant_type") == "refresh_token"
+			assert ctx.formParam("refresh_token") == "old-refresh-token"
+			json(ctx, [
+				access_token: "new-access-token",
+				refresh_token: "new-refresh-token",
+				token_type: "Bearer",
+				expires_in: 3600
+			])
+		}
+
+		when:
+		def result = service.refreshMicrosoftToken("client-id", "old-refresh-token")
+
+		then:
+		result.accessToken() == "new-access-token"
+		result.refreshToken() == "new-refresh-token"
+	}
+
+	def "rejects an XSTS token for a different user hash"() {
+		given:
+		server.post("/xsts") { ctx ->
+			def body = new JsonSlurper().parseText(ctx.body())
+			assert body.Properties.UserTokens == ["xbox-user-token"]
+			ctx.result(xboxToken("xsts-token", "different-user"))
+		}
+
+		when:
+		service.authorizeMinecraftServices(new MicrosoftAuthService.XboxToken("xbox-user-token", "expected-user"))
+
+		then:
+		def exception = thrown IOException
+		exception.message == "Xbox authentication changed the user hash"
+	}
+
+	def "distinguishes ownership from the ability to play"() {
+		given:
+		server.get("/entitlements") { ctx ->
+			assert ctx.header("Authorization") == "Bearer minecraft-token"
+			assert ctx.queryParam("requestId") != null
+			json(ctx, [items: items.collect { [name: it] }])
+		}
+
+		when:
+		def result = service.fetchMinecraftEntitlements("minecraft-token")
+
+		then:
+		result.canPlayMinecraft() == canPlay
+		result.ownsMinecraft() == owns
+
+		where:
+		items                                   | canPlay | owns
+		[
+			"game_minecraft",
+			"product_minecraft"
+		] | true    | true
+		["game_minecraft"]                      | true    | false
+		[]                                        | false   | false
+	}
+
+	def "returns an empty profile for an account without a Java profile"() {
+		given:
+		server.get("/profile") { ctx ->
+			ctx.status(HttpStatus.NOT_FOUND)
+		}
+
+		expect:
+		service.fetchMinecraftProfile("minecraft-token").isEmpty()
+	}
+
+	def "parses a complete Minecraft login and profile"() {
+		given:
+		server.post("/minecraft-login") { ctx ->
+			def body = new JsonSlurper().parseText(ctx.body())
+			assert body.xtoken == "XBL3.0 x=user-hash;xsts-token"
+			assert body.platform == "PC_LAUNCHER"
+			json(ctx, [access_token: "minecraft-token", token_type: "Bearer", expires_in: 86400])
+		}
+		server.get("/profile") { ctx ->
+			json(ctx, [
+				id: "0123456789abcdef0123456789abcdef",
+				name: "Player",
+				skins: [
+					[id: "skin-id", state: "ACTIVE", url: "https://textures.minecraft.net/skin", variant: "CLASSIC", alias: "Steve"]
+				],
+				capes: []
+			])
+		}
+
+		when:
+		def token = service.loginToMinecraft("user-hash", "xsts-token")
+		def profile = service.fetchMinecraftProfile(token.accessToken()).orElseThrow()
+
+		then:
+		token.expiresIn() == 86400
+		profile.name() == "Player"
+		profile.skins()*.id() == ["skin-id"]
+	}
+
+	def "rejects a successful response with missing required fields"() {
+		given:
+		server.post("/minecraft-login") { ctx ->
+			json(ctx, [token_type: "Bearer", expires_in: 86400])
+		}
+
+		when:
+		service.loginToMinecraft("user-hash", "xsts-token")
+
+		then:
+		def exception = thrown IOException
+		exception.message.contains("returned invalid JSON")
+	}
+
+	private MicrosoftAuthServiceImpl.Endpoints endpoints() {
+		def base = "http://127.0.0.1:${server.port()}"
+		return new MicrosoftAuthServiceImpl.Endpoints(
+				URI.create("$base/device-code"),
+				URI.create("$base/token"),
+				URI.create("$base/xbox-user"),
+				URI.create("$base/xsts"),
+				URI.create("$base/minecraft-login"),
+				URI.create("$base/entitlements"),
+				URI.create("$base/profile")
+				)
+	}
+
+	private static String xboxToken(String token, String userHash) {
+		return """{
+			"Token": "$token",
+			"DisplayClaims": {
+				"xui": [{"uhs": "$userHash"}]
+			}
+		}"""
+	}
+
+	private static void json(Context context, Object value) {
+		context.contentType("application/json").result(JsonOutput.toJson(value))
+	}
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftAuthTasksTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftAuthTasksTest.groovy
@@ -1,0 +1,327 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit.auth
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.function.Consumer
+
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import net.fabricmc.loom.task.launch.auth.MicrosoftAccountStore
+import net.fabricmc.loom.task.launch.auth.MicrosoftAuthService
+import net.fabricmc.loom.task.launch.auth.MicrosoftLoginService
+import net.fabricmc.loom.task.launch.auth.MicrosoftLoginTask
+import net.fabricmc.loom.task.launch.auth.MicrosoftLogoutTask
+import net.fabricmc.loom.task.launch.auth.MinecraftAccessTokenProvider
+import net.fabricmc.loom.util.nativeplatform.LoomNativePlatformException
+
+import static org.mockito.ArgumentMatchers.any
+import static org.mockito.ArgumentMatchers.eq
+import static org.mockito.Mockito.inOrder
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.never
+import static org.mockito.Mockito.verify
+import static org.mockito.Mockito.when
+
+class MicrosoftAuthTasksTest extends Specification {
+	@TempDir
+	Path tempDir
+
+	def "login verifies an existing account and saves its rotated refresh token"() {
+		given:
+		Path accountFile = Files.writeString(tempDir.resolve("account.json"), "stored")
+		def store = mock(MicrosoftAccountStore)
+		def loginService = mock(MicrosoftLoginService)
+		def accessTokenProvider = mock(MinecraftAccessTokenProvider)
+		def account = new MicrosoftAccountStore.Account("stored-client-id", "old-refresh-token", "profile-id", "Player")
+		when(store.read()).thenReturn(account)
+		when(accessTokenProvider.getAccessToken(eq("stored-client-id"), eq("old-refresh-token"), any(Consumer))).thenAnswer { invocation ->
+			Consumer<String> consumer = invocation.getArgument(2)
+			consumer.accept("rotated-refresh-token")
+			return new MinecraftAccessTokenProvider.AccessToken("minecraft-access-token", "rotated-refresh-token", 3600)
+		}
+		def task = loginTask(accountFile, "", store, loginService, accessTokenProvider)
+
+		when:
+		task.login()
+
+		then:
+		task.storeCreated
+		assert verify(store).read() == null
+		assert verify(accessTokenProvider).getAccessToken(eq("stored-client-id"), eq("old-refresh-token"), any(Consumer)) == null
+		verify(store).write(account.withRefreshToken("rotated-refresh-token"))
+		verify(store, never()).prepare()
+		assert verify(loginService, never()).login(any(), any()) == null
+	}
+
+	def "login replaces an unreadable stored account after successful authentication"() {
+		given:
+		Path accountFile = Files.writeString(tempDir.resolve("account.json"), "stored")
+		def store = mock(MicrosoftAccountStore)
+		def loginService = mock(MicrosoftLoginService)
+		def accessTokenProvider = mock(MinecraftAccessTokenProvider)
+		def profile = new MicrosoftAuthService.MinecraftProfile("new-profile-id", "NewPlayer")
+		def result = new MicrosoftLoginService.LoginResult(
+				"new-refresh-token",
+				profile,
+				new MicrosoftAuthService.MinecraftEntitlements(true, true)
+				)
+		when(store.read()).thenThrow(new IOException("invalid stored account"))
+		when(loginService.login(eq("client-id"), any(Consumer))).thenReturn(result)
+		def task = loginTask(accountFile, "client-id", store, loginService, accessTokenProvider)
+
+		when:
+		task.login()
+
+		then:
+		def order = inOrder(store, loginService)
+		assert order.verify(store).read() == null
+		order.verify(store).prepare()
+		assert order.verify(loginService).login(eq("client-id"), any(Consumer)) == null
+		order.verify(store).write(new MicrosoftAccountStore.Account("client-id", "new-refresh-token", "new-profile-id", "NewPlayer"))
+		assert verify(accessTokenProvider, never()).getAccessToken(any(), any(), any()) == null
+		verify(store, never()).delete()
+	}
+
+	def "login replaces an account whose refresh token can no longer authenticate"() {
+		given:
+		Path accountFile = Files.writeString(tempDir.resolve("account.json"), "stored")
+		def store = mock(MicrosoftAccountStore)
+		def loginService = mock(MicrosoftLoginService)
+		def accessTokenProvider = mock(MinecraftAccessTokenProvider)
+		def account = new MicrosoftAccountStore.Account("stored-client-id", "expired-refresh-token", "profile-id", "Player")
+		def profile = new MicrosoftAuthService.MinecraftProfile("new-profile-id", "NewPlayer")
+		def result = new MicrosoftLoginService.LoginResult(
+				"new-refresh-token",
+				profile,
+				new MicrosoftAuthService.MinecraftEntitlements(true, true)
+				)
+		when(store.read()).thenReturn(account)
+		when(accessTokenProvider.getAccessToken(eq("stored-client-id"), eq("expired-refresh-token"), any(Consumer)))
+				.thenThrow(new IOException("refresh token expired"))
+		when(loginService.login(eq("stored-client-id"), any(Consumer))).thenReturn(result)
+		def task = loginTask(accountFile, "client-id", store, loginService, accessTokenProvider)
+
+		when:
+		task.login()
+
+		then:
+		def order = inOrder(store, accessTokenProvider, loginService)
+		assert order.verify(store).read() == null
+		assert order.verify(accessTokenProvider).getAccessToken(eq("stored-client-id"), eq("expired-refresh-token"), any(Consumer)) == null
+		order.verify(store).prepare()
+		assert order.verify(loginService).login(eq("stored-client-id"), any(Consumer)) == null
+		order.verify(store).write(new MicrosoftAccountStore.Account("stored-client-id", "new-refresh-token", "new-profile-id", "NewPlayer"))
+		verify(store, never()).delete()
+	}
+
+	def "login reports an empty client ID before creating storage"() {
+		given:
+		def task = loginTask(tempDir.resolve("missing.json"), "")
+
+		when:
+		task.login()
+
+		then:
+		def exception = thrown(GradleException)
+		exception.message.contains("Constants.MICROSOFT_CLIENT_ID")
+		!task.storeCreated
+	}
+
+	def "login prepares storage before authentication and saves the durable account"() {
+		given:
+		def store = mock(MicrosoftAccountStore)
+		def loginService = mock(MicrosoftLoginService)
+		def profile = new MicrosoftAuthService.MinecraftProfile("profile-id", "Player")
+		def result = new MicrosoftLoginService.LoginResult(
+				"refresh-token",
+				profile,
+				new MicrosoftAuthService.MinecraftEntitlements(true, true)
+				)
+		when(loginService.login(eq("client-id"), any(Consumer))).thenReturn(result)
+		def task = loginTask(tempDir.resolve("missing.json"), "client-id", store, loginService)
+
+		when:
+		task.login()
+
+		then:
+		def order = inOrder(store, loginService)
+		order.verify(store).prepare()
+		assert order.verify(loginService).login(eq("client-id"), any(Consumer)) == null
+		verify(store).write(new MicrosoftAccountStore.Account("client-id", "refresh-token", "profile-id", "Player"))
+	}
+
+	def "login exposes secure storage preparation errors"() {
+		given:
+		def store = mock(MicrosoftAccountStore)
+		def loginService = mock(MicrosoftLoginService)
+		def task = loginTask(tempDir.resolve("missing.json"), "client-id", store, loginService)
+		when(store.prepare()).thenThrow(new LoomNativePlatformException("TPM secure storage is unavailable"))
+
+		when:
+		task.login()
+
+		then:
+		def exception = thrown(GradleException)
+		exception.message == "Microsoft login failed: TPM secure storage is unavailable"
+		assert verify(loginService, never()).login(any(), any()) == null
+	}
+
+	def "logout removes an orphaned platform key when no account exists"() {
+		given:
+		def store = mock(MicrosoftAccountStore)
+		def task = logoutTask(tempDir.resolve("missing.json"), store)
+
+		when:
+		task.logout()
+
+		then:
+		task.storeCreated
+		verify(store).delete()
+	}
+
+	def "logout deletes an existing account"() {
+		given:
+		Path accountFile = Files.writeString(tempDir.resolve("account.json"), "stored")
+		def store = mock(MicrosoftAccountStore)
+		def task = logoutTask(accountFile, store)
+
+		when:
+		task.logout()
+
+		then:
+		verify(store).delete()
+		verify(store, never()).prepare()
+	}
+
+	def "logout remains idempotent on an unsupported platform"() {
+		given:
+		Path accountFile = tempDir.resolve("missing.json")
+		def task = logoutTask(accountFile, null, new UnsupportedOperationException("unsupported"))
+
+		when:
+		task.logout()
+
+		then:
+		!Files.exists(accountFile)
+	}
+
+	def "logout deletes an account file on an unsupported platform"() {
+		given:
+		Path accountFile = Files.writeString(tempDir.resolve("account.json"), "stored")
+		def task = logoutTask(accountFile, null, new UnsupportedOperationException("unsupported"))
+
+		when:
+		task.logout()
+
+		then:
+		!Files.exists(accountFile)
+	}
+
+	private static TestMicrosoftLoginTask loginTask(Path accountFile, String clientId,
+			MicrosoftAccountStore store = null, MicrosoftLoginService loginService = null,
+			MinecraftAccessTokenProvider accessTokenProvider = null) {
+		def project = ProjectBuilder.builder().build()
+		def task = project.tasks.create("microsoftLoginTest", TestMicrosoftLoginTask)
+		task.testAccountPath = accountFile
+		task.clientId = clientId
+		task.accountStore = store
+		task.loginService = loginService
+		task.accessTokenProvider = accessTokenProvider
+		return task
+	}
+
+	private static TestMicrosoftLogoutTask logoutTask(Path accountFile, MicrosoftAccountStore store = null,
+			RuntimeException storeCreationFailure = null) {
+		def project = ProjectBuilder.builder().build()
+		def task = project.tasks.create("microsoftLogoutTest", TestMicrosoftLogoutTask)
+		task.testAccountPath = accountFile
+		task.accountStore = store
+		task.storeCreationFailure = storeCreationFailure
+		return task
+	}
+
+	static abstract class TestMicrosoftLoginTask extends MicrosoftLoginTask {
+		Path testAccountPath
+		String clientId
+		MicrosoftAccountStore accountStore
+		MicrosoftLoginService loginService
+		MinecraftAccessTokenProvider accessTokenProvider
+		boolean storeCreated
+
+		@Override
+		protected Path getAccountPath() {
+			return testAccountPath
+		}
+
+		@Override
+		protected String getClientId() {
+			return clientId
+		}
+
+		@Override
+		protected MicrosoftAccountStore createAccountStore(Path path) {
+			storeCreated = true
+			return accountStore
+		}
+
+		@Override
+		protected MicrosoftLoginService createLoginService() {
+			return loginService
+		}
+
+		@Override
+		protected MinecraftAccessTokenProvider createAccessTokenProvider() {
+			return accessTokenProvider
+		}
+	}
+
+	static abstract class TestMicrosoftLogoutTask extends MicrosoftLogoutTask {
+		Path testAccountPath
+		MicrosoftAccountStore accountStore
+		RuntimeException storeCreationFailure
+		boolean storeCreated
+
+		@Override
+		protected Path getAccountPath() {
+			return testAccountPath
+		}
+
+		@Override
+		protected MicrosoftAccountStore createAccountStore(Path path) {
+			storeCreated = true
+
+			if (storeCreationFailure != null) {
+				throw storeCreationFailure
+			}
+
+			return accountStore
+		}
+	}
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftGameAuthenticationTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftGameAuthenticationTest.groovy
@@ -1,0 +1,212 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit.auth
+
+import java.nio.file.Path
+import java.util.function.Consumer
+
+import javax.crypto.SecretKey
+import javax.crypto.spec.SecretKeySpec
+
+import org.slf4j.Logger
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import net.fabricmc.loom.task.launch.auth.MicrosoftAccountStore
+import net.fabricmc.loom.task.launch.auth.MicrosoftGameAuthentication
+import net.fabricmc.loom.task.launch.auth.MinecraftAccessTokenProvider
+import net.fabricmc.loom.util.nativeplatform.EncryptionKeyStore
+import net.fabricmc.loom.util.nativeplatform.LoomNativePlatformException
+
+class MicrosoftGameAuthenticationTest extends Specification {
+	@TempDir
+	Path directory
+
+	ReversibleTestKeyStore keyStore
+	MicrosoftAccountStore accountStore
+
+	def setup() {
+		keyStore = new ReversibleTestKeyStore()
+		accountStore = new MicrosoftAccountStore(directory.resolve("microsoft-auth.json"), keyStore)
+	}
+
+	def "returns launch arguments and persists the rotated refresh token"() {
+		given:
+		writeAccount()
+		def provider = Mock(MinecraftAccessTokenProvider)
+		def logger = Mock(Logger)
+		def authentication = new MicrosoftGameAuthentication(accountStore, provider, logger)
+
+		when:
+		def arguments = authentication.getLaunchArguments()
+
+		then:
+		1 * provider.getAccessToken("client-id", "old-refresh-token", _) >> { String clientId, String refreshToken, Consumer<String> consumer ->
+			consumer.accept("new-refresh-token")
+			return new MinecraftAccessTokenProvider.AccessToken("minecraft-access-token", "new-refresh-token", 3600)
+		}
+		arguments == [
+			"--username",
+			"Player",
+			"--uuid",
+			"0123456789abcdef0123456789abcdef",
+			"--accessToken",
+			"minecraft-access-token",
+			"--userType",
+			"msa"
+		]
+		accountStore.read() == new MicrosoftAccountStore.Account(
+				"client-id", "new-refresh-token", "0123456789abcdef0123456789abcdef", "Player"
+				)
+	}
+
+	def "does nothing when no stored account exists"() {
+		given:
+		def provider = Mock(MinecraftAccessTokenProvider)
+		def authentication = new MicrosoftGameAuthentication(accountStore, provider, Mock(Logger))
+
+		when:
+		def arguments = authentication.getLaunchArguments()
+
+		then:
+		0 * provider._
+		arguments.empty
+	}
+
+	def "does not fail the launch when the stored account cannot be read"() {
+		given:
+		writeAccount()
+		keyStore.failReads = true
+		def provider = Mock(MinecraftAccessTokenProvider)
+		def authentication = new MicrosoftGameAuthentication(accountStore, provider, Mock(Logger))
+
+		when:
+		def arguments = authentication.getLaunchArguments()
+
+		then:
+		0 * provider._
+		arguments.empty
+	}
+
+	def "does not fail the launch when refreshing the account fails"() {
+		given:
+		writeAccount()
+		def provider = Mock(MinecraftAccessTokenProvider)
+		def authentication = new MicrosoftGameAuthentication(accountStore, provider, Mock(Logger))
+
+		when:
+		def arguments = authentication.getLaunchArguments()
+
+		then:
+		1 * provider.getAccessToken("client-id", "old-refresh-token", _) >> { throw new IOException("refresh failed") }
+		arguments.empty
+	}
+
+	def "persists a rotated refresh token when downstream Minecraft authentication fails"() {
+		given:
+		writeAccount()
+		def provider = Mock(MinecraftAccessTokenProvider)
+		def authentication = new MicrosoftGameAuthentication(accountStore, provider, Mock(Logger))
+
+		when:
+		def arguments = authentication.getLaunchArguments()
+
+		then:
+		1 * provider.getAccessToken("client-id", "old-refresh-token", _) >> { String clientId, String refreshToken, Consumer<String> consumer ->
+			consumer.accept("new-refresh-token")
+			throw new IOException("downstream authentication failed")
+		}
+		arguments.empty
+		accountStore.read().refreshToken() == "new-refresh-token"
+	}
+
+	def "uses a refreshed access token when persisting its rotated refresh token fails"() {
+		given:
+		writeAccount()
+		keyStore.failStores = true
+		def provider = Mock(MinecraftAccessTokenProvider)
+		def authentication = new MicrosoftGameAuthentication(accountStore, provider, Mock(Logger))
+
+		when:
+		def arguments = authentication.getLaunchArguments()
+
+		then:
+		1 * provider.getAccessToken("client-id", "old-refresh-token", _) >> { String clientId, String refreshToken, Consumer<String> consumer ->
+			consumer.accept("new-refresh-token")
+			return new MinecraftAccessTokenProvider.AccessToken("minecraft-access-token", "new-refresh-token", 3600)
+		}
+		arguments == [
+			"--username",
+			"Player",
+			"--uuid",
+			"0123456789abcdef0123456789abcdef",
+			"--accessToken",
+			"minecraft-access-token",
+			"--userType",
+			"msa"
+		]
+	}
+
+	private void writeAccount() {
+		accountStore.write(new MicrosoftAccountStore.Account(
+				"client-id", "old-refresh-token", "0123456789abcdef0123456789abcdef", "Player"
+				))
+	}
+
+	private static final class ReversibleTestKeyStore implements EncryptionKeyStore {
+		boolean failReads
+		boolean failStores
+
+		@Override
+		void prepare() {
+		}
+
+		@Override
+		StoredKey store(SecretKey key) throws LoomNativePlatformException {
+			if (failStores) {
+				throw new LoomNativePlatformException("write failed")
+			}
+
+			return new StoredKey(key.algorithm, transform(key.encoded))
+		}
+
+		@Override
+		SecretKey read(StoredKey key) throws LoomNativePlatformException {
+			if (failReads) {
+				throw new LoomNativePlatformException("read failed")
+			}
+
+			return new SecretKeySpec(transform(key.data()), key.algorithm())
+		}
+
+		@Override
+		void delete() {
+		}
+
+		private static byte[] transform(byte[] input) {
+			return input.collect { (byte) (it ^ 0x5A) } as byte[]
+		}
+	}
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftLoginFlowTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftLoginFlowTest.groovy
@@ -78,9 +78,10 @@ class MicrosoftLoginFlowTest extends Specification {
 		def xsts = new MicrosoftAuthService.XboxToken("xsts", "user-hash")
 		def minecraftToken = new MicrosoftAuthService.MinecraftToken("minecraft-token", "Bearer", 86400)
 		def provider = new MinecraftAccessTokenProviderImpl(auth)
+		def rotatedRefreshTokens = []
 
 		when:
-		def result = provider.getAccessToken("client-id", "old-refresh-token")
+		def result = provider.getAccessToken("client-id", "old-refresh-token") { rotatedRefreshTokens.add(it) }
 
 		then:
 		1 * auth.refreshMicrosoftToken("client-id", "old-refresh-token") >> microsoftToken
@@ -91,24 +92,27 @@ class MicrosoftLoginFlowTest extends Specification {
 		result.accessToken() == "minecraft-token"
 		result.refreshToken() == "new-refresh-token"
 		result.expiresIn() == 86400
+		rotatedRefreshTokens == ["new-refresh-token"]
 	}
 
-	def "per-launch provider rejects an account that is no longer entitled to play"() {
+	def "per-launch provider reports the rotated token before a downstream entitlement failure"() {
 		given:
 		def auth = Stub(MicrosoftAuthService) {
-			refreshMicrosoftToken(_, _) >> new MicrosoftAuthService.MicrosoftToken.Success("microsoft-token", "refresh-token", "Bearer", 3600)
+			refreshMicrosoftToken(_, _) >> new MicrosoftAuthService.MicrosoftToken.Success("microsoft-token", "new-refresh-token", "Bearer", 3600)
 			authenticateXboxUser(_) >> new MicrosoftAuthService.XboxToken("xbox-user", "user-hash")
 			authorizeMinecraftServices(_) >> new MicrosoftAuthService.XboxToken("xsts", "user-hash")
 			loginToMinecraft(_, _) >> new MicrosoftAuthService.MinecraftToken("minecraft-token", "Bearer", 86400)
 			fetchMinecraftEntitlements(_) >> new MicrosoftAuthService.MinecraftEntitlements(false, false)
 		}
 		def provider = new MinecraftAccessTokenProviderImpl(auth)
+		def rotatedRefreshTokens = []
 
 		when:
-		provider.getAccessToken("client-id", "refresh-token")
+		provider.getAccessToken("client-id", "old-refresh-token") { rotatedRefreshTokens.add(it) }
 
 		then:
 		def exception = thrown IOException
 		exception.message == "The Microsoft account is not entitled to play Minecraft"
+		rotatedRefreshTokens == ["new-refresh-token"]
 	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftLoginFlowTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/auth/MicrosoftLoginFlowTest.groovy
@@ -1,0 +1,114 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit.auth
+
+import spock.lang.Specification
+
+import net.fabricmc.loom.task.launch.auth.MicrosoftAuthService
+import net.fabricmc.loom.task.launch.auth.MicrosoftLoginServiceImpl
+import net.fabricmc.loom.task.launch.auth.MinecraftAccessTokenProviderImpl
+
+class MicrosoftLoginFlowTest extends Specification {
+	def "login reports the device code, polls, and returns durable account details"() {
+		given:
+		def auth = Mock(MicrosoftAuthService)
+		def deviceCode = new MicrosoftAuthService.DeviceCode(
+				"device-code", "ABCD-EFGH", URI.create("https://microsoft.com/devicelogin"), 900, 1, "Sign in"
+				)
+		def microsoftToken = new MicrosoftAuthService.MicrosoftToken.Success("microsoft-token", "refresh-token", "Bearer", 3600)
+		def xboxUser = new MicrosoftAuthService.XboxToken("xbox-user", "user-hash")
+		def xsts = new MicrosoftAuthService.XboxToken("xsts", "user-hash")
+		def minecraftToken = new MicrosoftAuthService.MinecraftToken("minecraft-token", "Bearer", 86400)
+		def entitlements = new MicrosoftAuthService.MinecraftEntitlements(true, true)
+		def profile = new MicrosoftAuthService.MinecraftProfile("uuid", "Player")
+		def sleeps = []
+		def reportedCode
+		def login = new MicrosoftLoginServiceImpl(auth, { sleeps.add(it) })
+
+		when:
+		def result = login.login("client-id") { reportedCode = it }
+
+		then:
+		1 * auth.requestDeviceCode("client-id") >> deviceCode
+		2 * auth.requestMicrosoftToken("client-id", "device-code") >>> [
+			new MicrosoftAuthService.MicrosoftToken.Polling(
+			MicrosoftAuthService.MicrosoftToken.Polling.Status.AUTHORIZATION_PENDING, null
+			),
+			microsoftToken
+		]
+		1 * auth.authenticateXboxUser("microsoft-token") >> xboxUser
+		1 * auth.authorizeMinecraftServices(xboxUser) >> xsts
+		1 * auth.loginToMinecraft("user-hash", "xsts") >> minecraftToken
+		1 * auth.fetchMinecraftEntitlements("minecraft-token") >> entitlements
+		1 * auth.fetchMinecraftProfile("minecraft-token") >> Optional.of(profile)
+		reportedCode == deviceCode
+		sleeps*.seconds == [1, 1]
+		result.refreshToken() == "refresh-token"
+		result.profile() == profile
+		result.entitlements().ownsMinecraft()
+	}
+
+	def "per-launch provider refreshes the complete chain and returns the rotated refresh token"() {
+		given:
+		def auth = Mock(MicrosoftAuthService)
+		def microsoftToken = new MicrosoftAuthService.MicrosoftToken.Success("microsoft-token", "new-refresh-token", "Bearer", 3600)
+		def xboxUser = new MicrosoftAuthService.XboxToken("xbox-user", "user-hash")
+		def xsts = new MicrosoftAuthService.XboxToken("xsts", "user-hash")
+		def minecraftToken = new MicrosoftAuthService.MinecraftToken("minecraft-token", "Bearer", 86400)
+		def provider = new MinecraftAccessTokenProviderImpl(auth)
+
+		when:
+		def result = provider.getAccessToken("client-id", "old-refresh-token")
+
+		then:
+		1 * auth.refreshMicrosoftToken("client-id", "old-refresh-token") >> microsoftToken
+		1 * auth.authenticateXboxUser("microsoft-token") >> xboxUser
+		1 * auth.authorizeMinecraftServices(xboxUser) >> xsts
+		1 * auth.loginToMinecraft("user-hash", "xsts") >> minecraftToken
+		1 * auth.fetchMinecraftEntitlements("minecraft-token") >> new MicrosoftAuthService.MinecraftEntitlements(true, false)
+		result.accessToken() == "minecraft-token"
+		result.refreshToken() == "new-refresh-token"
+		result.expiresIn() == 86400
+	}
+
+	def "per-launch provider rejects an account that is no longer entitled to play"() {
+		given:
+		def auth = Stub(MicrosoftAuthService) {
+			refreshMicrosoftToken(_, _) >> new MicrosoftAuthService.MicrosoftToken.Success("microsoft-token", "refresh-token", "Bearer", 3600)
+			authenticateXboxUser(_) >> new MicrosoftAuthService.XboxToken("xbox-user", "user-hash")
+			authorizeMinecraftServices(_) >> new MicrosoftAuthService.XboxToken("xsts", "user-hash")
+			loginToMinecraft(_, _) >> new MicrosoftAuthService.MinecraftToken("minecraft-token", "Bearer", 86400)
+			fetchMinecraftEntitlements(_) >> new MicrosoftAuthService.MinecraftEntitlements(false, false)
+		}
+		def provider = new MinecraftAccessTokenProviderImpl(auth)
+
+		when:
+		provider.getAccessToken("client-id", "refresh-token")
+
+		then:
+		def exception = thrown IOException
+		exception.message == "The Microsoft account is not entitled to play Minecraft"
+	}
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/nativeplatform/EncryptionKeyStoreFactoryTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/nativeplatform/EncryptionKeyStoreFactoryTest.groovy
@@ -22,29 +22,38 @@
  * SOFTWARE.
  */
 
-package net.fabricmc.loom.task.launch.auth;
+package net.fabricmc.loom.test.unit.nativeplatform
 
-import java.io.IOException;
-import java.util.Objects;
-import java.util.function.Consumer;
+import java.nio.file.Path
 
-public final class MinecraftAccessTokenProviderImpl implements MinecraftAccessTokenProvider {
-	private final MicrosoftAuthService authService;
+import spock.lang.Requires
+import spock.lang.Specification
+import spock.lang.TempDir
 
-	public MinecraftAccessTokenProviderImpl() {
-		this(new MicrosoftAuthServiceImpl());
+import net.fabricmc.loom.util.nativeplatform.EncryptionKeyStoreFactory
+
+class EncryptionKeyStoreFactoryTest extends Specification {
+	@TempDir
+	Path tempDir
+
+	def "uses a stable key name for a normalized account path"() {
+		expect:
+		EncryptionKeyStoreFactory.keyNameFor(tempDir.resolve("nested/../microsoft-auth.json")) ==
+				EncryptionKeyStoreFactory.keyNameFor(tempDir.resolve("microsoft-auth.json"))
 	}
 
-	public MinecraftAccessTokenProviderImpl(MicrosoftAuthService authService) {
-		this.authService = Objects.requireNonNull(authService, "authService");
+	def "uses distinct key names for distinct Gradle user homes"() {
+		expect:
+		EncryptionKeyStoreFactory.keyNameFor(tempDir.resolve("first/caches/fabric-loom/microsoft-auth.json")) !=
+				EncryptionKeyStoreFactory.keyNameFor(tempDir.resolve("second/caches/fabric-loom/microsoft-auth.json"))
 	}
 
-	@Override
-	public AccessToken getAccessToken(String clientId, String refreshToken, Consumer<String> refreshTokenConsumer) throws IOException {
-		Objects.requireNonNull(refreshTokenConsumer, "refreshTokenConsumer");
-		MicrosoftAuthService.MicrosoftToken.Success microsoftToken = authService.refreshMicrosoftToken(clientId, refreshToken);
-		refreshTokenConsumer.accept(microsoftToken.refreshToken());
-		MinecraftAuthFlow.Result minecraft = MinecraftAuthFlow.authenticate(authService, microsoftToken.accessToken());
-		return new AccessToken(minecraft.token().accessToken(), microsoftToken.refreshToken(), minecraft.token().expiresIn());
+	@Requires({
+		os.windows
+	})
+	def "uses the same key name for differently cased Windows paths"() {
+		expect:
+		EncryptionKeyStoreFactory.keyNameFor(tempDir.resolve("Fabric-Loom/Microsoft-Auth.json")) ==
+				EncryptionKeyStoreFactory.keyNameFor(tempDir.resolve("fabric-loom/microsoft-auth.json"))
 	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/unit/nativeplatform/EncryptionKeyStoreFactoryTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/nativeplatform/EncryptionKeyStoreFactoryTest.groovy
@@ -30,6 +30,7 @@ import spock.lang.Requires
 import spock.lang.Specification
 import spock.lang.TempDir
 
+import net.fabricmc.loom.util.nativeplatform.EncryptionKeyStore
 import net.fabricmc.loom.util.nativeplatform.EncryptionKeyStoreFactory
 
 class EncryptionKeyStoreFactoryTest extends Specification {
@@ -46,6 +47,14 @@ class EncryptionKeyStoreFactoryTest extends Specification {
 		expect:
 		EncryptionKeyStoreFactory.keyNameFor(tempDir.resolve("first/caches/fabric-loom/microsoft-auth.json")) !=
 				EncryptionKeyStoreFactory.keyNameFor(tempDir.resolve("second/caches/fabric-loom/microsoft-auth.json"))
+	}
+
+	@Requires({
+		os.linux
+	})
+	def "uses the fallback key store on Linux"() {
+		expect:
+		EncryptionKeyStoreFactory.create(tempDir.resolve("microsoft-auth.json")).is(EncryptionKeyStore.FALLBACK)
 	}
 
 	@Requires({

--- a/src/test/groovy/net/fabricmc/loom/test/unit/nativeplatform/EncryptionKeyStoreTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/nativeplatform/EncryptionKeyStoreTest.groovy
@@ -1,0 +1,106 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit.nativeplatform
+
+import javax.crypto.SecretKey
+
+import spock.lang.Specification
+
+import net.fabricmc.loom.util.nativeplatform.EncryptionKeyStore
+
+class EncryptionKeyStoreTest extends Specification {
+	EncryptionKeyStore store = EncryptionKeyStore.FALLBACK
+
+	def "fallback lifecycle operations do not require platform state"() {
+		when:
+		store.prepare()
+		store.delete()
+
+		then:
+		noExceptionThrown()
+	}
+
+	def "fallback stores and reads an encoded key"() {
+		given:
+		byte[] encoded = (0..<32) as byte[]
+		SecretKey original = new BorrowedSecretKey("AES", encoded)
+
+		when:
+		def stored = store.store(original)
+		SecretKey recovered = store.read(stored)
+
+		then:
+		stored.algorithm() == "AES"
+		stored.data() == encoded
+		recovered.algorithm == "AES"
+		recovered.encoded == encoded
+	}
+
+	def "fallback defensively copies key data"() {
+		given:
+		byte[] encoded = new byte[32]
+		encoded[0] = 42
+
+		when:
+		def stored = store.store(new BorrowedSecretKey("AES", encoded))
+		encoded[0] = 0
+		byte[] storedData = stored.data()
+		storedData[0] = 1
+
+		then:
+		stored.data()[0] == 42
+		store.read(stored).encoded[0] == 42
+	}
+
+	def "fallback rejects an unencodable key"() {
+		when:
+		store.store(new BorrowedSecretKey("AES", encoded))
+
+		then:
+		def exception = thrown IllegalArgumentException
+		exception.message == "key must be encodable"
+
+		where:
+		encoded << [null, new byte[0]]
+	}
+
+	private static final class BorrowedSecretKey implements SecretKey {
+		private static final long serialVersionUID = 1L
+
+		final String algorithm
+		final String format = "RAW"
+		private final byte[] encoded
+
+		private BorrowedSecretKey(String algorithm, byte[] encoded) {
+			this.algorithm = algorithm
+			this.encoded = encoded
+		}
+
+		@Override
+		byte[] getEncoded() {
+			return encoded
+		}
+	}
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/nativeplatform/MacOSEncryptionKeyStoreTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/nativeplatform/MacOSEncryptionKeyStoreTest.groovy
@@ -1,0 +1,131 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit.nativeplatform
+
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+
+import spock.lang.Requires
+import spock.lang.Specification
+
+import net.fabricmc.loom.util.nativeplatform.EncryptionKeyStore
+import net.fabricmc.loom.util.nativeplatform.LoomNativePlatformException
+import net.fabricmc.loom.util.nativeplatform.MacOSEncryptionKeyStore
+
+@Requires({
+	os.macOs
+})
+class MacOSEncryptionKeyStoreTest extends Specification {
+	String keyName = "FabricLoomEncryptionKeyStoreTest-${UUID.randomUUID()}"
+	MacOSEncryptionKeyStore store = new MacOSEncryptionKeyStore(keyName, EncryptionKeyStore.UserInteraction.DISABLED)
+
+	def cleanup() {
+		store.delete()
+	}
+
+	def "prepares a persistent key without user interaction"() {
+		when:
+		store.prepare()
+		new MacOSEncryptionKeyStore(keyName, EncryptionKeyStore.UserInteraction.DISABLED).prepare()
+
+		then:
+		noExceptionThrown()
+	}
+
+	def "stores and reads a Java encryption key without user interaction"() {
+		given:
+		SecretKey original = aesKey()
+
+		when:
+		def stored = store.store(original)
+		SecretKey recovered = store.read(stored)
+
+		then:
+		stored.algorithm() == "AES"
+		stored.data() != original.encoded
+		recovered.algorithm == "AES"
+		recovered.encoded == original.encoded
+	}
+
+	def "storing a key does not clear caller-owned key bytes"() {
+		given:
+		byte[] encoded = new byte[32]
+		encoded[0] = 42
+		byte[] expected = encoded.clone()
+		SecretKey key = new BorrowedSecretKey(encoded)
+
+		when:
+		store.store(key)
+
+		then:
+		encoded == expected
+	}
+
+	def "persisted macOS key can be reopened by another store instance"() {
+		given:
+		SecretKey original = aesKey()
+		def stored = store.store(original)
+		def reopened = new MacOSEncryptionKeyStore(keyName, EncryptionKeyStore.UserInteraction.DISABLED)
+
+		expect:
+		reopened.read(stored).encoded == original.encoded
+	}
+
+	def "deleting the macOS key makes stored values unreadable"() {
+		given:
+		def stored = store.store(aesKey())
+
+		when:
+		store.delete()
+		store.read(stored)
+
+		then:
+		def exception = thrown LoomNativePlatformException
+		exception.message.contains("does not exist")
+	}
+
+	private static SecretKey aesKey() {
+		KeyGenerator generator = KeyGenerator.getInstance("AES")
+		generator.init(256)
+		return generator.generateKey()
+	}
+
+	private static final class BorrowedSecretKey implements SecretKey {
+		private static final long serialVersionUID = 1L
+
+		final String algorithm = "AES"
+		final String format = "RAW"
+		private final byte[] encoded
+
+		private BorrowedSecretKey(byte[] encoded) {
+			this.encoded = encoded
+		}
+
+		@Override
+		byte[] getEncoded() {
+			return encoded
+		}
+	}
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/nativeplatform/WindowsEncryptionKeyStoreTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/nativeplatform/WindowsEncryptionKeyStoreTest.groovy
@@ -1,0 +1,122 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit.nativeplatform
+
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+
+import spock.lang.Requires
+import spock.lang.Specification
+
+import net.fabricmc.loom.util.nativeplatform.EncryptionKeyStore
+import net.fabricmc.loom.util.nativeplatform.LoomNativePlatformException
+import net.fabricmc.loom.util.nativeplatform.WindowsEncryptionKeyStore
+
+@Requires({
+	os.windows
+})
+class WindowsEncryptionKeyStoreTest extends Specification {
+	String keyName = "FabricLoomEncryptionKeyStoreTest-${UUID.randomUUID()}"
+	WindowsEncryptionKeyStore store = new WindowsEncryptionKeyStore(keyName, EncryptionKeyStore.UserInteraction.DISABLED)
+
+	def cleanup() {
+		store.delete()
+	}
+
+	def "stores and reads a Java encryption key without user interaction"() {
+		given:
+		SecretKey original = aesKey()
+
+		when:
+		def stored = store.store(original)
+		SecretKey recovered = store.read(stored)
+
+		then:
+		stored.algorithm() == "AES"
+		stored.data() != original.encoded
+		recovered.algorithm == "AES"
+		recovered.encoded == original.encoded
+	}
+
+	def "storing a key does not clear caller-owned key bytes"() {
+		given:
+		byte[] encoded = new byte[32]
+		encoded[0] = 42
+		byte[] expected = encoded.clone()
+		SecretKey key = new BorrowedSecretKey(encoded)
+
+		when:
+		store.store(key)
+
+		then:
+		encoded == expected
+	}
+
+	def "persisted Windows key can be reopened by another store instance"() {
+		given:
+		SecretKey original = aesKey()
+		def stored = store.store(original)
+		def reopened = new WindowsEncryptionKeyStore(keyName, EncryptionKeyStore.UserInteraction.DISABLED)
+
+		expect:
+		reopened.read(stored).encoded == original.encoded
+	}
+
+	def "deleting the Windows key makes stored values unreadable"() {
+		given:
+		def stored = store.store(aesKey())
+
+		when:
+		store.delete()
+		store.read(stored)
+
+		then:
+		def exception = thrown LoomNativePlatformException
+		exception.message.contains("does not exist")
+	}
+
+	private static SecretKey aesKey() {
+		KeyGenerator generator = KeyGenerator.getInstance("AES")
+		generator.init(256)
+		return generator.generateKey()
+	}
+
+	private static final class BorrowedSecretKey implements SecretKey {
+		private static final long serialVersionUID = 1L
+
+		final String algorithm = "AES"
+		final String format = "RAW"
+		private final byte[] encoded
+
+		private BorrowedSecretKey(byte[] encoded) {
+			this.encoded = encoded
+		}
+
+		@Override
+		byte[] getEncoded() {
+			return encoded
+		}
+	}
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/nativeplatform/WindowsEncryptionKeyStoreTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/nativeplatform/WindowsEncryptionKeyStoreTest.groovy
@@ -45,6 +45,15 @@ class WindowsEncryptionKeyStoreTest extends Specification {
 		store.delete()
 	}
 
+	def "prepares a persistent key without user interaction"() {
+		when:
+		store.prepare()
+		new WindowsEncryptionKeyStore(keyName, EncryptionKeyStore.UserInteraction.DISABLED).prepare()
+
+		then:
+		noExceptionThrown()
+	}
+
 	def "stores and reads a Java encryption key without user interaction"() {
 		given:
 		SecretKey original = aesKey()


### PR DESCRIPTION
This PR adds support for authenticating with your Microsoft account to play a fully licensed copy of the game in dev, nothing changes if you do not wish to login. The following steps can be taken to login:

1. run the `microsoftLogin` task
2. grant access via your OS to allow loom to store its encryption key in a secure location
3. perform the Microsoft device authentication flow
4. refresh token get securely saved

Any following client runs (via the gradle task) will use the refresh token to acquire a Minecraft access token. If this fails an error is logged but the game will still start. If you run the game often (I have been told once a week, but dont quote me) you should never need to go through the full login flow.

As far as I am aware this is the most secure implimentation of storing the secrect refresh tokens in any Minecraft launcher (please correct me if im wrong!). On windows we store an encryption key in the TPM and require user interaction (with an optional password) to read this key. The key is used to encrypt the refresh token along with some other data into a json file. On macos we use the system keychain. This is to try and make it much much harder (but not impossible) for malware to read these tokens and take over your account.

Running the `microsoftLogout` task will delete the refresh token and remove the encryption key from the TPM/keychain.

If it looks like enterprise java code, thats becuase I wanted to make sure we could unit test as much of this as possible. There is a lot of complexity here that cannot easily be tested end-to-end. Yes, I have used AI to help me write some of this (especially tests) but a vast amount of manual research, design and effort has gone into this, I have been thinking of adding this for a long while. Do please point out issues. Its only really useful now that there is an option for the intelij runs to use the Gradle tasks.