### PR TITLE
Fix RenderDocRunTask not passing any JVM arguments

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/RenderDocRunTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RenderDocRunTask.java
@@ -75,7 +75,7 @@ public abstract class RenderDocRunTask extends RunGameTask {
 			exec.args(getRenderDocArgs().get());
 			exec.args("--working-dir", getInternalRunDir().get().getAsFile().getAbsolutePath());
 			exec.args(getJavaLauncher().get().getExecutablePath());
-			exec.args(getJvmArgs());
+			exec.args(getAllJvmArgs());
 			exec.args("-D%s=true".formatted(Constants.Properties.RENDER_DOC));
 			exec.args(getMainClass().get());
 


### PR DESCRIPTION
- Fixes the renderdoc task not working after https://github.com/FabricMC/fabric-loom/commit/ad89ffdb4e3c6fb1647e45cb5b3ca87ff1e77803
