### PR TITLE
Don't regenerate layered mappings if they exist already

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/LocalMavenHelper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/LocalMavenHelper.java
@@ -49,7 +49,7 @@ public record LocalMavenHelper(String group, String name, String version, @Nulla
 		return Files.copy(artifact, getOutputFile(classifier), StandardCopyOption.REPLACE_EXISTING);
 	}
 
-	public boolean exists(String classifier) {
+	public boolean exists(@Nullable String classifier) {
 		return Files.exists(getOutputFile(classifier)) && Files.exists(getPomPath());
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsFactory.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsFactory.java
@@ -81,8 +81,14 @@ public record LayeredMappingsFactory(LayeredMappingSpec spec) {
 
 		final Path mavenRepoDir = configContext.extension().getFiles().getGlobalMinecraftRepo().toPath();
 		final LocalMavenHelper maven = new LocalMavenHelper(GROUP, MODULE, spec().getVersion(), null, mavenRepoDir);
-		final Path jar = resolve(configContext.project());
-		maven.copyToMaven(jar, null);
+
+		LoomGradleExtension extension = LoomGradleExtension.get(configContext.project());
+
+		// If we have not generated these mappings already, regenerate them
+		if (!maven.exists(null) || extension.refreshDeps()) {
+			final Path jar = resolve(configContext.project());
+			maven.copyToMaven(jar, null);
+		}
 	}
 
 	public Path resolve(Project project) throws IOException {


### PR DESCRIPTION
I was having trouble with the Gradle configuration cache being invalid on every build due to the layered mappings being eagerly regenerated.

This guards the regeneration similarly to how we guard dependency remapping, which has fixed the configuration cache issue for me.