### PR TITLE
Use Strict Gson for JSON serialization.

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradlePlugin.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.Strictness;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.PluginAware;
@@ -53,6 +54,9 @@ import net.fabricmc.loom.util.OneDrive;
 public class LoomGradlePlugin implements Plugin<PluginAware> {
 	public static final String NAME = "fabric-loom";
 	public static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+	public static final Gson STRICT_GSON = GSON.newBuilder()
+			.setStrictness(Strictness.STRICT)
+			.create();
 	public static final String LOOM_VERSION = Objects.requireNonNullElse(LoomGradlePlugin.class.getPackage().getImplementationVersion(), "0.0.0+unknown");
 
 	/**

--- a/src/main/java/net/fabricmc/loom/util/ZipUtils.java
+++ b/src/main/java/net/fabricmc/loom/util/ZipUtils.java
@@ -212,7 +212,7 @@ public class ZipUtils {
 
 	public static <T> int transformJson(Class<T> typeOfT, Path zip, Map<String, UnsafeUnaryOperator<T>> transforms) throws IOException {
 		return transformMapped(zip, transforms, bytes -> LoomGradlePlugin.GSON.fromJson(new InputStreamReader(new ByteArrayInputStream(bytes), StandardCharsets.UTF_8), typeOfT),
-				s -> LoomGradlePlugin.GSON.toJson(s, typeOfT).getBytes(StandardCharsets.UTF_8));
+				s -> LoomGradlePlugin.STRICT_GSON.toJson(s, typeOfT).getBytes(StandardCharsets.UTF_8));
 	}
 
 	public static <T> void transformJson(Class<T> typeOfT, Path zip, String path, UnsafeUnaryOperator<T> transformer) throws IOException {

--- a/src/main/java/net/fabricmc/loom/util/fmj/gen/FabricModJsonV1Generator.java
+++ b/src/main/java/net/fabricmc/loom/util/fmj/gen/FabricModJsonV1Generator.java
@@ -85,7 +85,7 @@ public final class FabricModJsonV1Generator implements FabricModJsonGenerator<Fa
 		add(fmj, "languageAdapters", spec.getLanguageAdapters());
 		add(fmj, "custom", spec.getCustomData(), this::generateCustomData);
 
-		return LoomGradlePlugin.GSON.toJson(fmj);
+		return LoomGradlePlugin.STRICT_GSON.toJson(fmj);
 	}
 
 	private JsonElement generatePerson(FabricModJsonV1Spec.Person person) {

--- a/src/test/groovy/net/fabricmc/loom/test/unit/ZipUtilsTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/ZipUtilsTest.groovy
@@ -216,6 +216,37 @@ class ZipUtilsTest extends Specification {
 		transformed.get("test").asString == "THIS IS A TEST OF TRANSFORMING"
 	}
 
+	def "accept invalid json input"() {
+		given:
+		def dir = File.createTempDir()
+		def zip = File.createTempFile("loom-zip-test", ".zip").toPath()
+		new File(dir, "test.json").text = '{"test": "invalid\nstring"}'
+		ZipUtils.pack(dir.toPath(), zip)
+
+		when:
+		def json = ZipUtils.unpackJson(zip, "test.json", JsonObject.class)
+
+		then:
+		json.get("test").asString == "invalid\nstring"
+	}
+
+	def "reject invalid json output"() {
+		given:
+		def dir = File.createTempDir()
+		def zip = File.createTempFile("loom-zip-test", ".zip").toPath()
+		new File(dir, "test.json").text = '{}'
+		ZipUtils.pack(dir.toPath(), zip)
+
+		when:
+		ZipUtils.transformJson(JsonObject.class, zip, "test.json") { json ->
+			json.addProperty("invalid", Double.NaN)
+			json
+		}
+
+		then:
+		thrown IllegalArgumentException
+	}
+
 	// Also see: ClosedZipFSReproducer
 	def "unrecoverable error"() {
 		given:

--- a/src/test/groovy/net/fabricmc/loom/test/unit/fmj/FabricModJsonV1GeneratorTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/fmj/FabricModJsonV1GeneratorTest.groovy
@@ -511,6 +511,18 @@ class FabricModJsonV1GeneratorTest extends Specification {
 		tryParse(json) == 1
 	}
 
+	def "invalid custom data"() {
+		given:
+		def spec = baseSpec()
+		spec.customData.put("invalid", Double.NaN)
+
+		when:
+		FabricModJsonV1Generator.INSTANCE.generate(spec)
+
+		then:
+		thrown IllegalArgumentException
+	}
+
 	def "complete"() {
 		given:
 		def spec = objectFactory.newInstance(FabricModJsonV1Spec.class)


### PR DESCRIPTION
Should help (but not tottaly prevent) mods from generating fmj's with "invalid" json that can be hard to parse in other languages.