### PR TITLE
Add support for `markdown` mapping metadata entry

### DIFF
--- a/src/main/java/net/fabricmc/loom/api/processor/MarkdownJavadocOption.java
+++ b/src/main/java/net/fabricmc/loom/api/processor/MarkdownJavadocOption.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.api.processor;
+
+import org.jetbrains.annotations.ApiStatus;
+
+/// The state of Markdown javadoc support in the current project configuration.
+@ApiStatus.Experimental
+public enum MarkdownJavadocOption {
+	/// Markdown javadoc is not supported with this project setup.
+	UNSUPPORTED,
+	/// Markdown javadoc is supported, but not required, with this project setup.
+	SUPPORTED, // currently unused in Loom
+	/// Markdown javadoc is required with this project setup.
+	REQUIRED
+}

--- a/src/main/java/net/fabricmc/loom/api/processor/SpecContext.java
+++ b/src/main/java/net/fabricmc/loom/api/processor/SpecContext.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaPlugin;
+import org.jetbrains.annotations.ApiStatus;
 
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.configuration.processors.speccontext.ProjectView;
@@ -54,6 +55,9 @@ public interface SpecContext {
 	List<FabricModJson> modDependenciesCompileRuntimeClient();
 
 	MappingsNamespace productionNamespace();
+
+	@ApiStatus.Experimental
+	MarkdownJavadocOption markdownJavadocOption();
 
 	default List<FabricModJson> allMods() {
 		return Stream.concat(modDependencies().stream(), localMods().stream()).toList();

--- a/src/main/java/net/fabricmc/loom/configuration/processors/ModJavadocProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/ModJavadocProcessor.java
@@ -45,9 +45,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
+import net.fabricmc.loom.api.processor.MarkdownJavadocOption;
 import net.fabricmc.loom.api.processor.MinecraftJarProcessor;
 import net.fabricmc.loom.api.processor.ProcessorContext;
 import net.fabricmc.loom.api.processor.SpecContext;
+import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
 import net.fabricmc.loom.util.Checksum;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.fmj.FabricModJson;
@@ -81,7 +83,7 @@ public abstract class ModJavadocProcessor implements MinecraftJarProcessor<ModJa
 		List<ModJavadoc> javadocs = new ArrayList<>();
 
 		for (FabricModJson fabricModJson : context.modDependenciesCompileRuntime()) {
-			ModJavadoc javadoc = ModJavadoc.create(fabricModJson, context.productionNamespace());
+			ModJavadoc javadoc = ModJavadoc.create(fabricModJson, context.productionNamespace(), context.markdownJavadocOption());
 
 			if (javadoc != null) {
 				javadocs.add(javadoc);
@@ -117,7 +119,7 @@ public abstract class ModJavadocProcessor implements MinecraftJarProcessor<ModJa
 
 	public record ModJavadoc(String modId, MemoryMappingTree mappingTree, String mappingsHash) {
 		@Nullable
-		public static ModJavadoc create(FabricModJson fabricModJson, MappingsNamespace productionNamespace) {
+		public static ModJavadoc create(FabricModJson fabricModJson, MappingsNamespace productionNamespace, MarkdownJavadocOption markdownJavadocOption) {
 			final String modId = fabricModJson.getId();
 			final JsonElement customElement = fabricModJson.getCustom(Constants.CustomModJsonKeys.PROVIDED_JAVADOC);
 
@@ -151,6 +153,20 @@ public abstract class ModJavadocProcessor implements MinecraftJarProcessor<ModJa
 
 			if (!mappings.getSrcNamespace().equals(productionNamespace.toString())) {
 				throw new IllegalStateException("Javadoc provided by mod (%s) must have an %s source namespace".formatted(modId, productionNamespace.toString()));
+			}
+
+			switch (markdownJavadocOption) {
+			case REQUIRED -> {
+				if (mappings.getMetadata(MappingConfiguration.MARKDOWN_METADATA_KEY).isEmpty()) {
+					LOGGER.warn("Mod-provided javadoc from mod {} should have the " + MappingConfiguration.MARKDOWN_METADATA_KEY + " metadata entry", modId);
+				}
+			}
+
+			case UNSUPPORTED -> {
+				if (!mappings.getMetadata(MappingConfiguration.MARKDOWN_METADATA_KEY).isEmpty()) {
+					LOGGER.warn("Mod-provided javadoc from mod {} has the " + MappingConfiguration.MARKDOWN_METADATA_KEY + " metadata entry, but it is not supported with this project configuration", modId);
+				}
+			}
 			}
 
 			return new ModJavadoc(modId, mappings, mappingsHash);

--- a/src/main/java/net/fabricmc/loom/configuration/processors/speccontext/DeobfSpecContext.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/speccontext/DeobfSpecContext.java
@@ -43,6 +43,7 @@ import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
 
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
+import net.fabricmc.loom.api.processor.MarkdownJavadocOption;
 import net.fabricmc.loom.api.processor.SpecContext;
 import net.fabricmc.loom.util.AsyncCache;
 import net.fabricmc.loom.util.fmj.FabricModJson;
@@ -233,5 +234,10 @@ public record DeobfSpecContext(List<FabricModJson> modDependencies,
 	@Override
 	public MappingsNamespace productionNamespace() {
 		return MappingsNamespace.OFFICIAL;
+	}
+
+	@Override
+	public MarkdownJavadocOption markdownJavadocOption() {
+		return MarkdownJavadocOption.REQUIRED;
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/processors/speccontext/RemappedSpecContext.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/speccontext/RemappedSpecContext.java
@@ -39,11 +39,12 @@ import java.util.stream.Stream;
 
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaPlugin;
-import org.jspecify.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
+import org.jspecify.annotations.Nullable;
 
-import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.api.RemapConfigurationSettings;
+import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
+import net.fabricmc.loom.api.processor.MarkdownJavadocOption;
 import net.fabricmc.loom.api.processor.SpecContext;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftSourceSets;
 import net.fabricmc.loom.util.AsyncCache;
@@ -207,6 +208,11 @@ public record RemappedSpecContext(
 				.filter(modHolder -> !modHolder.common())
 				.map(ModHolder::mod)
 				.toList();
+	}
+
+	@Override
+	public MarkdownJavadocOption markdownJavadocOption() {
+		return MarkdownJavadocOption.UNSUPPORTED;
 	}
 
 	private record ModHolder(FabricModJson mod, boolean common) {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
@@ -40,19 +40,20 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import net.fabricmc.loom.configuration.DependencyInfo;
+import net.fabricmc.loom.api.decompilers.JavadocStyle;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
+import net.fabricmc.loom.configuration.DependencyInfo;
 import net.fabricmc.loom.configuration.providers.mappings.extras.annotations.AnnotationsData;
 import net.fabricmc.loom.configuration.providers.mappings.extras.annotations.AnnotationsLayer;
 import net.fabricmc.loom.configuration.providers.mappings.tiny.TinyJarInfo;
 import net.fabricmc.loom.configuration.providers.mappings.unpick.UnpickMetadata;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
-import net.fabricmc.loom.api.decompilers.JavadocStyle;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.FileSystemUtil;
 import net.fabricmc.loom.util.service.ServiceFactory;
 
 public abstract sealed class MappingConfiguration permits RemapMappingConfiguration, NoRemapMappingConfiguration {
+	public static final String MARKDOWN_METADATA_KEY = "markdown";
 	protected static final Logger LOGGER = LoggerFactory.getLogger(MappingConfiguration.class);
 
 	public final String mappingsIdentifier;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/NoRemapMappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/NoRemapMappingConfiguration.java
@@ -31,19 +31,23 @@ import java.nio.file.Path;
 
 import org.gradle.api.Project;
 import org.gradle.api.provider.Provider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import net.fabricmc.loom.api.decompilers.JavadocStyle;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.configuration.DependencyInfo;
 import net.fabricmc.loom.configuration.providers.mappings.tiny.TinyJarInfo;
 import net.fabricmc.loom.configuration.providers.mappings.unpick.UnpickMetadata;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
-import net.fabricmc.loom.api.decompilers.JavadocStyle;
 import net.fabricmc.loom.util.Checksum;
 import net.fabricmc.loom.util.service.ServiceFactory;
 import net.fabricmc.mappingio.MappingReader;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
 public final class NoRemapMappingConfiguration extends MappingConfiguration {
+	private static final Logger LOGGER = LoggerFactory.getLogger(NoRemapMappingConfiguration.class);
+
 	private NoRemapMappingConfiguration(String mappingsIdentifier, Path inputJar) {
 		super(mappingsIdentifier, inputJar);
 	}
@@ -84,6 +88,10 @@ public final class NoRemapMappingConfiguration extends MappingConfiguration {
 	private static void validateMappings(MemoryMappingTree mappingTree) throws IOException {
 		if (!MappingsNamespace.OFFICIAL.toString().equals(mappingTree.getSrcNamespace()) || !mappingTree.getDstNamespaces().isEmpty()) {
 			throw new IOException("Annotations mappings must contain only the official namespace");
+		}
+
+		if (mappingTree.getMetadata(MARKDOWN_METADATA_KEY).isEmpty()) {
+			LOGGER.warn("Annotations mappings should have the " + MARKDOWN_METADATA_KEY + " metadata entry. Comments are still assumed to be in Markdown.");
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/RemapMappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/RemapMappingConfiguration.java
@@ -27,6 +27,7 @@ package net.fabricmc.loom.configuration.providers.mappings;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -42,12 +43,12 @@ import org.jspecify.annotations.Nullable;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.LoomGradlePlugin;
+import net.fabricmc.loom.api.decompilers.JavadocStyle;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.configuration.DependencyInfo;
 import net.fabricmc.loom.configuration.providers.mappings.tiny.MappingsMerger;
 import net.fabricmc.loom.configuration.providers.mappings.tiny.TinyJarInfo;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
-import net.fabricmc.loom.api.decompilers.JavadocStyle;
 import net.fabricmc.loom.util.Checksum;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.DeletingFileVisitor;
@@ -55,6 +56,7 @@ import net.fabricmc.loom.util.ZipUtils;
 import net.fabricmc.loom.util.service.ServiceFactory;
 import net.fabricmc.mappingio.MappingReader;
 import net.fabricmc.mappingio.format.MappingFormat;
+import net.fabricmc.mappingio.tree.MemoryMappingTree;
 import net.fabricmc.stitch.Command;
 import net.fabricmc.stitch.commands.CommandProposeFieldNames;
 
@@ -139,6 +141,25 @@ public final class RemapMappingConfiguration extends MappingConfiguration {
 			LOGGER.info(":populating field names");
 			suggestFieldNames(minecraftJars.get(0), baseTinyMappings, tinyMappings);
 		}
+	}
+
+	private static void validateMappings(MemoryMappingTree mappingTree) throws IOException {
+		if (!mappingTree.getMetadata(MARKDOWN_METADATA_KEY).isEmpty()) {
+			LOGGER.warn("Markdown comments are currently not supported for remapped Minecraft. Reinterpreting comments as HTML.");
+		}
+	}
+
+	@Override
+	public TinyMappingsService getMappingsService(Project project, ServiceFactory serviceFactory) {
+		TinyMappingsService mappingsService = super.getMappingsService(project, serviceFactory);
+
+		try {
+			validateMappings(mappingsService.getMappingTree());
+		} catch (IOException e) {
+			throw new UncheckedIOException("Failed to validate mappings", e);
+		}
+
+		return mappingsService;
 	}
 
 	@Override


### PR DESCRIPTION
Currently, it's mostly ignored but still validated.