### PR TITLE
Fix: Strip whitespace from Mixin strings before looking them up in refmap.

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/mods/dependency/refmap/MixinRefmapInlinerClassVisitor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/dependency/refmap/MixinRefmapInlinerClassVisitor.java
@@ -78,7 +78,7 @@ public class MixinRefmapInlinerClassVisitor extends ClassVisitor {
 		@Override
 		public void visit(String name, Object value) {
 			if (value instanceof String strValue) {
-				value = remapper.remapReference(className, strValue);
+				value = remapper.remapReference(className, strValue.replaceAll("\\s", ""));
 			}
 
 			super.visit(name, value);

--- a/src/test/groovy/net/fabricmc/loom/test/unit/processor/MixinRefmapInlinerTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/processor/MixinRefmapInlinerTest.groovy
@@ -89,7 +89,7 @@ class MixinRefmapInlinerTest extends Specification {
 	@Mixin(targets = "MixinRefmapInlinerClassVisitor")
 	@CompileStatic
 	class ExampleClass {
-		@Inject(method = "injectExample", at = @At("HEAD"))
+		@Inject(method = " i n j e c t E x a m p l e ", at = @At("HEAD"))
 		void injectExample() {
 		}
 	}


### PR DESCRIPTION
This matches Mixin's own behaviour when writing the refmap entries (https://github.com/FabricMC/Mixin/blob/0a83ef1f5621bd7db10c497665ec5990b80c8d45/src/main/java/org/spongepowered/asm/mixin/refmap/ReferenceMapper.java#L223)

There is not currently much reason to have whitespace in selectors but that will change with the new `->` stuff