### PR TITLE
Defer game JVM argument evaluation

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractRunTask.java
@@ -147,7 +147,7 @@ public abstract class AbstractRunTask extends JavaExec {
 			}
 		});
 		getMainClass().set(config.flatMap(RunConfiguration::getDevLaunchMainClass));
-		getJvmArguments().addAll(getProject().provider(this::getGameJvmArgs));
+		getJvmArgumentProviders().add(this::getGameJvmArgs);
 
 		getInternalRunDir().set(config.flatMap(RunConfiguration::getRunDirectory));
 		getInternalEnvironmentVars().set(config.flatMap(RunConfiguration::getEnvironmentVars));
@@ -245,7 +245,7 @@ public abstract class AbstractRunTask extends JavaExec {
 		commandLine.add(XVFBExistsValueSource.XVFB);
 		commandLine.add("--auto-servernum");
 		commandLine.add(javaExec);
-		commandLine.addAll(getJvmArguments().get());
+		commandLine.addAll(getAllJvmArgs());
 		commandLine.add(getMainClass().get());
 		commandLine.addAll(getArgs());
 

--- a/src/test/groovy/net/fabricmc/loom/test/integration/RunConfigTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/RunConfigTest.groovy
@@ -279,4 +279,23 @@ class RunConfigTest extends Specification implements GradleProjectTestTrait {
 		where:
 		version << STANDARD_TEST_VERSIONS
 	}
+
+	@IgnoreIf({ !os.linux })
+	def "XVFB forwards game JVM arguments"() {
+		given:
+		def gradle = gradleProject(project: "runconfigs", version: LoomTestConstants.DEFAULT_GRADLE)
+		gradle.buildGradle << '''
+
+tasks.named('runCustomMain') {
+	useXvfb.set(true)
+}
+ '''
+
+		when:
+		def result = gradle.run(task: "runCustomMain")
+
+		then:
+		result.task(":runCustomMain").outcome == SUCCESS
+		result.output.contains("This contains a space")
+	}
 }


### PR DESCRIPTION
Defers resolving classpath and/or writing argfiles until the args are built. Also allows such deferred args to work properly with xvfb runs.